### PR TITLE
feat(user): persist theme preference on user profile

### DIFF
--- a/src/routes/user/index.test.ts
+++ b/src/routes/user/index.test.ts
@@ -263,6 +263,57 @@ describe("User API Endpoints", () => {
     expect(response.status).toBe(400);
   });
 
+  // Theme preference is stored on users.meta.theme
+  it("PUT /user/me persists the theme preference in meta", async () => {
+    // set theme to dark
+    const darkResponse = await app.request("/api/user/me", {
+      method: "PUT",
+      body: JSON.stringify({ theme: "dark" }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `jwt=${jwt}`,
+      },
+    });
+    expect(darkResponse.status).toBe(200);
+    const darkData: any = await darkResponse.json();
+    expect(darkData.meta?.theme).toBe("dark");
+
+    // verify it is returned again on GET
+    const getResponse = await app.request("/api/user/me", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `jwt=${jwt}`,
+      },
+    });
+    const getData: any = await getResponse.json();
+    expect(getData.meta?.theme).toBe("dark");
+
+    // switch back to light
+    const lightResponse = await app.request("/api/user/me", {
+      method: "PUT",
+      body: JSON.stringify({ theme: "light" }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `jwt=${jwt}`,
+      },
+    });
+    const lightData: any = await lightResponse.json();
+    expect(lightData.meta?.theme).toBe("light");
+  });
+
+  it("PUT /user/me rejects an invalid theme value with 400", async () => {
+    const response = await app.request("/api/user/me", {
+      method: "PUT",
+      body: JSON.stringify({ theme: "rainbow" }),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `jwt=${jwt}`,
+      },
+    });
+    expect(response.status).toBe(400);
+  });
+
   // Test available scopes endpoint
   it("should get available scopes for API tokens", async () => {
     const response = await app.request(

--- a/src/routes/user/protected.ts
+++ b/src/routes/user/protected.ts
@@ -163,19 +163,32 @@ export function defineSecuredUserRoutes(
         image: v.optional(v.nullable(v.string())),
         lastTenantId: v.optional(v.nullable(v.string())),
         phoneNumber: v.optional(v.nullable(v.string())),
+        theme: v.optional(v.picklist(["light", "dark"])),
       })
     ),
     async (c) => {
       try {
         // ensure to get only the allowed fields
-        const { firstname, surname, image, lastTenantId, phoneNumber } =
+        const { firstname, surname, image, lastTenantId, phoneNumber, theme } =
           c.req.valid("json");
+
+        // Theme is stored on the generic "meta" JSONB column. Merge it into the
+        // existing meta so other keys (e.g. customRegisterData) are preserved.
+        let meta: Record<string, unknown> | undefined;
+        if (theme !== undefined) {
+          const current = await getUserById(c.get("usersId"));
+          const currentMeta =
+            (current?.meta as Record<string, unknown> | null) ?? {};
+          meta = { ...currentMeta, theme };
+        }
+
         await updateUser(c.get("usersId"), {
           firstname,
           surname,
           image,
           lastTenantId,
           phoneNumber,
+          ...(meta !== undefined ? { meta } : {}),
         });
         const user = await getUserById(c.get("usersId"));
         return c.json(user);


### PR DESCRIPTION
## Summary
Allows clients to store a user's light/dark **theme preference** on their profile so it can be restored across devices/sessions.

- `PUT /user/me` now accepts an optional `theme` field (`"light"` | `"dark"`), validated via valibot.
- The value is merged into the existing `users.meta` JSONB column, **preserving other meta keys** (e.g. `customRegisterData`).
- It is returned again on `GET /user/me`, so the frontend can restore the saved theme.

## Why in the framework
`/user/me` is a framework-level route, so the persistence belongs here. The matching UI (sun/moon toggle in the profile menu) lives in the `robot-management-system` frontend and bumps the submodule pointer to this commit.

## Tests
Added route tests in `src/routes/user/index.test.ts`:
- persists `theme` in `meta` and returns it on GET (light ⇄ dark)
- rejects an invalid theme value with `400`

`bun test src/routes/user/index.test.ts` → 14 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)