### PR TITLE
Sanitize allowed origins from environment variable

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -87,6 +87,8 @@ export const setGlobalServerConfig = (config: ServerSpecificConfig) => {
   const _ORIGINS_FROM_ENV = process.env.ALLOWED_ORIGINS;
   _GLOBAL_SERVER_CONFIG.allowedOrigins = _ORIGINS_FROM_ENV
     ? _ORIGINS_FROM_ENV.split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
     : [];
 
   _GLOBAL_SERVER_CONFIG.authType = config.authType ?? "local";


### PR DESCRIPTION
## Summary
Improved parsing of the `ALLOWED_ORIGINS` environment variable to handle whitespace and empty values more robustly.

## Key Changes
- Added `.trim()` to remove leading/trailing whitespace from each origin string
- Added `.filter(Boolean)` to remove any empty strings that may result from the split operation

## Implementation Details
These changes ensure that origins like `"http://localhost:3000, http://example.com"` (with spaces after commas) are parsed correctly, and that trailing commas or empty values don't result in invalid origin entries in the configuration.

https://claude.ai/code/session_019AtS3CKpj2jYRLrmHf6QuF