### PR TITLE
test(resource): fix integration tests broken by default tenant guard (follow-up to #24)

### DIFF
--- a/src/lib/resource/resource-integration.test.ts
+++ b/src/lib/resource/resource-integration.test.ts
@@ -36,6 +36,12 @@ const resource = defineResource({
     queryKey: "tenantSpecificData",
     allowed: ["tenant"],
   },
+  // This test mounts the routes on a bare Hono app without authAndSetUsersInfo,
+  // so it does not simulate tenant membership. Opt out of the (now default)
+  // tenant membership guard so the generated routes' data behaviour can be
+  // exercised directly. Operation-level tenant scoping (by tenantId) is still
+  // enforced and is what the isolation tests below verify.
+  auth: { tenantGuard: "none" },
 });
 
 let app: SymbiosikaFrameworkHonoApp;


### PR DESCRIPTION
## Summary

Follow-up to #24, which was merged before this fix could be included. PR #24 changed `createCrudRoutes` to default `tenantGuard` to `"member"`, which applies the `isTenantMember` middleware to every generated route. `resource-integration.test.ts` mounts the generated routes on a bare Hono app **without** `authAndSetUsersInfo`, so no tenant membership is simulated and every request is now rejected with 403 — breaking all 11 integration tests on `develop`.

## Fix

Set `auth: { tenantGuard: "none" }` on the test's `defineResource(...)` so the generated routes' data behaviour (CRUD, filtering, sorting, pagination, relation expansion, operation-level tenant scoping) is exercised as before. Operation-level `tenantId` scoping is unchanged and still backs the tenant-isolation assertions.

## Verification

Run against a live PGlite DB (`bun run init` → `bun run db:local` → `framework:migrate`):

- `resource-integration.test.ts` → **11 pass / 0 fail** (was 11 fail on develop)
- full `src/lib/resource/` → 31 pass / 0 fail
- `bunx tsc --noEmit` → clean for `resource/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBJnzG9e7L1xtdPpJFBWt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBJnzG9e7L1xtdPpJFBWt1)_