### PR TITLE
security: fix cross-tenant IDOR, SSRF, path traversal and add review report

### DIFF
--- a/docs/security-review-2026-06.md
+++ b/docs/security-review-2026-06.md
@@ -1,0 +1,499 @@
+# Security Review — Symbiosika Framework
+
+**Datum:** 2026-06-10
+**Umfang:** Vollständiges Framework (TypeScript / Bun / Hono, Drizzle ORM + PostgreSQL), Stand `develop` (Merge `67f938c`).
+**Branch des Reviews:** `claude/framework-security-review-cmxlsl`
+**Art:** White-Box-Code-Review der gesamten Codebasis (kein dynamischer Pentest, keine laufende Instanz).
+
+> Hinweis: Die per HACK-Kommentar deaktivierte Middleware `checkUserPermission`
+> (`src/lib/utils/hono-middlewares.ts`) wurde auf ausdrücklichen Wunsch aus dem
+> Scope ausgenommen und ist hier **nicht** als Finding gelistet.
+
+---
+
+## Executive Summary
+
+Das Framework ist ein Multi-Tenant-SaaS-Baukasten mit ~60 Endpunkten, eigenem
+OAuth2/OIDC-Server, acht Auth-Methoden, File-Storage, Webhooks, Server-zu-Server-
+Connections und AI/Knowledge-Funktionen. Insgesamt sind viele Sicherheitsgrundlagen
+solide gelöst (Passwort-Hashing mit `Bun.password`, parametrisierte Drizzle-Queries,
+httpOnly-Cookies, PKCE im OAuth2-Server, gehashte API-Tokens, sauberes OTP-Design).
+
+Der Review hat jedoch eine Reihe **schwerwiegender Autorisierungs- und
+Schlüsselverwaltungs-Probleme** aufgedeckt. Die wichtigsten Themen:
+
+1. **Token-Schmiede durch Schlüssel-Fehlkonfiguration** — der Init-Prozess legt
+   den *öffentlichen* Schlüssel als `JWT_PRIVATE_KEY` ab; das gesamte Auth-System
+   läuft dadurch effektiv als symmetrisches HS256 mit einem als „public"
+   bezeichneten Schlüssel.
+2. **Mehrere Cross-Tenant-IDOR** — Connections (inkl. Schlüsselmaterial), Webhooks,
+   Knowledge-Einträge, permission-groups und Invitations waren über geratene IDs
+   tenant-übergreifend lesbar/änderbar/löschbar.
+3. **Systemisch: `validateScope` ist für interaktive Sessions wirkungslos** — viele
+   Routen verließen sich allein darauf und waren damit für jeden eingeloggten
+   Nutzer offen.
+4. **SSRF** über den URL-Parser und Webhook-Zustellung; **Path Traversal** im
+   lokalen File-Storage; **Secret-Leaks** in Logs.
+
+### Severity-Verteilung
+
+| Severity | Anzahl | IDs |
+|----------|--------|-----|
+| Critical | 4 | SYM-001, SYM-002, SYM-003, SYM-004 |
+| High | 6 | SYM-005, SYM-006, SYM-007, SYM-008, SYM-009, SYM-010 |
+| Medium | 7 | SYM-011 … SYM-017 |
+| Low/Info | 5 | SYM-018 … SYM-022 |
+
+### Status der Fixes
+
+In diesem Branch sind die selbst-enthaltenen, verlässlich testbaren Findings
+direkt behoben (siehe Spalte „Fix" unten). Die brisanten, aber **breaking**
+Themen (JWT-Schlüssel/Algorithmus, OAuth-CSRF) sind bewusst **nicht** blind
+geändert, weil sie eine koordinierte Schlüsselrotation bzw. Verhaltensänderung
+und einen Lauf gegen eine echte Instanz erfordern; sie sind hier mit konkreter
+Remediation dokumentiert.
+
+---
+
+## Findings
+
+### SYM-001 — JWT-Schlüssel-Fehlkonfiguration ermöglicht Token-Fälschung — **Critical** — *Report only (breaking)*
+
+**Fundort:** `.scripts/init.ts:102`, `src/lib/utils/jwt-keys.ts`, `src/lib/auth/index.ts:158`, `src/lib/utils/hono-middlewares.ts:48-51`, `src/lib/oauth2/keys.ts:16`, `src/lib/oauth2/tokens.ts:81`
+
+**Beschreibung:** Der Init-Generator schreibt den öffentlichen Schlüssel in **beide**
+Variablen:
+```ts
+JWT_PUBLIC_KEY: jwtKeys.publicKey,
+JWT_PRIVATE_KEY: jwtKeys.publicKey, // jwtKeys.privateKey,
+```
+Die Schlüssel sind reine base64-SPKI-Strings (kein PEM). `jwt.sign(claims, JWT_PRIVATE_KEY)`
+ohne `algorithm`-Option fällt damit auf **HS256** zurück und benutzt den String als
+HMAC-Secret; die Verifikation (`jwt.verify(token, JWT_PUBLIC_KEY, { algorithms: undefined })`)
+akzeptiert für `authType === "local"` jeden Algorithmus. Das gesamte System läuft so als
+symmetrisches HS256, dessen Secret der als *public* deklarierte und überall so behandelte
+Schlüssel ist.
+
+**Angriffsszenario:** Sobald `JWT_PUBLIC_KEY` als „öffentlich" weitergegeben wird (das ist
+die Erwartung an einen Public Key: JWKS-Veröffentlichung, Auth0-Style-Deployments,
+Client-Konfig, versehentlicher Commit), kann ein Angreifer beliebige Tokens HS256-signieren
+(`{ sub, email, oauth: true, scope: "all" }`). Solche `oauth:true`-Tokens überspringen
+zusätzlich die Session-Prüfung (`hono-middlewares.ts:69,85`) → vollständige Übernahme
+beliebiger Accounts/Tenants ohne DB-Zugriff. Auch ohne Veröffentlichung wird der private
+Schlüssel verworfen und ein als niedrig-sensibel behandelter Wert zum Signaturschlüssel.
+
+**Empfehlung:**
+1. `.scripts/init.ts:102` auf `jwtKeys.privateKey` korrigieren und Schlüssel **rotieren**.
+2. Signieren/Verifizieren explizit asymmetrisch: PEM-Wrapping der SPKI/PKCS8-Base64,
+   `jwt.sign(..., privateKeyPem, { algorithm: "RS256" })`, `jwt.verify(..., publicKeyPem, { algorithms: ["RS256"] })`.
+3. `algorithms` in `hono-middlewares.ts:48` **niemals** `undefined` lassen — immer pinnen.
+4. OAuth-Access-Tokens nicht mit dem Verifikations-Public-Key als HMAC-Secret signieren;
+   bei HS256 ein dediziertes Zufallssecret verwenden.
+   *(OIDC-`id_token` ist bereits korrekt RS256 mit den echten Server-RSA-Keys.)*
+
+**Warum nicht hier gefixt:** Breaking Change (invalidiert alle bestehenden Tokens, erfordert
+PEM-Handling über alle Sign/Verify-Pfade inkl. auth0-Modus und einen Integrationslauf).
+
+---
+
+### SYM-002 — Cross-Tenant-IDOR auf Connections inkl. Schlüsselmaterial — **Critical** — *Behoben*
+
+**Fundort:** `src/lib/connections/index.ts` (`getConnection`/`dropConnection`/`refreshConnection`/`verifyConnection`), `src/routes/tenant/[tenantId]/connections/index.ts`
+
+**Beschreibung:** Die ID-basierten Connection-Operationen filterten nur nach
+`connections.id`. Die Routen prüften zwar Mitgliedschaft im URL-Tenant, banden die
+Connection-Zeile aber nie an diesen Tenant.
+
+**Angriffsszenario:** Ein Admin/Mitglied von Tenant A ruft
+`GET/DELETE/POST /tenant/A/connections/{connId-von-B}` und liest (inkl. öffentlichem
+Schlüsselmaterial und Remote-URL), löscht oder „refresht" die Server-zu-Server-Connection
+von Tenant B.
+
+**Fix:** `getConnection`/`dropConnection`/`refreshConnection`/`verifyConnection` nehmen jetzt
+einen optionalen `tenantId` und filtern damit; die Routen übergeben den Pfad-`tenantId`.
+
+---
+
+### SYM-003 — Cross-Tenant-IDOR auf Knowledge-Einträge (Delete/Update) — **Critical** — *Behoben*
+
+**Fundort:** `src/lib/knowledge/permissions.ts` (`validateKnowledgeAccess`), `src/lib/knowledge/update-knowledge.ts`
+
+**Beschreibung:** `validateKnowledgeAccess` filterte nicht nach `tenantId`. Die erste
+Klausel erlaubte über `isNull(knowledgeEntry.teamId)` Zugriff auf **jeden** Eintrag ohne
+Team — tenant-übergreifend. Delete/Update operierten anschließend nur per `id`.
+
+**Angriffsszenario:** Ein Mitglied von Tenant A löscht oder überschreibt per
+`DELETE/PUT /tenant/A/knowledge/entries/{id-von-B}` Knowledge-Einträge von Tenant B,
+sofern deren `teamId` NULL ist (der häufige Default).
+
+**Fix:** `validateKnowledgeAccess` erzwingt jetzt in allen Zweigen
+`eq(knowledgeEntry.tenantId, tenantId)`; zusätzlich wurden die Delete/Update-Queries in
+`update-knowledge.ts` defensiv um den Tenant-Filter ergänzt.
+
+---
+
+### SYM-004 — Cross-Tenant-IDOR auf Webhooks + `hasAccessToWebhook`-Stub — **Critical** — *Behoben*
+
+**Fundort:** `src/lib/webhooks/crud.ts`, `src/routes/tenant/[tenantId]/webhooks/index.ts`
+
+**Beschreibung:** `hasAccessToWebhook` gab unbedingt `true` zurück; `getWebhookById`/
+`updateWebhook`/`deleteWebhook` filterten nur per `id`; die Routen hatten keine
+`isTenantMember`-Prüfung (nur das wirkungslose `validateScope`, siehe SYM-005).
+
+**Angriffsszenario:** Jeder eingeloggte Nutzer konnte beliebige Webhooks aller Tenants
+auslesen (inkl. `webhookUrl` + Header), umschreiben (Ziel-URL kapern) oder löschen.
+
+**Fix:** Der Stub wurde durch `getWebhookForTenant` ersetzt; alle CRUD-Funktionen erzwingen
+`and(eq(id), eq(tenantId))`; `isTenantMember` wurde allen Webhook-Routen vorangestellt; die
+Routen reichen den Pfad-`tenantId` durch.
+
+---
+
+### SYM-005 — `validateScope` ist für interaktive Sessions ein No-op — **High** — *Teilweise behoben (Routen-Härtung)*
+
+**Fundort:** `src/lib/utils/validate-scope.ts:14-17`, `src/lib/utils/hono-middlewares.ts:157`, `src/lib/auth/index.ts:141-187`
+
+**Beschreibung:** Login-JWTs tragen kein `scopes`-Claim. `checkToken` defaultet fehlende
+Scopes auf `["all"]`, und `validateScope` ruft bei `["all"]` sofort `next()`. Damit ist
+`validateScope(...)` für **jede** normale Nutzer-Session wirkungslos und schränkt nur
+API-Tokens ein. Routen, die ausschließlich auf `validateScope` als Autorisierung setzten,
+waren für jeden eingeloggten Nutzer offen.
+
+**Angriffsszenario:** Grundlage für SYM-004/006/007/008/009 — überall dort, wo nur
+`validateScope` und kein `isTenantMember`/`isTenantAdmin` stand.
+
+**Fix/Empfehlung:** Die betroffenen Routen wurden mit echten Tenant-Middlewares gehärtet
+(siehe SYM-002/004/006/007). Grundlegende Empfehlung: interaktive Sessions sollten nicht
+implizit `["all"]` erhalten — entweder echte Scopes vergeben oder `validateScope` so
+umbauen, dass es Sessions nicht durchwinkt. Das ist eine systemische Änderung mit
+Breaking-Potenzial und wurde daher nicht global umgestellt.
+
+---
+
+### SYM-006 — permission-groups-Routen ohne Tenant-Autorisierung — **High** — *Behoben*
+
+**Fundort:** `src/routes/tenant/[tenantId]/permission-groups/index.ts` (alle 11 Endpunkte)
+
+**Beschreibung:** Jede Route war nur mit `authAndSetUsersInfo` + (wirkungslosem)
+`validateScope` registriert — kein `isTenantMember`/`isTenantAdmin`. Die Lib-Funktionen
+operieren per `id`.
+
+**Angriffsszenario:** Jeder eingeloggte Nutzer konnte permission-groups und
+path-permissions **jedes** Tenants anlegen/lesen/ändern/löschen.
+
+**Fix:** Allen 11 Endpunkten wurde `isTenantAdmin` vorangestellt. *Empfehlung zusätzlich:*
+die Lib-Queries je Zeile auf den Tenant scopen (verifizieren, dass Gruppe/Permission zum
+Tenant gehören), um Defense-in-Depth zu vervollständigen.
+
+---
+
+### SYM-007 — Cross-Tenant-Löschen/Ablehnen von Invitations — **High** — *Behoben*
+
+**Fundort:** `src/lib/usermanagement/invitations.ts` (`dropTenantInvitation`/`declineTenantInvitation`), `src/routes/tenant/[tenantId]/invitations/index.ts`
+
+**Beschreibung:** `dropTenantInvitation`/`declineTenantInvitation` operierten per `id` ohne
+Tenant-Filter; die Decline-Route hatte zudem gar keine Mitgliedsprüfung.
+
+**Angriffsszenario:** Ein Admin von Tenant A löschte per
+`DELETE /tenant/A/invitations/{id-von-B}` Invitations von Tenant B; Decline war für jeden
+eingeloggten Nutzer gegen beliebige Invitation-IDs aufrufbar.
+
+**Fix:** Beide Funktionen filtern jetzt `and(eq(id), eq(tenantId))`; die Routen übergeben
+`tenantId`; die Decline-Route erhielt `isTenantMember`.
+
+---
+
+### SYM-008 — SSRF über URL-Parser und Webhook-Zustellung — **High** — *Behoben*
+
+**Fundort:** `src/lib/knowledge/parsing/url.ts:65` (aufgerufen aus `knowledge/index.ts:788`), `src/lib/webhooks/trigger.ts:49`
+
+**Beschreibung:** `fetch()` auf eine nutzer-/admin-kontrollierte URL ohne jede Validierung,
+mit automatischem Redirect-Folgen. Erreichbar für authentifizierte Tenant-Nutzer.
+
+**Angriffsszenario:** Ein Nutzer lässt den Server eine URL wie
+`http://169.254.169.254/latest/meta-data/` oder interne Adressen (`127.0.0.1`, `10.x`,
+`192.168.x`) abrufen und bekommt teils den Antwort-Body zurück → Zugriff auf
+Cloud-Metadaten/interne Dienste.
+
+**Fix:** Neue Guard-Utility `src/lib/utils/url-guard.ts` (`assertPublicHttpUrl`,
+`fetchWithSsrfGuard`) blockt Nicht-HTTP-Schemata, `localhost` und private/loopback/
+link-local/ULA-Bereiche (IPv4 + IPv6, inkl. IPv4-mapped) und validiert **jeden**
+Redirect-Hop via manuellem Folgen. Verdrahtet in `url.ts` und `webhooks/trigger.ts`.
+Unit-Tests: `src/lib/utils/url-guard.test.ts`.
+
+---
+
+### SYM-009 — Path Traversal im lokalen File-Storage — **High** — *Behoben*
+
+**Fundort:** `src/lib/storage/local.ts`, Routen `src/routes/tenant/[tenantId]/files/index.ts`
+
+**Beschreibung:** `bucket` und `filename` aus den Request-Pfadparametern landeten unsaniert
+in `path.join(ATTACHMENT_DIR, bucket, name)` für Read/Write/Delete. `..`-Segmente
+ermöglichten das Verlassen des Upload-Verzeichnisses.
+
+**Angriffsszenario:** Ein authentifizierter Tenant-Nutzer liest/löscht beliebige Dateien
+im Prozesskontext bzw. fremde Tenant-Buckets (z. B. `../../.env`, Server-Keys).
+
+**Fix:** `safeAttachmentPath()` validiert jedes Segment gegen `^[A-Za-z0-9._-]+$` (lehnt
+`..`, `/`, `\`, Nullbytes ab) und prüft per `path.resolve`-Containment, dass der Zielpfad
+innerhalb von `ATTACHMENT_DIR` bleibt. Angewandt auf save/get/delete. Unit-Tests:
+`src/lib/storage/local.test.ts`.
+
+---
+
+### SYM-010 — OAuth-Login-CSRF (`state` fehlt) + Token in Redirect-URL — **High** — *Report only*
+
+**Fundort:** `src/lib/auth/oauth2.ts:193-218`, `src/routes/user/public.ts:689-721`
+
+**Beschreibung:** Die Google-/Microsoft-Login-URLs setzen keinen `state`-Parameter; der
+Callback validiert `state` nie. Bei Erfolg wird per
+`c.redirect(.../${provider}?token=${result.token})` das Session-Token in der URL übergeben.
+
+**Angriffsszenario:** Klassisches Login-CSRF / Account-Fixation (Opfer wird still in den
+Account des Angreifers eingeloggt). Zusätzlich Token-Leak über Referer/History/Logs.
+
+**Empfehlung:** Zufälliges `state` generieren, an die Session (Cookie) binden, im Callback
+prüfen; Token über sicheres Cookie / POST-Body statt URL-Query zurückgeben; PKCE
+clientseitig erwägen.
+
+---
+
+### SYM-011 — WhatsApp-Inbound-Webhook ohne Signaturprüfung, IP-Allowlist deaktiviert — **Medium** — *Report only*
+
+**Fundort:** `src/routes/communiation/wa/index.ts`, `src/index.ts:276-289`
+
+**Beschreibung:** Der POST-Handler verarbeitet `processWebhook(body)` ohne
+`X-Hub-Signature-256`-HMAC-Prüfung; die `ipRestriction` ist mit `allowList: ["*"]`
+effektiv abgeschaltet (echte Meta-IPs auskommentiert).
+
+**Angriffsszenario:** Beliebige Dritte können gefälschte WhatsApp-Events einliefern; der
+Handler ordnet sie per `wa_id` einem Nutzer zu → Nachrichten-Spoofing/Impersonation in die
+nachgelagerte Chat-/AI-Verarbeitung.
+
+**Empfehlung:** `X-Hub-Signature-256` gegen das Meta-App-Secret verifizieren, bevor
+verarbeitet wird; echte IP-Allowlist reaktivieren.
+
+---
+
+### SYM-012 — OAuth2 Consent-CSRF — **Medium** — *Report only*
+
+**Fundort:** `src/lib/oauth2/index.ts:257-306`
+
+**Beschreibung:** `POST /oauth/consent` nimmt die Entscheidung aus dem Formular-Body, stützt
+sich nur auf das Session-Cookie und hat keinen CSRF-Token/Origin-Check; `authorize_query`
+kommt aus einem manipulierbaren Hidden-Field.
+
+**Empfehlung:** CSRF-Token an die Session binden und serverseitig prüfen; `Origin`/
+`Sec-Fetch-Site` validieren; Authorize-Parameter serverseitig (signiert/gespeichert) statt
+im Hidden-Field führen.
+
+---
+
+### SYM-013 — Authorization-Code / Refresh-Token Single-Use nicht race-sicher — **Medium** — *Report only*
+
+**Fundort:** `src/lib/oauth2/codes.ts:68-101`, `src/lib/oauth2/tokens.ts:184-219`
+
+**Beschreibung:** Lesen → Prüfen → Update erfolgt ohne Transaktion/Row-Lock und ohne
+`WHERE consumed_at IS NULL` auf dem UPDATE (TOCTOU). Gleiches Muster bei der
+Refresh-Token-Rotation.
+
+**Empfehlung:** Konsum atomar machen:
+`UPDATE ... SET consumed_at = now() WHERE id = ? AND consumed_at IS NULL RETURNING *` und
+0 betroffene Zeilen als „bereits benutzt" behandeln.
+
+---
+
+### SYM-014 — Offene, unauthentifizierte Dynamic Client Registration — **Medium** — *Report only*
+
+**Fundort:** `src/lib/oauth2/index.ts:436-483`, `src/lib/oauth2/clients.ts`
+
+**Beschreibung:** `POST /oauth/register` benötigt keine Auth, legt einen `public`-Client mit
+`tenantId: null` an und übernimmt eine vom Aufrufer gelieferte `client_id` (client_id-
+Squatting / Ressourcen-Missbrauch).
+
+**Empfehlung:** Registrierung deaktivieren oder gaten (Initial-Access-Token/Admin);
+keine aufrufergesteuerte `client_id` zulassen; dynamische Clients limitieren/scopen.
+
+---
+
+### SYM-015 — Admin-Log-Routen nur durch No-op-Scope geschützt — **Medium** — *Report only*
+
+**Fundort:** `src/routes/admin/index.ts:19-108`
+
+**Beschreibung:** `/admin/logs/download` und `/admin/logs/clear` nutzen nur
+`validateScope("app:logs")` ohne echte Plattform-Admin-Prüfung. Wegen SYM-005 passieren
+Sessions diese Prüfung.
+
+**Angriffsszenario:** Jeder eingeloggte Nutzer kann alle Server-Logs (potenziell Secrets/
+PII) herunterladen und löschen.
+
+**Empfehlung:** Hinter eine echte Plattform-Admin-Prüfung stellen, nicht nur einen Scope,
+den Sessions umgehen.
+
+---
+
+### SYM-016 — Teams: Create/List ohne Mitgliedsprüfung; Team-Ops nicht Tenant-gebunden — **Medium** — *Report only*
+
+**Fundort:** `src/routes/tenant/[tenantId]/teams/index.ts`, `src/lib/usermanagement/teams.ts`
+
+**Beschreibung:** `POST /teams` und `GET /teams` haben kein `isTenantMember`; Create macht
+den Aufrufer zum Team-Admin. `:teamId`-Routen prüfen Team-Mitgliedschaft, verifizieren aber
+nicht `teams.tenantId === URL-tenantId`.
+
+**Empfehlung:** `isTenantMember` an Create/List; in den `:teamId`-Middlewares/Queries
+`teams.tenantId === tenantId` erzwingen.
+
+---
+
+### SYM-017 — Kein Rate-Limiting auf Auth-Endpunkten — **Medium** — *Report only*
+
+**Fundort:** `src/routes/user/public.ts` (`/user/login`, `/user/request-login-code`,
+`/user/send-magic-link`, `/user/forgot-password`, `/user/reset-password`, `/user/token-exchange`)
+
+**Beschreibung:** Keine erkennbare Drosselung. Brute-Force von Passwörtern/Tokens und
+Mail-Bombing über die Magic-Link-/Verifikations-Endpunkte möglich. (Das OTP-Modul kappt
+immerhin Verifikationsversuche pro Code.)
+
+**Empfehlung:** IP-/Account-basiertes Rate-Limiting + exponentielles Backoff auf alle
+credential- und mailauslösenden Endpunkte.
+
+---
+
+### SYM-018 — AES-256-CBC ohne Authentizität — **Low** — *Report only*
+
+**Fundort:** `src/lib/crypt/aes.ts`
+
+**Beschreibung:** Tenant-Secrets werden mit AES-256-CBC ohne MAC/AEAD verschlüsselt (GCM-Pfad
+existiert, ist aber nicht Default). Kein Integritätsschutz; bei künftiger Exponierung eines
+Entschlüsselungs-Orakels Padding-Oracle-Risiko.
+
+**Empfehlung:** Auf AES-256-GCM (oder Encrypt-then-MAC) als Default umstellen; das
+Key-Versioning unterstützt das bereits.
+
+---
+
+### SYM-019 — User-Enumeration bei „forgot-password" — **Low** — *Behoben*
+
+**Fundort:** `src/lib/auth/index.ts` (`forgotPasswort`)
+
+**Beschreibung:** Vorher warf die Funktion „User not found" für unbekannte Adressen
+(über HTTP 500 sichtbar) → Account-Enumeration. (Das OTP-/Magic-Link-Design ist hier
+vorbildlich.)
+
+**Fix:** Gibt jetzt unabhängig von der Existenz eine generische Erfolgsmeldung zurück und
+versendet den Reset-Link nur, wenn der Account existiert; Fehler werden serverseitig
+geloggt. *Empfehlung zusätzlich:* auch die Login-Fehlermeldungen (`"Invalid login: ..."`)
+generisch halten (derzeit werden „user not found"/„passwords do not match"/„Email is not
+verified" durchgereicht).
+
+---
+
+### SYM-020 — Secret-Leaks in Logs — **Low** — *Behoben*
+
+**Fundort:** `src/lib/utils/jwt-keys.ts`, `src/lib/crypt/aes.ts`, `src/lib/communication/whatsapp/send.ts`
+
+**Beschreibung:** Beim Erstgenerieren wurden JWT-Private-Key und AES-Master-Key per
+`console.log` ausgegeben; `whatsapp/send.ts` loggte das Token-Präfix.
+
+**Fix:** JWT-/AES-Schlüssel werden nun in eine lokale Datei mit `0600` geschrieben (statt
+stdout), und nur der Dateipfad wird ausgegeben; das WhatsApp-Token-Log wurde entfernt.
+
+---
+
+### SYM-021 — `sql.raw()` mit Embedding-Vektor in Similarity-Search — **Low/Info** — *Report only*
+
+**Fundort:** `src/lib/knowledge/similarity-search.ts:101`
+
+**Beschreibung:** `sql.raw(`'[${embed.embedding}]'`)` interpoliert den Embedding-Vektor
+direkt. Der Vektor ist serverseitig generiert (numerisch), daher derzeit nicht injizierbar.
+Der `tenantId`-Filter in der Query ist korrekt parametrisiert.
+
+**Empfehlung:** Den Vektor als Parameter binden oder vor der Interpolation streng als
+Zahlen-Array validieren, um die Annahme „nur Zahlen" abzusichern.
+
+---
+
+### SYM-022 — Verbose Fehler-Reflektion & CORS-Default `["*"]` — **Low/Info** — *Report only*
+
+**Fundort:** zahlreiche Handler (`"… " + err`), `src/index.ts:161-166`, `README.md:28`
+
+**Beschreibung:** Viele Handler geben interne Fehlertexte an den Client zurück (Info-Leak).
+Der dokumentierte CORS-Default ist `allowedOrigins: ["*"]`. Da die CORS-Middleware keine
+`credentials: true` setzt, ist der Cookie-basierte Pfad nicht direkt cross-origin lesbar;
+dennoch ist `*` als Default unnötig weit.
+
+**Empfehlung:** Generische Client-Fehler + serverseitiges Detail-Logging; restriktive
+`allowedOrigins`-Defaults dokumentieren/erzwingen.
+
+---
+
+## Positivbefunde
+
+- **Passwort-Hashing** via `Bun.password.hash/verify` (`src/lib/auth/index.ts`).
+- **Parametrisierte Queries** durchgängig über Drizzle; keine String-konkatenierte SQL.
+- **OTP-Design** (`src/lib/auth/email-otp.ts`): nur Hash gespeichert, Single-Use, TTL,
+  Versuchslimit, keine User-Enumeration.
+- **API-Tokens** werden nur als SHA-256-Hash gespeichert; Scopes validiert.
+- **Cookies** httpOnly + secure (bei https) + SameSite=Lax; separater nicht-sensibler
+  `jwt_present`-Marker.
+- **OAuth2-Server:** PKCE für alle Clients verpflichtend (nur S256), timing-sicherer
+  PKCE-Vergleich, Redirect-URI-Exact-Match, Codes/Tokens an `client_id` gebunden, OIDC-
+  `id_token` korrekt RS256/JWKS, keine Scope-Eskalation.
+- **Sessions:** serverseitige `sid`-Prüfung pro Request macht Logout/Passwort-Reset wirksam
+  revozierbar.
+- **Tenant-Middlewares** `isTenantMember`/`isTenantAdmin` prüfen korrekt gegen den
+  URL-`tenantId` (nicht den JWT-Claim).
+
+---
+
+## Priorisierte Maßnahmenliste
+
+**Sofort (Critical):**
+1. SYM-001 JWT-Schlüssel korrigieren (`init.ts` → privateKey), RS256 pinnen, **Keys rotieren**.
+2. SYM-002/003/004 sind in diesem Branch behoben — reviewen & deployen.
+
+**Kurzfristig (High):**
+3. SYM-005 Scope-Modell: Sessions nicht implizit `["all"]` geben (systemische Änderung).
+4. SYM-010 OAuth-Login-`state` + Token nicht in URL.
+5. SYM-006/007/008/009 (behoben) reviewen.
+
+**Mittelfristig (Medium):**
+6. SYM-011 WhatsApp-Signatur + IP-Allowlist.
+7. SYM-012/013/014 OAuth-Härtung (Consent-CSRF, atomarer Code-Konsum, Registrierung gaten).
+8. SYM-015/016 echte Admin-Prüfung für Logs; Teams Tenant-Bindung.
+9. SYM-017 Rate-Limiting.
+
+**Aufräumen (Low/Info):**
+10. SYM-018 AES-GCM; SYM-019 (behoben) Login-Meldungen generisch; SYM-021 Embedding binden;
+    SYM-022 Fehler-/CORS-Härtung.
+
+---
+
+## In diesem Branch umgesetzte Fixes (Übersicht)
+
+| Finding | Geänderte Dateien |
+|---------|-------------------|
+| SYM-002 | `src/lib/connections/index.ts`, `src/routes/tenant/[tenantId]/connections/index.ts` |
+| SYM-003 | `src/lib/knowledge/permissions.ts`, `src/lib/knowledge/update-knowledge.ts` |
+| SYM-004 | `src/lib/webhooks/crud.ts`, `src/routes/tenant/[tenantId]/webhooks/index.ts` |
+| SYM-006 | `src/routes/tenant/[tenantId]/permission-groups/index.ts` |
+| SYM-007 | `src/lib/usermanagement/invitations.ts`, `src/routes/tenant/[tenantId]/invitations/index.ts` |
+| SYM-008 | `src/lib/utils/url-guard.ts` (neu), `src/lib/knowledge/parsing/url.ts`, `src/lib/webhooks/trigger.ts` |
+| SYM-009 | `src/lib/storage/local.ts` |
+| SYM-019 | `src/lib/auth/index.ts` |
+| SYM-020 | `src/lib/utils/jwt-keys.ts`, `src/lib/crypt/aes.ts`, `src/lib/communication/whatsapp/send.ts` |
+
+**Neue Tests:** `src/lib/utils/url-guard.test.ts`, `src/lib/storage/local.test.ts`
+(9 Tests, grün). Typecheck (`bun run build` / `tsc`) ist grün.
+
+## Verifikation
+
+```bash
+bun install
+bun run build                      # tsc — grün
+bun test src/lib/utils/url-guard.test.ts src/lib/storage/local.test.ts
+```
+
+Die vollständige Test-Suite benötigt eine PostgreSQL-Instanz (siehe
+`docker-compose.yml`) und wurde in dieser Umgebung nicht end-to-end ausgeführt; die
+geänderten Module sind über Typecheck und die neuen Unit-Tests abgesichert.

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -466,7 +466,9 @@ export const LocalAuth = {
   },
 
   async forgotPasswort(email: string, sendWelcomeText = false) {
-    // Check if user exists in DB (optional check for clarity)
+    // Look up the user but never reveal whether the address exists — returning
+    // a different result / error for unknown emails enables account
+    // enumeration. Only send the reset link when the user actually exists.
     const user = await getDb()
       .select({
         id: users.id,
@@ -474,11 +476,12 @@ export const LocalAuth = {
       })
       .from(users)
       .where(eq(users.email, email));
-    if (!user || user.length === 0) {
-      throw "User not found";
+    if (user && user.length > 0) {
+      await sendResetPasswordLink(email, sendWelcomeText).catch((err) => {
+        // Log server-side; do not surface to the caller (avoids enumeration).
+        log.error("Error sending reset password link: " + err);
+      });
     }
-    // Send password-reset link
-    await sendResetPasswordLink(email, sendWelcomeText);
     return { message: "Reset password link has been sent to your email." };
   },
 };

--- a/src/lib/communication/whatsapp/send.ts
+++ b/src/lib/communication/whatsapp/send.ts
@@ -8,7 +8,6 @@ export const sendWhatsAppMessage = async (
   log.debug(
     `Send whatsapp message to ${phoneNumber} with message ${message.slice(0, 10)}...`
   );
-  console.log(process.env.CLOUD_API_ACCESS_TOKEN?.slice(0, 3) + "...");
   const response = await fetch(url, {
     method: "POST",
     headers: {

--- a/src/lib/connections/index.ts
+++ b/src/lib/connections/index.ts
@@ -709,11 +709,12 @@ export async function authenticateConnection(
  * @param connectionId - Local connection ID
  */
 export async function verifyConnection(
-  connectionId: string
+  connectionId: string,
+  tenantId?: string
 ): Promise<{ token: string }> {
   try {
-    // Get connection
-    const connection = await getConnection(connectionId);
+    // Get connection (scoped to the tenant when called from a request)
+    const connection = await getConnection(connectionId, tenantId);
     if (!connection) {
       throw new Error(`Connection ${connectionId} not found`);
     }
@@ -779,14 +780,21 @@ export async function verifyConnection(
  * Get connection by ID
  */
 export async function getConnection(
-  connectionId: string
+  connectionId: string,
+  tenantId?: string
 ): Promise<ConnectionsSelect | null> {
   try {
     const db = getDb();
+    // When a tenantId is supplied (request-facing calls), scope the lookup to
+    // that tenant so connections of other tenants cannot be read by guessing
+    // their id (IDOR — connection rows contain key material).
+    const where = tenantId
+      ? and(eq(connections.id, connectionId), eq(connections.tenantId, tenantId))
+      : eq(connections.id, connectionId);
     const result = await db
       .select()
       .from(connections)
-      .where(eq(connections.id, connectionId))
+      .where(where)
       .limit(1);
 
     return result[0] || null;
@@ -886,12 +894,15 @@ export async function getConnectionByLocalTenant(
 /**
  * Drop connection
  */
-export async function dropConnection(connectionId: string): Promise<void> {
+export async function dropConnection(
+  connectionId: string,
+  tenantId?: string
+): Promise<void> {
   try {
     const db = getDb();
 
-    // Verify connection exists
-    const connection = await getConnection(connectionId);
+    // Verify connection exists (and belongs to the tenant, when scoped)
+    const connection = await getConnection(connectionId, tenantId);
     if (!connection) {
       throw new Error("Connection not found");
     }
@@ -910,12 +921,15 @@ export async function dropConnection(connectionId: string): Promise<void> {
 /**
  * Refresh connection - update lastConnectedAt timestamp
  */
-export async function refreshConnection(connectionId: string): Promise<void> {
+export async function refreshConnection(
+  connectionId: string,
+  tenantId?: string
+): Promise<void> {
   try {
     const db = getDb();
 
-    // Verify connection exists
-    const connection = await getConnection(connectionId);
+    // Verify connection exists (and belongs to the tenant, when scoped)
+    const connection = await getConnection(connectionId, tenantId);
     if (!connection) {
       throw new Error("Connection not found");
     }

--- a/src/lib/crypt/aes.ts
+++ b/src/lib/crypt/aes.ts
@@ -9,12 +9,19 @@ const checkSecrets = async () => {
     process.env.SECRETS_AES_KEY = key;
     process.env.SECRETS_AES_IV = iv;
 
-    // write them out
-    console.log("Created new AES key and IV:");
-    console.log(`SECRETS_AES_KEY=${key}`);
-    console.log(`SECRETS_AES_IV=${iv}`);
-    console.log("Please add that to your .env file");
-    console.log("Then run the application again");
+    // Write the generated secret to a local file with owner-only permissions
+    // instead of printing it — the AES master key encrypts every tenant secret,
+    // so it must not end up in terminal scrollback or log pipelines.
+    const { writeFileSync } = await import("node:fs");
+    const outPath = "./aes-keys.generated.env";
+    writeFileSync(outPath, `SECRETS_AES_KEY=${key}\nSECRETS_AES_IV=${iv}\n`, {
+      mode: 0o600,
+    });
+    console.log(
+      `Created new AES key/IV and wrote them to ${outPath} (permissions 0600).`
+    );
+    console.log("Move them into your .env file, delete the generated file,");
+    console.log("then run the application again.");
     process.exit(0);
   }
 };

--- a/src/lib/knowledge/parsing/url.ts
+++ b/src/lib/knowledge/parsing/url.ts
@@ -16,6 +16,7 @@ import { Readability } from "@mozilla/readability";
 import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
 import log from "../../log";
+import { fetchWithSsrfGuard } from "../../utils/url-guard";
 
 const DEFAULT_USER_AGENT =
   "Mozilla/5.0 (compatible; SymbiosikaKnowledgeBot/1.0; +https://symbiosika.de)";
@@ -62,14 +63,15 @@ const fetchHtml = async (url: string, opts?: UrlToMarkdownOptions) => {
     opts?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
   );
   try {
-    const response = await fetch(url, {
+    // SSRF guard: validate the URL (and every redirect hop) so a user-supplied
+    // URL cannot reach internal services or the cloud metadata endpoint.
+    const response = await fetchWithSsrfGuard(url, {
       headers: {
         "User-Agent": opts?.userAgent ?? DEFAULT_USER_AGENT,
         Accept:
           "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         "Accept-Language": "en;q=0.9,de;q=0.8",
       },
-      redirect: "follow",
       signal: controller.signal,
     });
 

--- a/src/lib/knowledge/permissions.ts
+++ b/src/lib/knowledge/permissions.ts
@@ -100,10 +100,13 @@ export const validateKnowledgeAccess = async (
 ) => {
   const userTeams = await getUserTeamIds(userId, tenantId);
 
-  // First check: user has direct access to the knowledge entry
+  // First check: user has direct access to the knowledge entry.
+  // The entry MUST belong to the requested tenant — without this filter any
+  // entry with a NULL teamId would be accessible across tenant boundaries.
   const directAccess = await getDb().query.knowledgeEntry.findFirst({
     where: and(
       eq(knowledgeEntry.id, knowledgeId),
+      eq(knowledgeEntry.tenantId, tenantId),
       or(
         eq(knowledgeEntry.userId, userId),
         // Include NULL teamId and entries with user's teams
@@ -120,9 +123,12 @@ export const validateKnowledgeAccess = async (
   }
 
   // Second check: access through knowledge group assignments
-  // First get the entry with its knowledge group
+  // First get the entry with its knowledge group (scoped to the tenant)
   const entryWithGroup = await getDb().query.knowledgeEntry.findFirst({
-    where: eq(knowledgeEntry.id, knowledgeId),
+    where: and(
+      eq(knowledgeEntry.id, knowledgeId),
+      eq(knowledgeEntry.tenantId, tenantId)
+    ),
     columns: {
       id: true,
       knowledgeGroupId: true,

--- a/src/lib/knowledge/update-knowledge.ts
+++ b/src/lib/knowledge/update-knowledge.ts
@@ -1,5 +1,5 @@
 import { getDb } from "../db/db-connection";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { knowledgeEntry, knowledgeChunks } from "../db/schema/knowledge";
 import { isUserPartOfTeam } from "../usermanagement/teams";
 import { validateKnowledgeAccess } from "./permissions";
@@ -26,7 +26,11 @@ export const deleteKnowledgeEntry = async (
     );
   }
 
-  await getDb().delete(knowledgeEntry).where(eq(knowledgeEntry.id, id));
+  await getDb()
+    .delete(knowledgeEntry)
+    .where(
+      and(eq(knowledgeEntry.id, id), eq(knowledgeEntry.tenantId, tenantId))
+    );
 };
 
 /**
@@ -63,7 +67,9 @@ export const updateKnowledgeEntry = async (
   const r = await getDb()
     .update(knowledgeEntry)
     .set(data)
-    .where(eq(knowledgeEntry.id, id))
+    .where(
+      and(eq(knowledgeEntry.id, id), eq(knowledgeEntry.tenantId, tenantId))
+    )
     .returning();
 
   return r[0];
@@ -99,10 +105,13 @@ export const updateKnowledgeEntryText = async (
     );
   }
 
-  // Get the existing entry to preserve metadata
+  // Get the existing entry to preserve metadata (scoped to the tenant)
   const existingEntry = await getDb()
     .query.knowledgeEntry.findFirst({
-      where: eq(knowledgeEntry.id, id),
+      where: and(
+        eq(knowledgeEntry.id, id),
+        eq(knowledgeEntry.tenantId, tenantId)
+      ),
     });
 
   if (!existingEntry) {

--- a/src/lib/storage/local.test.ts
+++ b/src/lib/storage/local.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import fs from "fs/promises";
+import path from "path";
+import {
+  getFileFromLocalDisc,
+  saveFileToLocalDisc,
+  deleteFileFromLocalDisc,
+} from "./local";
+
+const ATTACHMENT_DIR = path.join(process.cwd(), "static/upload");
+
+/**
+ * These tests exercise the path-traversal hardening: any bucket / file name
+ * that could escape the upload directory must be rejected before touching the
+ * filesystem.
+ */
+describe("local storage path traversal protection", () => {
+  const traversalNames = [
+    "../secret",
+    "..",
+    "../../etc/passwd",
+    "foo/bar",
+    "foo\\bar",
+    "with\0null",
+    "/etc/passwd",
+  ];
+
+  it("rejects traversal in getFileFromLocalDisc (bucket and name)", async () => {
+    for (const bad of traversalNames) {
+      await expect(getFileFromLocalDisc(bad, "bucket", "t1")).rejects.toThrow();
+      await expect(getFileFromLocalDisc("file.txt", bad, "t1")).rejects.toThrow();
+    }
+  });
+
+  it("rejects traversal in deleteFileFromLocalDisc", async () => {
+    for (const bad of traversalNames) {
+      await expect(
+        deleteFileFromLocalDisc(bad, "bucket", "t1")
+      ).rejects.toThrow();
+      await expect(
+        deleteFileFromLocalDisc("file.txt", bad, "t1")
+      ).rejects.toThrow();
+    }
+  });
+
+  it("rejects traversal bucket in saveFileToLocalDisc", async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], "test.bin");
+    for (const bad of traversalNames) {
+      await expect(saveFileToLocalDisc(file, bad, "t1")).rejects.toThrow();
+    }
+  });
+
+  it("accepts a safe bucket and round-trips a file", async () => {
+    const bucket = "safe-bucket_1";
+    const file = new File([new Uint8Array([4, 5, 6, 7])], "doc.bin");
+    const saved = await saveFileToLocalDisc(file, bucket, "t1");
+    const publicName = saved.path.split("/").pop()!;
+    const fetched = await getFileFromLocalDisc(publicName, bucket, "t1");
+    const bytes = new Uint8Array(await fetched.arrayBuffer());
+    expect(Array.from(bytes)).toEqual([4, 5, 6, 7]);
+    await deleteFileFromLocalDisc(publicName, bucket, "t1");
+  });
+
+  afterAll(async () => {
+    await fs
+      .rm(path.join(ATTACHMENT_DIR, "safe-bucket_1"), {
+        recursive: true,
+        force: true,
+      })
+      .catch(() => {});
+  });
+});

--- a/src/lib/storage/local.ts
+++ b/src/lib/storage/local.ts
@@ -9,6 +9,48 @@ import type {
 const ATTACHMENT_DIR = path.join(process.cwd(), "static/upload");
 console.log("Server´s upload directory: ", ATTACHMENT_DIR);
 
+/**
+ * `bucket` and the file name come from the request path. Without validation a
+ * caller could use "../" (or an absolute path / encoded separators) to read,
+ * write, or delete files outside the upload directory or in another tenant's
+ * bucket. We allow only a conservative character set per segment and, as a
+ * second line of defence, verify the resolved path stays inside ATTACHMENT_DIR.
+ */
+const SAFE_SEGMENT = /^[A-Za-z0-9._-]+$/;
+
+const assertSafeSegment = (value: string, label: string): void => {
+  if (
+    !value ||
+    value === "." ||
+    value === ".." ||
+    value.includes("/") ||
+    value.includes("\\") ||
+    value.includes("\0") ||
+    !SAFE_SEGMENT.test(value)
+  ) {
+    throw new Error(`Invalid ${label}`);
+  }
+};
+
+/**
+ * Build a file path under ATTACHMENT_DIR for the given bucket/name, rejecting
+ * any input that would escape the upload directory.
+ */
+const safeAttachmentPath = (bucket: string, name?: string): string => {
+  assertSafeSegment(bucket, "bucket");
+  if (name !== undefined) assertSafeSegment(name, "file name");
+  const filePath =
+    name !== undefined
+      ? path.join(ATTACHMENT_DIR, bucket, name)
+      : path.join(ATTACHMENT_DIR, bucket);
+  const root = path.resolve(ATTACHMENT_DIR);
+  const resolved = path.resolve(filePath);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw new Error("Resolved path escapes the upload directory");
+  }
+  return filePath;
+};
+
 export const saveFileToLocalDisc: SaveFileFunction = async (
   file,
   bucket,
@@ -20,17 +62,15 @@ export const saveFileToLocalDisc: SaveFileFunction = async (
     ? fileName.split(".").pop()!.toLowerCase()
     : "";
 
-  // Generate the file path
-  const filePath = path.join(
-    ATTACHMENT_DIR,
-    bucket,
-    fileExtension ? `${id}.${fileExtension}` : id
-  );
+  // Generate the file path (bucket is request-controlled → validated; the file
+  // name is a server-generated UUID).
+  const publicName = fileExtension ? `${id}.${fileExtension}` : id;
+  const filePath = safeAttachmentPath(bucket, publicName);
 
   // Save the file to the disk
   const fileBuffer = Buffer.from(await file.arrayBuffer());
 
-  await fs.mkdir(path.join(ATTACHMENT_DIR, bucket), { recursive: true });
+  await fs.mkdir(safeAttachmentPath(bucket), { recursive: true });
   await fs.writeFile(filePath, fileBuffer);
   const publicFileName = fileExtension ? `${id}.${fileExtension}` : id;
 
@@ -47,8 +87,8 @@ export const getFileFromLocalDisc: GetFileFunction = async (
   bucket,
   tenantId
 ) => {
-  // Generate the file path
-  const filePath = path.join(ATTACHMENT_DIR, bucket, name);
+  // Generate the file path (bucket and name are request-controlled → validated)
+  const filePath = safeAttachmentPath(bucket, name);
   // return the file
   try {
     const file = await fs.readFile(filePath);
@@ -63,8 +103,8 @@ export const deleteFileFromLocalDisc: DeleteFileFunction = async (
   bucket,
   tenantId
 ) => {
-  // Generate the file path
-  const filePath = path.join(ATTACHMENT_DIR, bucket, name);
+  // Generate the file path (bucket and name are request-controlled → validated)
+  const filePath = safeAttachmentPath(bucket, name);
   // Delete the file
   await fs.unlink(filePath);
 };

--- a/src/lib/usermanagement/invitations.ts
+++ b/src/lib/usermanagement/invitations.ts
@@ -58,10 +58,20 @@ export const getUsersTenantInvitations = async (userId: string) => {
 /**
  * Drop an invitation by its ID
  */
-export const dropTenantInvitation = async (invitationId: string) => {
+export const dropTenantInvitation = async (
+  invitationId: string,
+  tenantId: string
+) => {
+  // Scope to the tenant so an admin of one tenant cannot delete another
+  // tenant's invitations by guessing ids.
   await getDb()
     .delete(tenantInvitations)
-    .where(eq(tenantInvitations.id, invitationId));
+    .where(
+      and(
+        eq(tenantInvitations.id, invitationId),
+        eq(tenantInvitations.tenantId, tenantId)
+      )
+    );
 };
 
 /**
@@ -180,11 +190,19 @@ export const acceptAllPendingInvitationsForTenantMember = async (
 /**
  * Decline an invitation by its ID
  */
-export const declineTenantInvitation = async (invitationId: string) => {
+export const declineTenantInvitation = async (
+  invitationId: string,
+  tenantId: string
+) => {
   await getDb()
     .update(tenantInvitations)
     .set({ status: "declined" })
-    .where(eq(tenantInvitations.id, invitationId));
+    .where(
+      and(
+        eq(tenantInvitations.id, invitationId),
+        eq(tenantInvitations.tenantId, tenantId)
+      )
+    );
 };
 
 /**

--- a/src/lib/utils/jwt-keys.ts
+++ b/src/lib/utils/jwt-keys.ts
@@ -32,8 +32,12 @@ export async function generateJWTKeys(): Promise<{
 }
 
 /**
- * Checks if JWT keys exist and generates them if missing
- * Outputs keys to console for manual addition to .env file
+ * Checks if JWT keys exist and generates them if missing.
+ *
+ * The generated key material is written to a local file with owner-only
+ * permissions (0600) instead of being printed to stdout — printing private key
+ * material would leak it into terminal scrollback, CI logs, and aggregated log
+ * pipelines.
  */
 export async function ensureJWTKeys(): Promise<void> {
   const privateKey = process.env.JWT_PRIVATE_KEY;
@@ -46,11 +50,19 @@ export async function ensureJWTKeys(): Promise<void> {
     const { privateKey: newPrivateKey, publicKey: newPublicKey } =
       await generateJWTKeys();
 
-    console.log("📋 Add these keys to your .env file:\n");
-    console.log("JWT_PRIVATE_KEY=" + newPrivateKey);
-    console.log("JWT_PUBLIC_KEY=" + newPublicKey);
+    const { writeFile } = await import("node:fs/promises");
+    const outPath = "./jwt-keys.generated.env";
+    await writeFile(
+      outPath,
+      `JWT_PRIVATE_KEY=${newPrivateKey}\nJWT_PUBLIC_KEY=${newPublicKey}\n`,
+      { mode: 0o600 }
+    );
+
     console.log(
-      "\n⚠️  Keep these keys secure and never commit them to version control!\n"
+      `📋 New JWT keys written to ${outPath} (permissions 0600). Move them into your .env file and delete the generated file.`
+    );
+    console.log(
+      "⚠️  Keep these keys secret and never commit them to version control!\n"
     );
 
     process.exit(0);

--- a/src/lib/utils/url-guard.test.ts
+++ b/src/lib/utils/url-guard.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import {
+  assertPublicHttpUrl,
+  isBlockedAddress,
+  SsrfBlockedError,
+} from "./url-guard";
+
+describe("isBlockedAddress", () => {
+  it("blocks loopback, private, link-local and metadata addresses", () => {
+    const blocked = [
+      "127.0.0.1",
+      "127.5.5.5",
+      "10.0.0.1",
+      "10.255.255.255",
+      "172.16.0.1",
+      "172.31.255.255",
+      "192.168.1.1",
+      "169.254.169.254", // cloud metadata
+      "0.0.0.0",
+      "100.64.0.1",
+      "::1",
+      "fe80::1",
+      "fc00::1",
+      "fd12:3456::1",
+      "::ffff:127.0.0.1", // IPv4-mapped loopback
+    ];
+    for (const ip of blocked) {
+      expect(isBlockedAddress(ip)).toBe(true);
+    }
+  });
+
+  it("allows public addresses", () => {
+    const allowed = ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:4700::1111"];
+    for (const ip of allowed) {
+      expect(isBlockedAddress(ip)).toBe(false);
+    }
+  });
+});
+
+describe("assertPublicHttpUrl", () => {
+  it("rejects non-http(s) schemes", async () => {
+    await expect(assertPublicHttpUrl("file:///etc/passwd")).rejects.toThrow(
+      SsrfBlockedError
+    );
+    await expect(assertPublicHttpUrl("ftp://example.com")).rejects.toThrow(
+      SsrfBlockedError
+    );
+    await expect(
+      assertPublicHttpUrl("gopher://127.0.0.1")
+    ).rejects.toThrow(SsrfBlockedError);
+  });
+
+  it("rejects localhost and internal literal IPs", async () => {
+    await expect(assertPublicHttpUrl("http://localhost/")).rejects.toThrow(
+      SsrfBlockedError
+    );
+    await expect(
+      assertPublicHttpUrl("http://app.localhost/")
+    ).rejects.toThrow(SsrfBlockedError);
+    await expect(assertPublicHttpUrl("http://127.0.0.1/")).rejects.toThrow(
+      SsrfBlockedError
+    );
+    await expect(
+      assertPublicHttpUrl("http://169.254.169.254/latest/meta-data/")
+    ).rejects.toThrow(SsrfBlockedError);
+    await expect(assertPublicHttpUrl("http://[::1]:8080/")).rejects.toThrow(
+      SsrfBlockedError
+    );
+    await expect(assertPublicHttpUrl("http://192.168.0.10/")).rejects.toThrow(
+      SsrfBlockedError
+    );
+  });
+
+  it("rejects malformed urls", async () => {
+    await expect(assertPublicHttpUrl("not a url")).rejects.toThrow(
+      SsrfBlockedError
+    );
+  });
+});

--- a/src/lib/utils/url-guard.ts
+++ b/src/lib/utils/url-guard.ts
@@ -1,0 +1,153 @@
+/**
+ * URL guard to mitigate Server-Side Request Forgery (SSRF).
+ *
+ * Before the server fetches a URL that originates (directly or indirectly) from
+ * user input, we validate that:
+ *   - the scheme is http(s),
+ *   - the host does not resolve to a private, loopback, link-local, or otherwise
+ *     internal address (which would let a caller reach internal services or the
+ *     cloud metadata endpoint, e.g. 169.254.169.254).
+ *
+ * Because DNS can rebind and HTTP redirects can point at internal hosts, callers
+ * that follow redirects must re-validate every hop. `fetchWithSsrfGuard` does
+ * this by following redirects manually.
+ */
+import { lookup } from "node:dns/promises";
+
+export class SsrfBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SsrfBlockedError";
+  }
+}
+
+const ipv4ToInt = (ip: string): number | null => {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n > 255) return null;
+    value = value * 256 + n;
+  }
+  return value >>> 0;
+};
+
+const isBlockedIpv4 = (ip: string): boolean => {
+  const v = ipv4ToInt(ip);
+  if (v === null) return false;
+  const inRange = (cidrBase: string, bits: number) => {
+    const base = ipv4ToInt(cidrBase)!;
+    const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+    return (v & mask) === (base & mask);
+  };
+  return (
+    inRange("0.0.0.0", 8) || // "this" network
+    inRange("10.0.0.0", 8) || // private
+    inRange("100.64.0.0", 10) || // carrier-grade NAT
+    inRange("127.0.0.0", 8) || // loopback
+    inRange("169.254.0.0", 16) || // link-local incl. cloud metadata
+    inRange("172.16.0.0", 12) || // private
+    inRange("192.0.0.0", 24) || // IETF protocol assignments
+    inRange("192.168.0.0", 16) || // private
+    inRange("198.18.0.0", 15) || // benchmarking
+    inRange("224.0.0.0", 4) || // multicast
+    inRange("240.0.0.0", 4) // reserved / broadcast
+  );
+};
+
+const isBlockedIpv6 = (ip: string): boolean => {
+  const addr = ip.toLowerCase().split("%")[0]!; // strip zone id
+  if (addr === "::1" || addr === "::") return true; // loopback / unspecified
+  // IPv4-mapped (::ffff:a.b.c.d) — validate the embedded v4 address.
+  const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (mapped) return isBlockedIpv4(mapped[1]!);
+  return (
+    addr.startsWith("fe8") || // link-local fe80::/10
+    addr.startsWith("fe9") ||
+    addr.startsWith("fea") ||
+    addr.startsWith("feb") ||
+    addr.startsWith("fc") || // unique local fc00::/7
+    addr.startsWith("fd")
+  );
+};
+
+/** True when the literal IP must never be the target of a server-side fetch. */
+export const isBlockedAddress = (ip: string): boolean =>
+  ip.includes(":") ? isBlockedIpv6(ip) : isBlockedIpv4(ip);
+
+/**
+ * Validate that `rawUrl` is an http(s) URL whose host does not resolve to an
+ * internal address. Throws `SsrfBlockedError` when the URL must not be fetched.
+ */
+export const assertPublicHttpUrl = async (rawUrl: string): Promise<URL> => {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new SsrfBlockedError("Invalid URL");
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new SsrfBlockedError(`Blocked URL scheme: ${url.protocol}`);
+  }
+
+  const host = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    throw new SsrfBlockedError("Blocked host: localhost");
+  }
+
+  // If the host is already a literal IP, check it directly. Otherwise resolve
+  // all addresses and ensure none are internal.
+  const looksLikeIp = /^[0-9.]+$/.test(host) || host.includes(":");
+  if (looksLikeIp) {
+    if (isBlockedAddress(host)) {
+      throw new SsrfBlockedError(`Blocked address: ${host}`);
+    }
+    return url;
+  }
+
+  let resolved: { address: string }[];
+  try {
+    resolved = await lookup(host, { all: true });
+  } catch {
+    throw new SsrfBlockedError(`Could not resolve host: ${host}`);
+  }
+  if (resolved.length === 0) {
+    throw new SsrfBlockedError(`Host did not resolve: ${host}`);
+  }
+  for (const { address } of resolved) {
+    if (isBlockedAddress(address)) {
+      throw new SsrfBlockedError(
+        `Host ${host} resolves to a blocked address (${address})`
+      );
+    }
+  }
+  return url;
+};
+
+/**
+ * fetch() wrapper that validates the target (and every redirect hop) against
+ * the SSRF guard. Redirects are followed manually so a 30x response cannot send
+ * the request to an internal host.
+ */
+export const fetchWithSsrfGuard = async (
+  rawUrl: string,
+  init: RequestInit = {},
+  maxRedirects = 5
+): Promise<Response> => {
+  let currentUrl = rawUrl;
+  for (let i = 0; i <= maxRedirects; i++) {
+    await assertPublicHttpUrl(currentUrl);
+    const response = await fetch(currentUrl, { ...init, redirect: "manual" });
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location) return response;
+      currentUrl = new URL(location, currentUrl).toString();
+      continue;
+    }
+    return response;
+  }
+  throw new SsrfBlockedError("Too many redirects");
+};

--- a/src/lib/webhooks/crud.ts
+++ b/src/lib/webhooks/crud.ts
@@ -4,11 +4,18 @@ import type { WebhookInsert, WebhookSelect } from "../db/schema/webhooks";
 import { webhooks } from "../db/schema/webhooks";
 
 /**
- * Helper to check if user has access to webhook
- * as a direct owner or part of a team that owns the webhook
+ * Returns the webhook only if it belongs to the given tenant. All by-id
+ * operations go through this so a webhook of another tenant cannot be read,
+ * modified, or deleted by guessing its id (IDOR — webhook rows hold the target
+ * URL and custom headers).
  */
-export const hasAccessToWebhook = async (webhookId: string, userId: string) => {
-  return true;
+const getWebhookForTenant = async (
+  id: string,
+  tenantId: string
+): Promise<WebhookSelect | undefined> => {
+  return await getDb().query.webhooks.findFirst({
+    where: and(eq(webhooks.id, id), eq(webhooks.tenantId, tenantId)),
+  });
 };
 
 /**
@@ -31,16 +38,14 @@ export const createWebhook = async (userId: string, input: WebhookInsert) => {
 };
 
 /**
- * Get webhook by its ID
- * will check if user has access to webhook
+ * Get webhook by its ID, scoped to the tenant.
  */
-export const getWebhookById = async (id: string, userId: string) => {
-  if (!(await hasAccessToWebhook(id, userId))) {
-    throw new Error("User does not have permission to access webhook");
-  }
-  return await getDb().query.webhooks.findFirst({
-    where: eq(webhooks.id, id),
-  });
+export const getWebhookById = async (
+  id: string,
+  userId: string,
+  tenantId: string
+) => {
+  return await getWebhookForTenant(id, tenantId);
 };
 
 /**
@@ -77,18 +82,22 @@ export const getAllOrganisationWebhooks = async (tenantId: string) => {
 export const updateWebhook = async (
   id: string,
   input: Partial<WebhookSelect>,
-  userId: string
+  userId: string,
+  tenantId: string
 ) => {
-  if (!(await hasAccessToWebhook(id, userId))) {
-    throw new Error("User does not have permission to update webhook");
+  const existing = await getWebhookForTenant(id, tenantId);
+  if (!existing) {
+    throw new Error("Webhook not found");
   }
   const [updated] = await getDb()
     .update(webhooks)
     .set({
       ...input,
+      // never allow moving a webhook to another tenant via the update payload
+      tenantId,
       updatedAt: new Date().toISOString(),
     })
-    .where(eq(webhooks.id, id))
+    .where(and(eq(webhooks.id, id), eq(webhooks.tenantId, tenantId)))
     .returning();
 
   return updated;
@@ -98,9 +107,12 @@ export const updateWebhook = async (
  * Delete a webhook by its ID
  * will check if user has access to webhook
  */
-export const deleteWebhook = async (id: string, userId: string) => {
-  if (!(await hasAccessToWebhook(id, userId))) {
-    throw new Error("User does not have permission to delete webhook");
-  }
-  await getDb().delete(webhooks).where(eq(webhooks.id, id));
+export const deleteWebhook = async (
+  id: string,
+  userId: string,
+  tenantId: string
+) => {
+  await getDb()
+    .delete(webhooks)
+    .where(and(eq(webhooks.id, id), eq(webhooks.tenantId, tenantId)));
 };

--- a/src/lib/webhooks/trigger.ts
+++ b/src/lib/webhooks/trigger.ts
@@ -1,6 +1,7 @@
 import { getDb } from "../db/db-connection";
 import { webhooks } from "../db/schema/webhooks";
 import { and, eq } from "drizzle-orm";
+import { fetchWithSsrfGuard, SsrfBlockedError } from "../utils/url-guard";
 
 export interface WebhookTriggerOptions {
   payload?: any;
@@ -45,8 +46,9 @@ export const triggerWebhook = async (
   };
 
   try {
-    // Make the request
-    const response = await fetch(webhook.webhookUrl, {
+    // SSRF guard: the webhook URL is operator/tenant supplied; ensure it cannot
+    // be used to reach internal services or the cloud metadata endpoint.
+    const response = await fetchWithSsrfGuard(webhook.webhookUrl, {
       method: webhook.method,
       headers,
       body:
@@ -70,6 +72,12 @@ export const triggerWebhook = async (
   } catch (error) {
     if (error instanceof WebhookTriggerError) {
       throw error;
+    }
+    if (error instanceof SsrfBlockedError) {
+      throw new WebhookTriggerError(
+        `Webhook URL is not allowed: ${error.message}`,
+        400
+      );
     }
     throw new WebhookTriggerError(
       `Failed to trigger webhook: ${error + ""}`,

--- a/src/routes/tenant/[tenantId]/connections/index.ts
+++ b/src/routes/tenant/[tenantId]/connections/index.ts
@@ -399,7 +399,10 @@ const defineConnectionsRoutes = (app: SymbiosikaFrameworkHonoApp, basePath: stri
     authAndSetUsersInfo,
     checkUserPermission,
     isTenantMember,
-    validator("param", v.object({ connectionId: v.string() })),
+    validator(
+      "param",
+      v.object({ tenantId: v.string(), connectionId: v.string() })
+    ),
     validateScope("connections:read"),
     describeRoute({
       description: "Verify connection status",
@@ -414,9 +417,12 @@ const defineConnectionsRoutes = (app: SymbiosikaFrameworkHonoApp, basePath: stri
     }),
     async (c) => {
       try {
-        const { connectionId } = c.req.valid("param");
+        const { tenantId, connectionId } = c.req.valid("param");
 
-        const result = await connectionsService.verifyConnection(connectionId);
+        const result = await connectionsService.verifyConnection(
+          connectionId,
+          tenantId
+        );
 
         return c.json(result);
       } catch (error) {
@@ -527,7 +533,10 @@ const defineConnectionsRoutes = (app: SymbiosikaFrameworkHonoApp, basePath: stri
     authAndSetUsersInfo,
     checkUserPermission,
     isTenantMember,
-    validator("param", v.object({ connectionId: v.string() })),
+    validator(
+      "param",
+      v.object({ tenantId: v.string(), connectionId: v.string() })
+    ),
     validateScope("connections:read"),
     describeRoute({
       description: "Get a specific connection",
@@ -542,8 +551,11 @@ const defineConnectionsRoutes = (app: SymbiosikaFrameworkHonoApp, basePath: stri
     }),
     async (c) => {
       try {
-        const { connectionId } = c.req.valid("param");
-        const connection = await connectionsService.getConnection(connectionId);
+        const { tenantId, connectionId } = c.req.valid("param");
+        const connection = await connectionsService.getConnection(
+          connectionId,
+          tenantId
+        );
 
         if (!connection) {
           throw new HTTPException(404, {
@@ -571,7 +583,10 @@ const defineConnectionsRoutes = (app: SymbiosikaFrameworkHonoApp, basePath: stri
     authAndSetUsersInfo,
     checkUserPermission,
     isTenantAdmin,
-    validator("param", v.object({ connectionId: v.string() })),
+    validator(
+      "param",
+      v.object({ tenantId: v.string(), connectionId: v.string() })
+    ),
     validateScope("connections:write"),
     describeRoute({
       description: "Refresh connection timestamp",
@@ -586,8 +601,8 @@ const defineConnectionsRoutes = (app: SymbiosikaFrameworkHonoApp, basePath: stri
     }),
     async (c) => {
       try {
-        const { connectionId } = c.req.valid("param");
-        await connectionsService.refreshConnection(connectionId);
+        const { tenantId, connectionId } = c.req.valid("param");
+        await connectionsService.refreshConnection(connectionId, tenantId);
 
         return c.json({
           message: "Connection refreshed successfully",
@@ -611,7 +626,10 @@ const defineConnectionsRoutes = (app: SymbiosikaFrameworkHonoApp, basePath: stri
     authAndSetUsersInfo,
     checkUserPermission,
     isTenantAdmin,
-    validator("param", v.object({ connectionId: v.string() })),
+    validator(
+      "param",
+      v.object({ tenantId: v.string(), connectionId: v.string() })
+    ),
     validateScope("connections:write"),
     describeRoute({
       description: "Drop a connection",
@@ -626,8 +644,8 @@ const defineConnectionsRoutes = (app: SymbiosikaFrameworkHonoApp, basePath: stri
     }),
     async (c) => {
       try {
-        const { connectionId } = c.req.valid("param");
-        await connectionsService.dropConnection(connectionId);
+        const { tenantId, connectionId } = c.req.valid("param");
+        await connectionsService.dropConnection(connectionId, tenantId);
 
         return c.json({
           message: "Connection dropped successfully",

--- a/src/routes/tenant/[tenantId]/invitations/index.ts
+++ b/src/routes/tenant/[tenantId]/invitations/index.ts
@@ -26,7 +26,7 @@ import {
   tenantInvitationsSelectSchema,
 } from "../../../../lib/db/db-schema";
 import { RESPONSES } from "../../../../lib/responses";
-import { checkTenantIdInBody, isTenantAdmin } from "../..";
+import { checkTenantIdInBody, isTenantAdmin, isTenantMember } from "../..";
 import { validateScope } from "../../../../lib/utils/validate-scope";
 
 export default function defineInvitationsRoutes(
@@ -149,7 +149,7 @@ export default function defineInvitationsRoutes(
     async (c) => {
       try {
         const { tenantId, id } = c.req.valid("param");
-        await dropTenantInvitation(id);
+        await dropTenantInvitation(id, tenantId);
         return c.json(RESPONSES.SUCCESS);
       } catch (err) {
         throw new HTTPException(500, {
@@ -214,6 +214,7 @@ export default function defineInvitationsRoutes(
     }),
     validateScope("tenants:write"),
     validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
     async (c) => {
       try {
         const { tenantId, id } = c.req.valid("param");
@@ -223,7 +224,7 @@ export default function defineInvitationsRoutes(
             tenantId
           );
         } else {
-          await declineTenantInvitation(id);
+          await declineTenantInvitation(id, tenantId);
         }
 
         return c.json(RESPONSES.SUCCESS);

--- a/src/routes/tenant/[tenantId]/permission-groups/index.ts
+++ b/src/routes/tenant/[tenantId]/permission-groups/index.ts
@@ -33,6 +33,7 @@ import * as v from "valibot";
 import { describeRoute } from "hono-openapi";
 import { RESPONSES } from "../../../../lib/responses";
 import { validateScope } from "../../../../lib/utils/validate-scope";
+import { isTenantAdmin } from "../../../tenant/index";
 
 export default function definePermissionGroupRoutes(
   app: SymbiosikaFrameworkHonoApp,
@@ -44,6 +45,7 @@ export default function definePermissionGroupRoutes(
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/permission-groups",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Create a new permission group",
@@ -79,6 +81,7 @@ export default function definePermissionGroupRoutes(
   app.get(
     API_BASE_PATH + "/tenant/:tenantId/permission-groups",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Get all permission groups of an tenant",
@@ -114,6 +117,7 @@ export default function definePermissionGroupRoutes(
   app.get(
     API_BASE_PATH + "/tenant/:tenantId/permission-groups/:id",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Get a single permission group",
@@ -152,6 +156,7 @@ export default function definePermissionGroupRoutes(
   app.put(
     API_BASE_PATH + "/tenant/:tenantId/permission-groups/:id",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Update a permission group",
@@ -192,6 +197,7 @@ export default function definePermissionGroupRoutes(
   app.delete(
     API_BASE_PATH + "/tenant/:tenantId/permission-groups/:id",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Delete a permission group",
@@ -226,6 +232,7 @@ export default function definePermissionGroupRoutes(
     API_BASE_PATH +
       "/tenant/:tenantId/permission-groups/:groupId/permissions/:permissionId",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Assign a permission to a permission group",
@@ -274,6 +281,7 @@ export default function definePermissionGroupRoutes(
     API_BASE_PATH +
       "/tenant/:tenantId/permission-groups/:groupId/permissions/:permissionId",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Remove a permission from a permission group",
@@ -311,6 +319,7 @@ export default function definePermissionGroupRoutes(
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/path-permissions",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Create a new path permission",
@@ -346,6 +355,7 @@ export default function definePermissionGroupRoutes(
   app.get(
     API_BASE_PATH + "/tenant/:tenantId/path-permissions/:id",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Get a single path permission",
@@ -384,6 +394,7 @@ export default function definePermissionGroupRoutes(
   app.put(
     API_BASE_PATH + "/tenant/:tenantId/path-permissions/:id",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Update a path permission",
@@ -424,6 +435,7 @@ export default function definePermissionGroupRoutes(
   app.delete(
     API_BASE_PATH + "/tenant/:tenantId/path-permissions/:id",
     authAndSetUsersInfo,
+    isTenantAdmin,
     describeRoute({
       tags: ["permission-groups"],
       summary: "Delete a path permission",

--- a/src/routes/tenant/[tenantId]/webhooks/index.ts
+++ b/src/routes/tenant/[tenantId]/webhooks/index.ts
@@ -23,6 +23,7 @@ import { describeRoute } from "hono-openapi";
 import { resolver, validator } from "hono-openapi";
 import { RESPONSES } from "../../../../lib/responses";
 import { validateScope } from "../../../../lib/utils/validate-scope";
+import { isTenantAdmin, isTenantMember } from "../../../tenant/index";
 import log from "../../../../lib/log";
 
 /**
@@ -43,6 +44,7 @@ export default function defineWebhookRoutes(
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/webhooks",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Create a new webhook",
@@ -87,6 +89,7 @@ export default function defineWebhookRoutes(
   app.get(
     API_BASE_PATH + "/tenant/:tenantId/webhooks",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Get all webhooks for the user",
@@ -124,6 +127,7 @@ export default function defineWebhookRoutes(
   app.get(
     API_BASE_PATH + "/tenant/:tenantId/webhooks/global",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Get all tenant webhooks",
@@ -161,6 +165,7 @@ export default function defineWebhookRoutes(
   app.get(
     API_BASE_PATH + "/tenant/:tenantId/webhooks/:id",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Get a specific webhook by ID",
@@ -184,8 +189,8 @@ export default function defineWebhookRoutes(
     async (c) => {
       try {
         const userId = c.get("usersId");
-        const { id } = c.req.valid("param");
-        const webhook = await getWebhookById(id, userId);
+        const { id, tenantId } = c.req.valid("param");
+        const webhook = await getWebhookById(id, userId, tenantId);
         if (!webhook) {
           throw new HTTPException(404, { message: "Webhook not found" });
         }
@@ -205,6 +210,7 @@ export default function defineWebhookRoutes(
   app.put(
     API_BASE_PATH + "/tenant/:tenantId/webhooks/:id",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Update a webhook",
@@ -229,9 +235,9 @@ export default function defineWebhookRoutes(
     async (c) => {
       try {
         const userId = c.get("usersId");
-        const { id } = c.req.valid("param");
+        const { id, tenantId } = c.req.valid("param");
         const parsed = c.req.valid("json");
-        const webhook = await updateWebhook(id, parsed, userId);
+        const webhook = await updateWebhook(id, parsed, userId, tenantId);
         if (!webhook) {
           throw new HTTPException(404, { message: "Webhook not found" });
         }
@@ -251,6 +257,7 @@ export default function defineWebhookRoutes(
   app.delete(
     API_BASE_PATH + "/tenant/:tenantId/webhooks/:id",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Delete a webhook",
@@ -269,8 +276,8 @@ export default function defineWebhookRoutes(
     async (c) => {
       try {
         const userId = c.get("usersId");
-        const { id } = c.req.valid("param");
-        await deleteWebhook(id, userId);
+        const { id, tenantId } = c.req.valid("param");
+        await deleteWebhook(id, userId, tenantId);
         return c.json(RESPONSES.SUCCESS);
       } catch (err) {
         throw new HTTPException(500, {
@@ -287,6 +294,7 @@ export default function defineWebhookRoutes(
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/webhooks/register/n8n",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Register a webhook for n8n",
@@ -376,6 +384,7 @@ export default function defineWebhookRoutes(
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/webhooks/check",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Check if a webhook exists",
@@ -402,8 +411,9 @@ export default function defineWebhookRoutes(
       try {
         const userId = c.get("usersId");
         const { webhookId } = c.req.valid("json");
+        const { tenantId } = c.req.valid("param");
 
-        const webhook = await getWebhookById(webhookId, userId);
+        const webhook = await getWebhookById(webhookId, userId, tenantId);
         return c.json({
           exists: !!webhook,
         });
@@ -419,6 +429,7 @@ export default function defineWebhookRoutes(
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/webhooks/:id/trigger",
     authAndSetUsersInfo,
+    isTenantMember,
     describeRoute({
       tags: ["webhooks"],
       summary: "Trigger a webhook",


### PR DESCRIPTION
Security review of the framework. Adds docs/security-review-2026-06.md with
the full findings and remediation, and fixes the self-contained Critical/High
issues:

- Cross-tenant IDOR (SYM-002/003/004/006/007): scope connection, knowledge,
  webhook, permission-group and invitation operations to the tenant; add
  isTenantMember/isTenantAdmin where missing; replace the always-true
  hasAccessToWebhook stub.
- SSRF (SYM-008): new url-guard utility blocking internal/loopback/link-local
  targets and validating every redirect hop; wired into the URL parser and
  webhook delivery.
- Path traversal (SYM-009): validate bucket/file-name segments and enforce an
  upload-directory containment check in local storage.
- User enumeration on forgot-password (SYM-019): generic response regardless of
  account existence.
- Secret leaks in logs (SYM-020): write generated JWT/AES keys to a 0600 file
  instead of stdout; drop WhatsApp token log.

Adds unit tests for the SSRF guard and path-traversal protection. Typecheck and
the new tests pass. Breaking issues (JWT key/algorithm misconfiguration,
OAuth-login CSRF) are documented with remediation but intentionally left for a
coordinated change.

https://claude.ai/code/session_01Cn6J437VoMxmLpBLt97khf