### PR TITLE
feat(email): write debug emails as individual files in logs/email/

### DIFF
--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -121,27 +121,25 @@ class SMTPService {
 
     // Console mode: log email to console instead of sending
     if (this.consoleMode) {
-      const emailData = {
-        from: sender || process.env.SMTP_DEFAULT_SENDER,
-        to: recipients.join(", "),
-        subject,
-        text,
-        html,
-      };
+      const from = sender || process.env.SMTP_DEFAULT_SENDER || "unknown";
+      const to = recipients.join(", ");
+      const body = text || htmlToPlainText(html || "");
 
       console.log("\n" + "=".repeat(60));
       console.log("📧 EMAIL (Console Mode - Not Actually Sent)");
       console.log("=".repeat(60));
-      console.log(`From: ${emailData.from}`);
-      console.log(`To: ${emailData.to}`);
-      console.log(`Subject: ${emailData.subject}`);
+      console.log(`From:    ${from}`);
+      console.log(`To:      ${to}`);
+      console.log(`Subject: ${subject}`);
       console.log("-".repeat(60));
-      if (text) {
-        console.log(text);
-      } else if (html) {
-        console.log(htmlToPlainText(html));
-      }
+      console.log(body);
       console.log("=".repeat(60) + "\n");
+
+      const timestamp = new Date().toISOString();
+      const filePath = await log.writeEmailFile({ timestamp, from, to, subject, body, html });
+      if (filePath) {
+        console.log(`📁 Email saved to: ${filePath}`);
+      }
 
       this.log(`[Console Mode] Email logged: ${subject}`);
       return true;

--- a/src/lib/log/index.ts
+++ b/src/lib/log/index.ts
@@ -172,6 +172,58 @@ class Logger {
     }
   }
 
+  async writeEmailFile(options: {
+    timestamp: string;
+    from: string;
+    to: string;
+    subject: string;
+    body: string;
+    html?: string;
+  }): Promise<string | null> {
+    const emailDir = path.join(process.cwd(), "logs", "email");
+    try {
+      await fs.mkdir(emailDir, { recursive: true });
+    } catch (error: any) {
+      if (error.code !== "EEXIST") {
+        console.error("Error creating email log directory:", error);
+        return null;
+      }
+    }
+
+    // Timestamp format: YYYY-MM-DDTHH-mm-ss-SSS for proper lexicographic sorting
+    const fileTimestamp = options.timestamp.replace(/:/g, "-").replace(/\./g, "-");
+    const subjectSlug = options.subject
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .substring(0, 50);
+    const fileName = `${fileTimestamp}_${subjectSlug}.txt`;
+    const filePath = path.join(emailDir, fileName);
+
+    const lines = [
+      `Timestamp: ${options.timestamp}`,
+      `From:      ${options.from}`,
+      `To:        ${options.to}`,
+      `Subject:   ${options.subject}`,
+      "",
+      "=".repeat(60),
+      "",
+      options.body,
+    ];
+
+    if (options.html) {
+      lines.push("", "=".repeat(60), "--- HTML ---", "", options.html);
+    }
+
+    try {
+      await fs.writeFile(filePath, lines.join("\n"), "utf8");
+      return filePath;
+    } catch (error) {
+      console.error("Error writing email log file:", error);
+      return null;
+    }
+  }
+
   async getLogFilePaths(): Promise<string[]> {
     const logFiles: string[] = [];
 


### PR DESCRIPTION
In console mode (SMTP_HOST=console.localhost) each email is now also written
as a standalone .txt file under logs/email/. The filename starts with an ISO
timestamp (colons replaced by dashes) so files sort chronologically:

  logs/email/2026-06-13T08-25-01-123_magic-link-login.txt

Each file contains a plain-text header (Timestamp / From / To / Subject),
the readable body (HTML stripped via htmlToPlainText), and the raw HTML
appended at the end for inspection.

Logger gains a new writeEmailFile() method that creates the directory on
demand and handles write errors without crashing the request.

https://claude.ai/code/session_01PrHGPgfy22Dj9Vy5zE8Xth