### PR TITLE
Add db:query script for inspecting development database

### DIFF
--- a/.scripts/db-query.ts
+++ b/.scripts/db-query.ts
@@ -1,0 +1,86 @@
+/**
+ * DB Query Script
+ *
+ * Runs a raw SQL query against the development database and prints the
+ * result (or the error) to the console as JSON. The query is passed
+ * directly on the command line.
+ *
+ * The script connects automatically to the database defined by the local
+ * POSTGRES_* environment variables (the development environment), using the
+ * framework's normal `getDb()` connection — so no extra configuration is
+ * required.
+ *
+ * Purpose:
+ *   Lets an AI agent (or a developer) inspect raw data in the dev database
+ *   without writing a one-off script for every question.
+ *
+ * Usage:
+ *   bun run db:query "SELECT * FROM base_tenants LIMIT 5"
+ *   bun run ./.scripts/db-query.ts "SELECT count(*) FROM base_users"
+ *
+ * Output (on success):
+ *   { "ok": true, "rowCount": <n>, "rows": [ ... ] }
+ *
+ * Output (on error):
+ *   { "ok": false, "error": "<message>" }
+ */
+
+import { sql } from "drizzle-orm";
+import { getDb } from "../src/lib/db/db-connection";
+
+async function main() {
+  // Everything after the script path is treated as the query. This allows
+  // passing the query either as a single quoted argument or unquoted with
+  // multiple tokens.
+  const query = process.argv.slice(2).join(" ").trim();
+
+  if (!query) {
+    console.error(
+      JSON.stringify(
+        {
+          ok: false,
+          error:
+            'No query provided. Usage: bun run db:query "SELECT * FROM base_tenants LIMIT 5"',
+        },
+        null,
+        2
+      )
+    );
+    process.exit(1);
+  }
+
+  const db = getDb();
+  const result = await db.execute(sql.raw(query));
+
+  // postgres-js returns a RowList (array-like) for query results. Normalize
+  // it to a plain array so JSON.stringify produces clean output.
+  const rows = Array.isArray(result) ? result : Array.from(result as any);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        rowCount: rows.length,
+        rows,
+      },
+      null,
+      2
+    )
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(
+      JSON.stringify(
+        {
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        null,
+        2
+      )
+    );
+    process.exit(1);
+  });

--- a/.scripts/db-query.ts
+++ b/.scripts/db-query.ts
@@ -69,6 +69,22 @@ async function main() {
   );
 }
 
+/**
+ * Build a readable error message. Drizzle wraps the real DB error (e.g.
+ * "relation ... does not exist") in `error.cause`, so surface that too.
+ */
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = (error as { cause?: unknown }).cause;
+    const causeMessage =
+      cause instanceof Error ? cause.message : cause ? String(cause) : "";
+    return causeMessage && causeMessage !== error.message
+      ? `${error.message} (${causeMessage})`
+      : error.message;
+  }
+  return String(error);
+}
+
 main()
   .then(() => process.exit(0))
   .catch((error) => {
@@ -76,7 +92,7 @@ main()
       JSON.stringify(
         {
           ok: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: describeError(error),
         },
         null,
         2

--- a/docs/skills/db-query/SKILL.md
+++ b/docs/skills/db-query/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: db-query
+description: >
+  Use when you need to inspect raw data in the development database by running an arbitrary
+  SQL query and reading the result. Use when the user asks to "check the DB", "look up rows",
+  "run a query", "see what's in table X", or verify data while debugging. Runs a raw SQL query
+  via the framework's getDb() connection against the dev database and prints rows (or the error)
+  as JSON to the console.
+---
+
+# DB Query Skill
+
+This skill runs a **raw SQL query** against the development database and prints
+the result to the console as JSON. It exists so an AI agent (or developer) can
+inspect raw data directly without writing a one-off script for every question.
+
+## How it works
+
+- Uses the framework's normal `getDb()` connection (`src/lib/db/db-connection.ts`).
+- Connects automatically to the database defined by the local `POSTGRES_*`
+  environment variables — i.e. the development environment. No extra config.
+- The query is passed **directly on the command line**.
+- Output is JSON on the console: rows on success, an error message on failure.
+
+## Usage
+
+```bash
+bun run db:query "SELECT * FROM base_tenants LIMIT 5"
+```
+
+Equivalent (calling the script directly):
+
+```bash
+bun run ./.scripts/db-query.ts "SELECT count(*) FROM base_users"
+```
+
+Always wrap the query in quotes so the shell passes it as one argument.
+
+## Output
+
+On success:
+
+```json
+{
+  "ok": true,
+  "rowCount": 2,
+  "rows": [
+    { "id": "...", "name": "..." }
+  ]
+}
+```
+
+On error (invalid SQL, no DB connection, etc.):
+
+```json
+{
+  "ok": false,
+  "error": "relation \"foo\" does not exist"
+}
+```
+
+## Notes
+
+- Table names use the framework's prefixes (e.g. `base_tenants`, `base_users`).
+  Use a query like `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`
+  to discover available tables.
+- This executes raw SQL with no validation — it is a development/inspection tool.
+  Prefer `SELECT` for inspection; any statement the connected user is allowed to
+  run will execute.
+- Requires the dev database to be reachable. For local development start it with
+  `bun run db:local` (PGlite on localhost:5432) before querying.

--- a/docs/skills/db-query/SKILL.md
+++ b/docs/skills/db-query/SKILL.md
@@ -1,71 +1,89 @@
 ---
 name: db-query
 description: >
-  Use when you need to inspect raw data in the development database by running an arbitrary
-  SQL query and reading the result. Use when the user asks to "check the DB", "look up rows",
-  "run a query", "see what's in table X", or verify data while debugging. Runs a raw SQL query
-  via the framework's getDb() connection against the dev database and prints rows (or the error)
-  as JSON to the console.
+  Use when you need to inspect or verify real data in the development database. Use when the user
+  asks to "check the DB", "look up rows", "run a query", "see what's in table X", count records,
+  confirm a migration worked, or debug why something looks wrong by reading the actual data.
+  Runs a raw SQL query and prints the rows (or the error) as JSON to the console.
 ---
 
 # DB Query Skill
 
-This skill runs a **raw SQL query** against the development database and prints
-the result to the console as JSON. It exists so an AI agent (or developer) can
-inspect raw data directly without writing a one-off script for every question.
+Run any SQL query against the development database and read the result as JSON.
+Use it to **answer questions about the actual data** — what exists, how many,
+what the values are — instead of guessing or writing a throwaway script.
 
-## How it works
+## What you can do with it
 
-- Uses the framework's normal `getDb()` connection (`src/lib/db/db-connection.ts`).
-- Connects automatically to the database defined by the local `POSTGRES_*`
-  environment variables — i.e. the development environment. No extra config.
-- The query is passed **directly on the command line**.
-- Output is JSON on the console: rows on success, an error message on failure.
+- **Look things up**: read rows from any table to see the real data.
+- **Count / aggregate**: `count(*)`, `sum`, `group by` to understand volume and distribution.
+- **Verify your work**: after a migration, insert, or fix, query the table to confirm the data is as expected.
+- **Debug**: when behavior looks wrong, inspect the underlying rows to find the cause.
+- **Discover the schema**: list tables and columns when you don't know the structure yet.
+
+Anything the connected DB user can run will execute. Prefer `SELECT` for
+inspection. The result is plain JSON, so you can read it directly and reason
+about the values.
 
 ## Usage
 
 ```bash
-bun run db:query "SELECT * FROM base_tenants LIMIT 5"
+bun run db:query "<SQL>"
 ```
 
-Equivalent (calling the script directly):
+Always wrap the query in quotes so the shell passes it as a single argument.
+
+## Examples
+
+**1. List the available tables** (when you don't know the schema yet):
 
 ```bash
-bun run ./.scripts/db-query.ts "SELECT count(*) FROM base_users"
+bun run db:query "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename"
 ```
-
-Always wrap the query in quotes so the shell passes it as one argument.
-
-## Output
-
-On success:
 
 ```json
 {
   "ok": true,
   "rowCount": 2,
   "rows": [
-    { "id": "...", "name": "..." }
+    { "tablename": "base_tenants" },
+    { "tablename": "base_users" }
   ]
 }
 ```
 
-On error (invalid SQL, no DB connection, etc.):
+**2. Inspect rows in a table** (note the table prefix — see below):
+
+```bash
+bun run db:query "SELECT id, email FROM base_users LIMIT 5"
+```
+
+```json
+{
+  "ok": true,
+  "rowCount": 1,
+  "rows": [
+    { "id": "a1b2...", "email": "user@example.com" }
+  ]
+}
+```
+
+On error you get the reason, so you can correct the query:
 
 ```json
 {
   "ok": false,
-  "error": "relation \"foo\" does not exist"
+  "error": "Failed query: ... (relation \"users\" does not exist)"
 }
 ```
 
-## Notes
+## Important
 
-- Table names use the framework's prefixes (e.g. `base_tenants`, `base_users`).
-  Use a query like `SELECT tablename FROM pg_tables WHERE schemaname = 'public'`
-  to discover available tables.
-- This executes raw SQL with no validation — it is a development/inspection tool.
-  Prefer `SELECT` for inspection; any statement the connected user is allowed to
-  run will execute.
-- Requires the dev database to be reachable. For local development start it with
-  `bun run db:local` (PGlite on localhost:5432) before querying.
+- **Zero config**: no setup, connection string, or flags needed. Just run it.
+- **Uses the app's database**: it connects automatically to the same development
+  database the app uses (the local `POSTGRES_*` environment). Whatever you query
+  is the real data the running app sees.
+- **Table names need their prefix**: framework tables are prefixed (e.g.
+  `base_users`, `base_tenants`, not `users`/`tenants`). If a query fails with
+  "relation does not exist", you likely dropped the prefix — list the tables
+  (example 1) to find the exact name.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "dev": "bun --hot run demo.ts",
     "dev:inspect": "bun --inspect --hot run demo.ts",
     "db:local": "bun run ./.scripts/local-db-server.ts",
+    "db:query": "bun run ./.scripts/db-query.ts",
     "dev:local": "pglite-server --db=./dev-db/pglite --extensions=vector -m 20 -p 5432 --run 'bun run framework:migrate && bun run dev'",
     "framework:migrate": "drizzle-kit migrate",
     "framework:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
Adds a new `db:query` utility script that allows running arbitrary SQL queries against the development database and viewing results as JSON. This enables quick inspection of raw data without writing one-off scripts.

## Changes
- **New script** `.scripts/db-query.ts`: Executes raw SQL queries against the dev database using the framework's `getDb()` connection
  - Accepts SQL query as command-line argument
  - Returns results as JSON with row count and data on success
  - Returns structured error messages on failure
  - Handles both single-quoted and multi-token query arguments
  - Normalizes postgres-js RowList results to plain arrays for clean JSON output
  - Provides detailed error messages including underlying database errors

- **New documentation** `docs/skills/db-query/SKILL.md`: Comprehensive guide for using the db:query skill
  - Usage examples and output format documentation
  - Notes on table naming conventions and limitations
  - Instructions for discovering available tables

- **Updated** `package.json`: Added `db:query` npm script for convenient access

## Implementation Details
- Uses Drizzle ORM's `sql.raw()` for executing arbitrary SQL
- Wraps errors with `describeError()` helper to surface underlying database errors from Drizzle's error chain
- Outputs all results as formatted JSON to stdout for easy parsing and integration with other tools
- Requires no additional configuration beyond existing `POSTGRES_*` environment variables

https://claude.ai/code/session_01K9aRznXD6ZXQ3UjELoFAoj