### PR TITLE
Add URL query API for resource filtering, sorting, and relation expansion

### DIFF
--- a/docs/framework/17_Resource_Query_API.md
+++ b/docs/framework/17_Resource_Query_API.md
@@ -1,0 +1,121 @@
+# Resource Query API (Generic Table API via URL)
+
+The resource system turns a single Drizzle table definition into a complete,
+tenant-scoped CRUD resource: business logic, Hono routes and (optionally) AI
+tools. The list endpoint exposes a **normalized, URL-driven query API** for
+filtering, searching, sorting, pagination and relation expansion — similar to
+the table APIs offered by PostgREST / Supabase / Directus.
+
+## Defining a resource
+
+```typescript
+import { defineResource } from "@framework/lib/resource";
+import { competitors, competitorsInsertSchema, competitorsUpdateSchema } from "../db/schema";
+import { desc, asc } from "drizzle-orm";
+
+export const competitorsResource = defineResource({
+  table: competitors,
+  name: "competitors",
+  route: "/tenant/:tenantId/competitors",
+  insertSchema: competitorsInsertSchema,
+  updateSchema: competitorsUpdateSchema,
+  defaultOrderBy: (t) => [desc(t.createdAt)],
+  // optional: enable ?expand=
+  relations: {
+    queryKey: "competitors",        // key under db.query.*
+    allowed: ["tenant", "owner"],   // relations callers may expand
+  },
+});
+
+// In your route setup:
+competitorsResource.registerRoutes(app);
+```
+
+The table **must** have `id` and `tenantId` columns. Every query is implicitly
+scoped to the `tenantId` from the URL.
+
+## Generated endpoints
+
+| Method | Path            | Purpose                                  |
+| ------ | --------------- | ---------------------------------------- |
+| GET    | `/`             | List with filtering / sorting / paging   |
+| GET    | `/:id`          | Get one                                  |
+| POST   | `/`             | Create                                   |
+| PUT    | `/:id`          | Update                                   |
+| DELETE | `/:id`          | Delete                                   |
+| GET    | `/markdown`     | Markdown export (only if configured)     |
+
+## Query syntax (GET `/`)
+
+Filtering uses a PostgREST-style `operator.value` form. Any query parameter
+that is **not** a reserved key is treated as a filter on the column of that
+name. Unknown columns are silently ignored (validated against the real table
+columns), so filters can never reach arbitrary fields.
+
+```text
+GET /tenant/:tenantId/competitors
+      ?status=eq.active        →  status = 'active'
+      &name=like.john          →  name ILIKE '%john%'
+      &score=gte.5             →  score >= 5
+      &score=lte.10            →  score <= 10
+      &id=in.(1,2,3)           →  id IN ('1','2','3')
+      &country=DE              →  country = 'DE'   (no prefix ⇒ eq)
+```
+
+Supported operators: `eq`, `like` (case-insensitive contains), `gte`, `lte`,
+`in`.
+
+### Reserved keys
+
+| Param            | Meaning                                            |
+| ---------------- | -------------------------------------------------- |
+| `limit`          | Max rows (positive integer)                        |
+| `offset`         | Rows to skip (>= 0)                                |
+| `orderBy`        | Column name to sort by                             |
+| `orderDirection` | `asc` (default) or `desc`                          |
+| `expand`         | Comma-separated relation names to eager-load       |
+
+If the prefix before the first `.` is not a known operator, the entire value is
+treated as an `eq` match (e.g. `?domain=example.com` filters for the literal
+`example.com`).
+
+## Relations (`expand`)
+
+When `relations` is configured, callers can eager-load related rows:
+
+```text
+GET /tenant/:tenantId/competitors?expand=tenant,owner&limit=20
+```
+
+Expansion uses Drizzle's relational query API
+(`db.query.<queryKey>.findMany({ with })`), so the table's `relations()` must be
+registered in the schema. `relations.allowed` acts as an allow-list — any
+relation not listed there is ignored.
+
+**Limitation:** filters and ordering apply to the **root table only**. Relations
+are eager-loaded but cannot themselves be filtered through the URL — this is a
+deliberate constraint of Drizzle's relational query builder. If you need to
+filter a parent by a child's column, write a dedicated endpoint with an explicit
+join.
+
+## Programmatic access
+
+The same options are available directly on `resource.operations.getAll`:
+
+```typescript
+const rows = await competitorsResource.operations.getAll(tenantId, {
+  filters: [{ field: "status", operator: "eq", value: "active" }],
+  orderBy: "createdAt",
+  orderDirection: "desc",
+  limit: 20,
+  expand: ["tenant"],
+});
+```
+
+The URL parser is exported as well, so the same syntax can be reused elsewhere:
+
+```typescript
+import { parseQueryOptions } from "@framework/lib/resource";
+
+const options = parseQueryOptions(c.req.query());
+```

--- a/src/lib/db/schema/additional-data.ts
+++ b/src/lib/db/schema/additional-data.ts
@@ -138,6 +138,16 @@ export const tenantSpecificDataUpdateSchema = createUpdateSchema(
   tenantSpecificData
 );
 
+export const tenantSpecificDataRelations = relations(
+  tenantSpecificData,
+  ({ one }) => ({
+    tenant: one(tenants, {
+      fields: [tenantSpecificData.tenantId],
+      references: [tenants.id],
+    }),
+  })
+);
+
 // Table for team specific data
 
 export const teamSpecificData = pgBaseTable(

--- a/src/lib/resource/crud-operations.ts
+++ b/src/lib/resource/crud-operations.ts
@@ -23,6 +23,7 @@ import type {
   CrudHooks,
   QueryOptions,
   QueryFilter,
+  ResourceRelationsConfig,
 } from "./types";
 
 /**
@@ -37,6 +38,11 @@ export interface CrudOperationsConfig<T extends PgTable<TableConfig>> {
   defaultOrderBy?: (table: T) => any[];
   /** Lifecycle hooks for business rules */
   hooks?: CrudHooks;
+  /**
+   * Relation expansion config. Enables `getAll(..., { expand })` via Drizzle's
+   * relational query API. Requires the table's `relations()` to be registered.
+   */
+  relations?: ResourceRelationsConfig;
 }
 
 /**
@@ -108,7 +114,31 @@ export function createCrudOperations<T extends PgTable<TableConfig>>(
   }
 
   /**
-   * Get all entries for a tenant with optional filtering, pagination, and sorting
+   * Resolve the ORDER BY clause as an array of column expressions, shared by
+   * the flat and relational query paths. An explicit `orderBy` field wins over
+   * the configured default; an unknown field falls back to the default.
+   */
+  function resolveOrderBy(
+    orderBy: string | undefined,
+    orderDirection: "asc" | "desc"
+  ): SQL[] | undefined {
+    if (orderBy) {
+      const orderCol = columns[orderBy as keyof typeof columns];
+      if (orderCol) {
+        return [orderDirection === "desc" ? desc(orderCol) : asc(orderCol)];
+      }
+    }
+    if (config.defaultOrderBy) {
+      return config.defaultOrderBy(table);
+    }
+    return undefined;
+  }
+
+  /**
+   * Get all entries for a tenant with optional filtering, pagination, sorting
+   * and relation expansion. When `expand` is requested and relations are
+   * configured, the query runs through Drizzle's relational query API so the
+   * requested relations are eager-loaded; otherwise a flat select is used.
    */
   async function getAll(
     tenantId: string,
@@ -120,32 +150,52 @@ export function createCrudOperations<T extends PgTable<TableConfig>>(
       offset,
       orderBy,
       orderDirection = "asc",
+      expand = [],
     } = options;
+
+    // Always filter by tenant, then add validated custom filters.
+    const conditions: SQL[] = [eq(tenantIdCol, tenantId)];
+    if (filters.length > 0) {
+      conditions.push(...buildFilterConditions(table, filters));
+    }
+    const whereClause = and(...conditions);
+    const orderByClause = resolveOrderBy(orderBy, orderDirection);
+
+    // Relation-aware path via the relational query API.
+    if (expand.length > 0 && config.relations) {
+      const { queryKey, allowed } = config.relations;
+      const queryApi = (getDb().query as Record<string, any>)[queryKey];
+      if (!queryApi) {
+        throw new Error(
+          `Cannot expand relations: table "${queryKey}" is not registered on db.query`
+        );
+      }
+
+      // Allow-list: only expose relations the resource opted into.
+      const withClause: Record<string, true> = {};
+      for (const relation of expand) {
+        if (allowed.includes(relation)) {
+          withClause[relation] = true;
+        }
+      }
+
+      return queryApi.findMany({
+        where: whereClause,
+        ...(Object.keys(withClause).length > 0 ? { with: withClause } : {}),
+        ...(orderByClause ? { orderBy: orderByClause } : {}),
+        ...(limit !== undefined ? { limit } : {}),
+        ...(offset !== undefined ? { offset } : {}),
+      });
+    }
 
     // @ts-expect-error - Drizzle's from() uses a deferred conditional type
     // that TypeScript cannot resolve with generic PgTable type params
     let query = getDb().select().from(table).$dynamic();
 
-    // Always filter by tenant
-    const conditions: SQL[] = [eq(tenantIdCol, tenantId)];
+    query = query.where(whereClause);
 
-    // Add custom filters
-    if (filters.length > 0) {
-      conditions.push(...buildFilterConditions(table, filters));
-    }
-
-    query = query.where(and(...conditions));
-
-    // Sorting
-    if (orderBy) {
-      const orderCol = columns[orderBy as keyof typeof columns];
-      if (orderCol) {
-        query = query.orderBy(
-          orderDirection === "desc" ? desc(orderCol) : asc(orderCol)
-        );
-      }
-    } else if (config.defaultOrderBy) {
-      query = query.orderBy(...config.defaultOrderBy(table));
+    if (orderByClause) {
+      query = query.orderBy(...orderByClause);
     }
 
     // Pagination

--- a/src/lib/resource/crud-routes.ts
+++ b/src/lib/resource/crud-routes.ts
@@ -8,7 +8,8 @@ import { validator } from "hono-openapi";
 import * as v from "valibot";
 import { HTTPException } from "hono/http-exception";
 import type { SFContextVariables } from "../../types";
-import type { CrudOperations, QueryOptions } from "./types";
+import type { CrudOperations } from "./types";
+import { parseQueryOptions } from "./query-params";
 
 /**
  * Configuration for createCrudRoutes
@@ -22,36 +23,6 @@ export interface CrudRoutesConfig {
   markdown?: {
     renderer: (entries: any[]) => string;
   };
-}
-
-/**
- * Parse query parameters into QueryOptions for getAll
- */
-function parseQueryOptions(
-  query: Record<string, string | undefined>
-): QueryOptions {
-  const options: QueryOptions = {};
-
-  if (query.limit) {
-    const parsed = parseInt(query.limit, 10);
-    if (!isNaN(parsed) && parsed > 0) {
-      options.limit = parsed;
-    }
-  }
-  if (query.offset) {
-    const parsed = parseInt(query.offset, 10);
-    if (!isNaN(parsed) && parsed >= 0) {
-      options.offset = parsed;
-    }
-  }
-  if (query.orderBy) {
-    options.orderBy = query.orderBy;
-  }
-  if (query.orderDirection === "asc" || query.orderDirection === "desc") {
-    options.orderDirection = query.orderDirection;
-  }
-
-  return options;
 }
 
 /**
@@ -106,7 +77,9 @@ export function createCrudRoutes(
   const app = new Hono<{ Variables: SFContextVariables }>();
   const { entityName } = config;
 
-  // GET / - List all entries with optional pagination and sorting
+  // GET / - List entries with optional filtering, pagination, sorting and
+  // relation expansion. Filters use PostgREST-style query params, e.g.
+  //   ?status=eq.active&age=gte.18&name=like.john&expand=tenant&limit=20
   app.get(
     "/",
     validator("param", v.object({ tenantId: v.string() })),

--- a/src/lib/resource/define-resource.ts
+++ b/src/lib/resource/define-resource.ts
@@ -52,6 +52,7 @@ export function defineResource<T extends PgTable<TableConfig>>(
     updateSchema: config.updateSchema,
     defaultOrderBy: config.defaultOrderBy,
     hooks: config.hooks,
+    relations: config.relations,
   });
 
   // 2. Create routes

--- a/src/lib/resource/index.ts
+++ b/src/lib/resource/index.ts
@@ -16,11 +16,21 @@ export type {
   FilterOperator,
   QueryFilter,
   QueryOptions,
+  ResourceRelationsConfig,
   CrudHooks,
   CrudOperations,
   ResourceConfig,
   ResourceDefinition,
 } from "./types";
+
+// URL query parsing (filtering, pagination, sorting, relation expansion)
+export {
+  parseQueryOptions,
+  parseFilterParams,
+  parseExpandParam,
+  parseFilterValue,
+  RESERVED_QUERY_KEYS,
+} from "./query-params";
 
 // Schema utilities
 export {

--- a/src/lib/resource/query-params.test.ts
+++ b/src/lib/resource/query-params.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect } from "bun:test";
+import {
+  parseQueryOptions,
+  parseFilterParams,
+  parseExpandParam,
+  parseFilterValue,
+  RESERVED_QUERY_KEYS,
+} from "./query-params";
+
+describe("resource query-params parser", () => {
+  test("parseFilterValue: in operator splits a parenthesised list", () => {
+    expect(parseFilterValue("in", "(a,b,c)")).toEqual(["a", "b", "c"]);
+    expect(parseFilterValue("in", "(a, b , c)")).toEqual(["a", "b", "c"]);
+    expect(parseFilterValue("in", "a,b")).toEqual(["a", "b"]);
+    expect(parseFilterValue("in", "()")).toEqual([]);
+  });
+
+  test("parseFilterValue: non-in operators keep the raw string", () => {
+    expect(parseFilterValue("eq", "active")).toBe("active");
+    expect(parseFilterValue("gte", "18")).toBe("18");
+    expect(parseFilterValue("like", "john")).toBe("john");
+  });
+
+  test("parseFilterParams: PostgREST-style operator prefixes", () => {
+    const filters = parseFilterParams({
+      status: "eq.active",
+      name: "like.john",
+      min: "gte.18",
+      max: "lte.65",
+      id: "in.(1,2,3)",
+    });
+
+    expect(filters).toEqual([
+      { field: "status", operator: "eq", value: "active" },
+      { field: "name", operator: "like", value: "john" },
+      { field: "min", operator: "gte", value: "18" },
+      { field: "max", operator: "lte", value: "65" },
+      { field: "id", operator: "in", value: ["1", "2", "3"] },
+    ]);
+  });
+
+  test("parseFilterParams: missing prefix defaults to eq", () => {
+    expect(parseFilterParams({ status: "active" })).toEqual([
+      { field: "status", operator: "eq", value: "active" },
+    ]);
+  });
+
+  test("parseFilterParams: unknown prefix is treated as a literal eq value", () => {
+    // 'example' is not an operator -> the whole value is an eq match
+    expect(parseFilterParams({ domain: "example.com" })).toEqual([
+      { field: "domain", operator: "eq", value: "example.com" },
+    ]);
+  });
+
+  test("parseFilterParams: reserved keys and empty values are skipped", () => {
+    const filters = parseFilterParams({
+      limit: "10",
+      offset: "5",
+      orderBy: "createdAt",
+      orderDirection: "desc",
+      expand: "tenant",
+      empty: "",
+      status: "eq.active",
+    });
+    expect(filters).toEqual([
+      { field: "status", operator: "eq", value: "active" },
+    ]);
+    // sanity check on the reserved set itself
+    for (const key of [
+      "limit",
+      "offset",
+      "orderBy",
+      "orderDirection",
+      "expand",
+    ]) {
+      expect(RESERVED_QUERY_KEYS.has(key)).toBe(true);
+    }
+  });
+
+  test("parseExpandParam: splits, trims and drops empties", () => {
+    expect(parseExpandParam("tenant,knowledgeChunks")).toEqual([
+      "tenant",
+      "knowledgeChunks",
+    ]);
+    expect(parseExpandParam(" tenant , , user ")).toEqual(["tenant", "user"]);
+    expect(parseExpandParam("")).toEqual([]);
+    expect(parseExpandParam(undefined)).toEqual([]);
+  });
+
+  test("parseQueryOptions: combines pagination, sorting, expand and filters", () => {
+    const options = parseQueryOptions({
+      limit: "20",
+      offset: "40",
+      orderBy: "createdAt",
+      orderDirection: "desc",
+      expand: "tenant,user",
+      status: "eq.active",
+      score: "gte.5",
+    });
+
+    expect(options.limit).toBe(20);
+    expect(options.offset).toBe(40);
+    expect(options.orderBy).toBe("createdAt");
+    expect(options.orderDirection).toBe("desc");
+    expect(options.expand).toEqual(["tenant", "user"]);
+    expect(options.filters).toEqual([
+      { field: "status", operator: "eq", value: "active" },
+      { field: "score", operator: "gte", value: "5" },
+    ]);
+  });
+
+  test("parseQueryOptions: invalid pagination values are ignored", () => {
+    const options = parseQueryOptions({
+      limit: "0",
+      offset: "-1",
+      orderDirection: "sideways",
+    });
+    expect(options.limit).toBeUndefined();
+    expect(options.offset).toBeUndefined();
+    expect(options.orderDirection).toBeUndefined();
+  });
+
+  test("parseQueryOptions: omits empty filter and expand keys", () => {
+    const options = parseQueryOptions({ limit: "5" });
+    expect(options.filters).toBeUndefined();
+    expect(options.expand).toBeUndefined();
+    expect(options.limit).toBe(5);
+  });
+});

--- a/src/lib/resource/query-params.ts
+++ b/src/lib/resource/query-params.ts
@@ -1,0 +1,164 @@
+/**
+ * URL query parsing for the resource system.
+ *
+ * This module is intentionally free of runtime dependencies (only type-only
+ * imports) so it can be unit-tested without a database or HTTP framework.
+ *
+ * It turns a flat query-string record (as returned by Hono's `c.req.query()`)
+ * into a normalized {@link QueryOptions} object understood by the CRUD layer.
+ *
+ * ## Filtering syntax (PostgREST-style)
+ *
+ * Any query parameter that is not a reserved key is treated as a filter on the
+ * column with that name. The value uses an `operator.value` form:
+ *
+ * ```text
+ * ?status=eq.active          status = 'active'
+ * ?name=like.john            name ILIKE '%john%'
+ * ?age=gte.18                age >= 18
+ * ?age=lte.65                age <= 65
+ * ?id=in.(a,b,c)             id IN ('a','b','c')
+ * ?status=active             status = 'active'   (no prefix -> defaults to eq)
+ * ```
+ *
+ * If the prefix before the first `.` is not a known operator the whole value is
+ * treated as an `eq` value (so `?domain=example.com` filters for the literal
+ * `example.com`).
+ *
+ * ## Reserved keys
+ *
+ * `limit`, `offset`, `orderBy`, `orderDirection`, `expand` are never treated as
+ * filters. They control pagination, sorting and relation expansion instead.
+ */
+
+import type { QueryOptions, QueryFilter, FilterOperator } from "./types";
+
+/**
+ * Query parameters that control the query itself and are never treated as
+ * column filters.
+ */
+export const RESERVED_QUERY_KEYS = new Set<string>([
+  "limit",
+  "offset",
+  "orderBy",
+  "orderDirection",
+  "expand",
+]);
+
+const KNOWN_OPERATORS: readonly FilterOperator[] = [
+  "eq",
+  "like",
+  "gte",
+  "lte",
+  "in",
+];
+
+function isOperator(value: string): value is FilterOperator {
+  return (KNOWN_OPERATORS as readonly string[]).includes(value);
+}
+
+/**
+ * Parse the value part of a filter into the shape expected by the CRUD layer.
+ * For the `in` operator a parenthesised, comma-separated list is split into an
+ * array; all other operators keep the raw string value.
+ */
+export function parseFilterValue(
+  operator: FilterOperator,
+  raw: string
+): unknown {
+  if (operator === "in") {
+    const inner = raw.replace(/^\(/, "").replace(/\)$/, "").trim();
+    if (inner.length === 0) return [];
+    return inner.split(",").map((part) => part.trim());
+  }
+  return raw;
+}
+
+/**
+ * Extract column filters from a raw query record. Reserved keys and empty
+ * values are skipped. Field-name validation against the actual table columns
+ * happens later in the CRUD layer, so unknown columns are harmless here.
+ */
+export function parseFilterParams(
+  query: Record<string, string | undefined>
+): QueryFilter[] {
+  const filters: QueryFilter[] = [];
+
+  for (const [field, rawValue] of Object.entries(query)) {
+    if (RESERVED_QUERY_KEYS.has(field)) continue;
+    if (rawValue === undefined || rawValue === "") continue;
+
+    let operator: FilterOperator = "eq";
+    let valuePart = rawValue;
+
+    const dotIndex = rawValue.indexOf(".");
+    if (dotIndex > 0) {
+      const maybeOperator = rawValue.slice(0, dotIndex);
+      if (isOperator(maybeOperator)) {
+        operator = maybeOperator;
+        valuePart = rawValue.slice(dotIndex + 1);
+      }
+    }
+
+    filters.push({
+      field,
+      operator,
+      value: parseFilterValue(operator, valuePart),
+    });
+  }
+
+  return filters;
+}
+
+/**
+ * Parse the `expand` parameter into a list of relation names.
+ * Accepts a comma-separated list, e.g. `?expand=tenant,knowledgeChunks`.
+ */
+export function parseExpandParam(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+/**
+ * Parse a raw query record into {@link QueryOptions} for `getAll`:
+ * pagination, sorting, relation expansion and column filters.
+ */
+export function parseQueryOptions(
+  query: Record<string, string | undefined>
+): QueryOptions {
+  const options: QueryOptions = {};
+
+  if (query.limit) {
+    const parsed = parseInt(query.limit, 10);
+    if (!isNaN(parsed) && parsed > 0) {
+      options.limit = parsed;
+    }
+  }
+  if (query.offset) {
+    const parsed = parseInt(query.offset, 10);
+    if (!isNaN(parsed) && parsed >= 0) {
+      options.offset = parsed;
+    }
+  }
+  if (query.orderBy) {
+    options.orderBy = query.orderBy;
+  }
+  if (query.orderDirection === "asc" || query.orderDirection === "desc") {
+    options.orderDirection = query.orderDirection;
+  }
+
+  const expand = parseExpandParam(query.expand);
+  if (expand.length > 0) {
+    options.expand = expand;
+  }
+
+  const filters = parseFilterParams(query);
+  if (filters.length > 0) {
+    options.filters = filters;
+  }
+
+  return options;
+}

--- a/src/lib/resource/resource-integration.test.ts
+++ b/src/lib/resource/resource-integration.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Integration tests for the resource system against a real framework table.
+ *
+ * Uses `tenantSpecificData` (a real, tenant-scoped table) wired through
+ * `defineResource`, and exercises the generated HTTP API end-to-end against a
+ * live Postgres: CRUD, URL filtering, sorting, pagination, relation expansion
+ * (?expand=) and tenant isolation.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { eq, inArray } from "drizzle-orm";
+import {
+  initTests,
+  TEST_ORGANISATION_1,
+  TEST_ORGANISATION_2,
+} from "../../test/init.test";
+import { testFetcher } from "../../test/fetcher.test";
+import { getDb } from "../db/db-connection";
+import {
+  tenantSpecificData,
+  tenantSpecificDataInsertSchema,
+  tenantSpecificDataUpdateSchema,
+} from "../db/schema/additional-data";
+import type { SymbiosikaFrameworkHonoApp } from "../../types";
+import { defineResource } from "./define-resource";
+
+// A resource built from a real framework table.
+const resource = defineResource({
+  table: tenantSpecificData,
+  name: "tenant-specific-data",
+  route: "/tenant/:tenantId/tenant-specific-data",
+  insertSchema: tenantSpecificDataInsertSchema,
+  updateSchema: tenantSpecificDataUpdateSchema,
+  defaultOrderBy: (t) => [t.key],
+  relations: {
+    queryKey: "tenantSpecificData",
+    allowed: ["tenant"],
+  },
+});
+
+let app: SymbiosikaFrameworkHonoApp;
+const ORG1 = TEST_ORGANISATION_1.id;
+const ORG2 = TEST_ORGANISATION_2.id;
+const base1 = `/tenant/${ORG1}/tenant-specific-data`;
+const base2 = `/tenant/${ORG2}/tenant-specific-data`;
+
+const cleanup = () =>
+  getDb()
+    .delete(tenantSpecificData)
+    .where(inArray(tenantSpecificData.tenantId, [ORG1, ORG2]));
+
+describe("Resource system (defineResource) against tenantSpecificData", () => {
+  beforeAll(async () => {
+    await initTests();
+    app = new Hono();
+    resource.registerRoutes(app);
+    await cleanup();
+
+    // Seed a known data set in ORG1 (and one row in ORG2 for isolation checks).
+    const seed = [
+      { tenantId: ORG1, key: "alpha", version: 1, data: { kind: "fruit" } },
+      { tenantId: ORG1, key: "beta", version: 2, data: { kind: "fruit" } },
+      { tenantId: ORG1, key: "gamma", version: 3, data: { kind: "veg" } },
+      { tenantId: ORG2, key: "alpha", version: 9, data: { kind: "other" } },
+    ];
+    await getDb().insert(tenantSpecificData).values(seed);
+  });
+
+  afterAll(() => {
+    cleanup().then(() => {});
+  });
+
+  test("CRUD cycle via the generated routes", async () => {
+    const created = await testFetcher.post(app, base1, undefined, {
+      key: "crud-item",
+      version: 0,
+      data: { hello: "world" },
+    });
+    expect(created.status).toBe(200);
+    expect(created.jsonResponse?.success).toBe(true);
+    const id = created.jsonResponse?.data.id;
+    expect(id).toBeDefined();
+    expect(created.jsonResponse?.data.tenantId).toBe(ORG1);
+
+    const fetched = await testFetcher.get(app, `${base1}/${id}`, undefined);
+    expect(fetched.status).toBe(200);
+    expect(fetched.jsonResponse?.data.key).toBe("crud-item");
+
+    const updated = await testFetcher.put(app, `${base1}/${id}`, undefined, {
+      data: { hello: "updated" },
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.jsonResponse?.data.data).toEqual({ hello: "updated" });
+
+    const removed = await testFetcher.delete(app, `${base1}/${id}`, undefined);
+    expect(removed.status).toBe(200);
+
+    const gone = await testFetcher.get(app, `${base1}/${id}`, undefined);
+    expect(gone.status).toBe(404);
+  });
+
+  test("filter: eq on a text column", async () => {
+    const res = await testFetcher.get(app, `${base1}?key=eq.beta`, undefined);
+    expect(res.status).toBe(200);
+    expect(res.jsonResponse.data).toHaveLength(1);
+    expect(res.jsonResponse.data[0].key).toBe("beta");
+  });
+
+  test("filter: like (case-insensitive contains)", async () => {
+    const res = await testFetcher.get(app, `${base1}?key=like.ET`, undefined);
+    expect(res.status).toBe(200);
+    const keys = res.jsonResponse.data.map((r: any) => r.key);
+    expect(keys).toEqual(["beta"]);
+  });
+
+  test("filter: in (list membership)", async () => {
+    const res = await testFetcher.get(
+      app,
+      `${base1}?key=in.(alpha,gamma)`,
+      undefined
+    );
+    expect(res.status).toBe(200);
+    const keys = res.jsonResponse.data.map((r: any) => r.key).sort();
+    expect(keys).toEqual(["alpha", "gamma"]);
+  });
+
+  test("filter: gte / lte on a numeric column", async () => {
+    const gte = await testFetcher.get(app, `${base1}?version=gte.2`, undefined);
+    expect(gte.status).toBe(200);
+    expect(gte.jsonResponse.data.map((r: any) => r.version).sort()).toEqual([
+      2, 3,
+    ]);
+
+    const lte = await testFetcher.get(app, `${base1}?version=lte.2`, undefined);
+    expect(lte.status).toBe(200);
+    expect(lte.jsonResponse.data.map((r: any) => r.version).sort()).toEqual([
+      1, 2,
+    ]);
+  });
+
+  test("sorting and pagination", async () => {
+    const desc = await testFetcher.get(
+      app,
+      `${base1}?orderBy=key&orderDirection=desc`,
+      undefined
+    );
+    expect(desc.jsonResponse.data.map((r: any) => r.key)).toEqual([
+      "gamma",
+      "beta",
+      "alpha",
+    ]);
+
+    const paged = await testFetcher.get(
+      app,
+      `${base1}?orderBy=key&orderDirection=asc&limit=1&offset=1`,
+      undefined
+    );
+    expect(paged.jsonResponse.data).toHaveLength(1);
+    expect(paged.jsonResponse.data[0].key).toBe("beta");
+  });
+
+  test("expand: eager-load the tenant relation", async () => {
+    const res = await testFetcher.get(
+      app,
+      `${base1}?key=eq.alpha&expand=tenant`,
+      undefined
+    );
+    expect(res.status).toBe(200);
+    expect(res.jsonResponse.data).toHaveLength(1);
+    expect(res.jsonResponse.data[0].tenant).toBeDefined();
+    expect(res.jsonResponse.data[0].tenant.id).toBe(ORG1);
+    expect(res.jsonResponse.data[0].tenant.name).toBe(TEST_ORGANISATION_1.name);
+  });
+
+  test("expand: non-allowlisted relations are ignored", async () => {
+    const res = await testFetcher.get(
+      app,
+      `${base1}?key=eq.alpha&expand=secretRelation`,
+      undefined
+    );
+    expect(res.status).toBe(200);
+    expect(res.jsonResponse.data[0].secretRelation).toBeUndefined();
+  });
+
+  test("filter on an unknown column is ignored (no injection)", async () => {
+    const res = await testFetcher.get(
+      app,
+      `${base1}?notAColumn=eq.whatever`,
+      undefined
+    );
+    expect(res.status).toBe(200);
+    // All ORG1 rows returned, the bogus filter had no effect
+    expect(res.jsonResponse.data.length).toBe(3);
+  });
+
+  test("tenant isolation: list is scoped to the URL tenant", async () => {
+    const res1 = await testFetcher.get(app, base1, undefined);
+    const res2 = await testFetcher.get(app, base2, undefined);
+    expect(res1.jsonResponse.data.length).toBe(3);
+    expect(res2.jsonResponse.data.length).toBe(1);
+    expect(res2.jsonResponse.data[0].version).toBe(9);
+  });
+
+  test("tenant isolation: getById cannot cross tenants", async () => {
+    const org2List = await testFetcher.get(app, base2, undefined);
+    const org2Id = org2List.jsonResponse.data[0].id;
+
+    // The ORG2 row must not be reachable through the ORG1 scope
+    const cross = await testFetcher.get(app, `${base1}/${org2Id}`, undefined);
+    expect(cross.status).toBe(404);
+  });
+});

--- a/src/lib/resource/types.ts
+++ b/src/lib/resource/types.ts
@@ -36,7 +36,7 @@ export interface QueryFilter {
 }
 
 /**
- * Options for getAll queries - filtering, pagination, sorting
+ * Options for getAll queries - filtering, pagination, sorting, relation expansion
  */
 export interface QueryOptions {
   filters?: QueryFilter[];
@@ -44,6 +44,33 @@ export interface QueryOptions {
   offset?: number;
   orderBy?: string;
   orderDirection?: "asc" | "desc";
+  /**
+   * Names of relations to eager-load alongside each entry.
+   * Only relations declared in the resource's `relations.allowed` list are
+   * expanded; unknown names are ignored. Requires `relations` to be configured.
+   */
+  expand?: string[];
+}
+
+/**
+ * Relation expansion config for a resource.
+ *
+ * Expansion uses Drizzle's relational query API
+ * (`db.query.<queryKey>.findMany({ with })`), which requires the table's
+ * `relations()` to be registered in the schema.
+ */
+export interface ResourceRelationsConfig {
+  /**
+   * The table's key in the Drizzle schema as exposed on `db.query`.
+   * This is the JS property name the table is registered under, which may
+   * differ from the SQL table name (e.g. `knowledgeEntry`, not `knowledge`).
+   */
+  queryKey: string;
+  /**
+   * Relation names that callers may request via `?expand=`.
+   * Acts as an allow-list: any requested relation not in this list is ignored.
+   */
+  allowed: string[];
 }
 
 /**
@@ -101,6 +128,12 @@ export interface ResourceConfig<
   defaultOrderBy?: (table: T) => any[];
   /** Lifecycle hooks for business rules */
   hooks?: CrudHooks;
+  /**
+   * Relation expansion config. When set, callers can request related rows via
+   * `?expand=relationName` on the list endpoint. Requires the table's
+   * `relations()` to be registered in the Drizzle schema.
+   */
+  relations?: ResourceRelationsConfig;
   /** AI tool configuration */
   ai?: {
     enabled: boolean;


### PR DESCRIPTION
## Summary

This PR adds a complete URL-driven query API to the resource system, enabling PostgREST-style filtering, sorting, pagination, and relation expansion on list endpoints. The implementation includes a dedicated query parser module, integration tests against a real table, and comprehensive documentation.

## Key Changes

- **New `query-params.ts` module**: Parses URL query strings into normalized `QueryOptions` objects. Supports PostgREST-style operators (`eq`, `like`, `gte`, `lte`, `in`) with a `operator.value` syntax. Reserved keys (`limit`, `offset`, `orderBy`, `orderDirection`, `expand`) are never treated as filters. Unknown columns are silently ignored for safety.

- **Relation expansion support**: Added `expand` parameter to `QueryOptions` and `ResourceRelationsConfig` type. When relations are configured on a resource, callers can eager-load related rows via `?expand=relationName`. Uses Drizzle's relational query API (`db.query.<queryKey>.findMany({ with })`) with an allow-list to control which relations are accessible.

- **Updated `crud-operations.ts`**: 
  - Added `relations` config field to `CrudOperationsConfig`
  - Enhanced `getAll()` to support relation expansion via a separate code path using Drizzle's relational query API
  - Extracted `resolveOrderBy()` helper to share ORDER BY logic between flat and relational queries

- **Updated `crud-routes.ts`**: Replaced inline `parseQueryOptions()` with import from the new `query-params` module for reusability.

- **Integration tests (`resource-integration.test.ts`)**: Comprehensive end-to-end tests against `tenantSpecificData` table covering CRUD, filtering (eq, like, in, gte, lte), sorting, pagination, relation expansion, allow-list enforcement, injection safety, and tenant isolation.

- **Unit tests (`query-params.test.ts`)**: Full coverage of the query parser including operator parsing, filter extraction, expand parameter handling, and edge cases.

- **Documentation (`Resource_Query_API.md`)**: User guide covering resource definition, generated endpoints, query syntax, reserved keys, relation expansion, and programmatic access.

- **Schema updates**: Added `tenantSpecificDataRelations` to `additional-data.ts` to enable relation expansion in tests.

- **Exports**: Added query parser functions and types to the public resource API via `index.ts`.

## Implementation Details

- The query parser is intentionally dependency-free (type-only imports) to enable unit testing without database or HTTP framework setup
- Filters are validated against actual table columns in the CRUD layer, preventing injection attacks
- Unknown filter columns are silently ignored rather than erroring, allowing safe URL construction
- The `in` operator accepts parenthesized or bare comma-separated lists: `?id=in.(1,2,3)` or `?id=in.1,2,3`
- Relation expansion uses an allow-list pattern; requested relations not in `relations.allowed` are ignored
- Tenant isolation is enforced at the query level; cross-tenant access is impossible

https://claude.ai/code/session_01EZo1i525fFKAS94D9kEoa1