### PR TITLE
Add block-based wiki content to knowledgeTexts with optional embedding

### DIFF
--- a/drizzle-sql/0017_handy_thunderball.sql
+++ b/drizzle-sql/0017_handy_thunderball.sql
@@ -1,0 +1,26 @@
+CREATE TYPE "public"."knowledge_block_type" AS ENUM('markdown', 'html');--> statement-breakpoint
+CREATE TYPE "public"."knowledge_content_mode" AS ENUM('text', 'blocks');--> statement-breakpoint
+CREATE TABLE "base_knowledge_text_block" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"knowledge_text_id" uuid NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"type" "knowledge_block_type" DEFAULT 'markdown' NOT NULL,
+	"content" text DEFAULT '' NOT NULL,
+	"position" varchar(64) NOT NULL,
+	"meta" jsonb DEFAULT '{}' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "base_knowledge_text" ADD COLUMN "content_mode" "knowledge_content_mode" DEFAULT 'text' NOT NULL;--> statement-breakpoint
+ALTER TABLE "base_knowledge_text" ADD COLUMN "position" varchar(64);--> statement-breakpoint
+ALTER TABLE "base_knowledge_text" ADD COLUMN "embedding_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "base_knowledge_text" ADD COLUMN "knowledge_entry_id" uuid;--> statement-breakpoint
+ALTER TABLE "base_knowledge_text_history" ADD COLUMN "content_mode" "knowledge_content_mode" DEFAULT 'text' NOT NULL;--> statement-breakpoint
+ALTER TABLE "base_knowledge_text_history" ADD COLUMN "blocks" jsonb;--> statement-breakpoint
+ALTER TABLE "base_knowledge_text_block" ADD CONSTRAINT "base_knowledge_text_block_knowledge_text_id_base_knowledge_text_id_fk" FOREIGN KEY ("knowledge_text_id") REFERENCES "public"."base_knowledge_text"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "base_knowledge_text_block" ADD CONSTRAINT "base_knowledge_text_block_tenant_id_base_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."base_tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "knowledge_text_block_page_position_idx" ON "base_knowledge_text_block" USING btree ("knowledge_text_id","position");--> statement-breakpoint
+CREATE INDEX "knowledge_text_block_knowledge_text_id_idx" ON "base_knowledge_text_block" USING btree ("knowledge_text_id");--> statement-breakpoint
+CREATE INDEX "knowledge_text_block_tenant_id_idx" ON "base_knowledge_text_block" USING btree ("tenant_id");--> statement-breakpoint
+ALTER TABLE "base_knowledge_text" ADD CONSTRAINT "base_knowledge_text_knowledge_entry_id_base_knowledge_entry_id_fk" FOREIGN KEY ("knowledge_entry_id") REFERENCES "public"."base_knowledge_entry"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle-sql/meta/0017_snapshot.json
+++ b/drizzle-sql/meta/0017_snapshot.json
@@ -1,0 +1,6012 @@
+{
+  "id": "7e8fb013-ac58-4a43-af17-00b92b70477d",
+  "prevId": "a0b6e9f5-43ee-4801-8574-fa3672ce7fc1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.base_group_permissions": {
+      "name": "base_group_permissions",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "group_permissions_group_id_idx": {
+          "name": "group_permissions_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_permissions_permission_id_idx": {
+          "name": "group_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_group_permissions_group_id_base_user_permission_groups_id_fk": {
+          "name": "base_group_permissions_group_id_base_user_permission_groups_id_fk",
+          "tableFrom": "base_group_permissions",
+          "tableTo": "base_user_permission_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_group_permissions_permission_id_base_path_permissions_id_fk": {
+          "name": "base_group_permissions_permission_id_base_path_permissions_id_fk",
+          "tableFrom": "base_group_permissions",
+          "tableTo": "base_path_permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_group_permissions_group_id_permission_id_pk": {
+          "name": "base_group_permissions_group_id_permission_id_pk",
+          "columns": [
+            "group_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_invitation_codes": {
+      "name": "base_invitation_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": -1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_invitation_code": {
+          "name": "unique_invitation_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_codes_tenant_id_idx": {
+          "name": "invitation_codes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_codes_expires_at_idx": {
+          "name": "invitation_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_invitation_codes_tenant_id_base_tenants_id_fk": {
+          "name": "base_invitation_codes_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_invitation_codes",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_magic_link_sessions": {
+      "name": "base_magic_link_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "magic_link_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login'"
+        }
+      },
+      "indexes": {
+        "unique_token": {
+          "name": "unique_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_sessions_user_id_idx": {
+          "name": "magic_link_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_sessions_expires_at_idx": {
+          "name": "magic_link_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_magic_link_sessions_user_id_base_users_id_fk": {
+          "name": "base_magic_link_sessions_user_id_base_users_id_fk",
+          "tableFrom": "base_magic_link_sessions",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_path_permissions": {
+      "name": "base_path_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "permission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_expression": {
+          "name": "path_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permissions_method_idx": {
+          "name": "permissions_method_idx",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_type_idx": {
+          "name": "permissions_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_path_permissions_tenant_id_base_tenants_id_fk": {
+          "name": "base_path_permissions_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_path_permissions",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_category_name": {
+          "name": "unique_category_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_sessions": {
+      "name": "base_sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_sessions_user_id_base_users_id_fk": {
+          "name": "base_sessions_user_id_base_users_id_fk",
+          "tableFrom": "base_sessions",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_team_members": {
+      "name": "base_team_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_team_members_user_id_base_users_id_fk": {
+          "name": "base_team_members_user_id_base_users_id_fk",
+          "tableFrom": "base_team_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_team_members_team_id_base_teams_id_fk": {
+          "name": "base_team_members_team_id_base_teams_id_fk",
+          "tableFrom": "base_team_members",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_team_members_user_id_team_id_pk": {
+          "name": "base_team_members_user_id_team_id_pk",
+          "columns": [
+            "user_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_teams": {
+      "name": "base_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_teams_tenant_id_base_tenants_id_fk": {
+          "name": "base_teams_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_teams",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_invitations": {
+      "name": "base_tenant_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_invitation": {
+          "name": "unique_invitation",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_idx": {
+          "name": "invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_created_at_idx": {
+          "name": "invitations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_invitations_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_invitations_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_invitations",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_members": {
+      "name": "base_tenant_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_members_user_id_idx": {
+          "name": "tenant_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_members_tenant_id_idx": {
+          "name": "tenant_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_members_user_id_base_users_id_fk": {
+          "name": "base_tenant_members_user_id_base_users_id_fk",
+          "tableFrom": "base_tenant_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_tenant_members_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_members_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_members",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_tenant_members_user_id_tenant_id_pk": {
+          "name": "base_tenant_members_user_id_tenant_id_pk",
+          "columns": [
+            "user_id",
+            "tenant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenants": {
+      "name": "base_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "tenant_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_name_local_unique_idx": {
+          "name": "tenants_name_local_unique_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"base_tenants\".\"origin\" = 'local'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_group_members": {
+      "name": "base_user_group_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_groups_id": {
+          "name": "user_groups_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_user_group_members_user_id_base_users_id_fk": {
+          "name": "base_user_group_members_user_id_base_users_id_fk",
+          "tableFrom": "base_user_group_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_user_group_members_user_groups_id_base_user_permission_groups_id_fk": {
+          "name": "base_user_group_members_user_groups_id_base_user_permission_groups_id_fk",
+          "tableFrom": "base_user_group_members",
+          "tableTo": "base_user_permission_groups",
+          "columnsFrom": [
+            "user_groups_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_user_group_members_user_id_user_groups_id_pk": {
+          "name": "base_user_group_members_user_id_user_groups_id_pk",
+          "columns": [
+            "user_id",
+            "user_groups_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_messages": {
+      "name": "base_user_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_messages_user_id_idx": {
+          "name": "user_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_confirmed_at_idx": {
+          "name": "user_messages_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_created_at_idx": {
+          "name": "user_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_message_type_idx": {
+          "name": "user_messages_message_type_idx",
+          "columns": [
+            {
+              "expression": "message_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_messages_user_id_base_users_id_fk": {
+          "name": "base_user_messages_user_id_base_users_id_fk",
+          "tableFrom": "base_user_messages",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_permission_groups": {
+      "name": "base_user_permission_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_permission_groups_name_idx": {
+          "name": "user_permission_groups_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_permission_groups_created_at_idx": {
+          "name": "user_permission_groups_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_permission_groups_tenant_id_base_tenants_id_fk": {
+          "name": "base_user_permission_groups_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_user_permission_groups",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_users": {
+      "name": "base_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "user_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surname": {
+          "name": "surname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salutation": {
+          "name": "salutation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number_verified": {
+          "name": "phone_number_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone_number_as_number": {
+          "name": "phone_number_as_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_pin_number": {
+          "name": "phone_pin_number",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ext_user_id": {
+          "name": "ext_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_name": {
+          "name": "profile_image_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_content_type": {
+          "name": "profile_image_content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_tenant_id": {
+          "name": "last_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_email": {
+          "name": "unique_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_phone_number": {
+          "name": "unique_phone_number",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_phone_number_as_number": {
+          "name": "unique_phone_number_as_number",
+          "columns": [
+            {
+              "expression": "phone_number_as_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_verified_idx": {
+          "name": "users_email_verified_idx",
+          "columns": [
+            {
+              "expression": "email_verified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_users_last_tenant_id_base_tenants_id_fk": {
+          "name": "base_users_last_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_users",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "last_tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_webauthn_credentials": {
+      "name": "base_webauthn_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webauthn_credentials_credential_id_idx": {
+          "name": "webauthn_credentials_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webauthn_credentials_user_id_idx": {
+          "name": "webauthn_credentials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_webauthn_credentials_user_id_base_users_id_fk": {
+          "name": "base_webauthn_credentials_user_id_base_users_id_fk",
+          "tableFrom": "base_webauthn_credentials",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_secrets": {
+      "name": "base_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference": {
+          "name": "reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "secrets_idx": {
+          "name": "secrets_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_ref_idx": {
+          "name": "secrets_ref_idx",
+          "columns": [
+            {
+              "expression": "reference",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_ref_id_idx": {
+          "name": "secrets_ref_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_name_idx": {
+          "name": "secrets_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_type_idx": {
+          "name": "secrets_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_secrets_tenant_id_base_tenants_id_fk": {
+          "name": "base_secrets_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_secrets",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secrets_reference_name_idx": {
+          "name": "secrets_reference_name_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_files": {
+      "name": "base_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extension": {
+          "name": "extension",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_id_idx": {
+          "name": "files_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_bucket_name_idx": {
+          "name": "files_bucket_name_idx",
+          "columns": [
+            {
+              "expression": "bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_created_at_idx": {
+          "name": "files_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_updated_at_idx": {
+          "name": "files_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_name_idx": {
+          "name": "files_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_expires_at_idx": {
+          "name": "files_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_files_tenant_id_base_tenants_id_fk": {
+          "name": "base_files_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_files",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_app_specific_data": {
+      "name": "base_app_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_data_created_at_idx": {
+          "name": "app_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_data_version_idx": {
+          "name": "app_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_app_specific_data_key_unique": {
+          "name": "base_app_specific_data_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_team_specific_data": {
+      "name": "base_team_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_data_key_idx": {
+          "name": "team_data_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_data_created_at_idx": {
+          "name": "team_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_data_version_idx": {
+          "name": "team_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_team_specific_data_team_id_base_teams_id_fk": {
+          "name": "base_team_specific_data_team_id_base_teams_id_fk",
+          "tableFrom": "base_team_specific_data",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_team_specific_data_team_id_key_unique": {
+          "name": "base_team_specific_data_team_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_specific_data": {
+      "name": "base_tenant_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_data_key_idx": {
+          "name": "tenant_data_key_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_data_created_at_idx": {
+          "name": "tenant_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_data_version_idx": {
+          "name": "tenant_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_specific_data_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_specific_data_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_specific_data",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_tenant_specific_data_tenant_id_category_unique": {
+          "name": "base_tenant_specific_data_tenant_id_category_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "category"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_specific_data": {
+      "name": "base_user_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_data_type_idx": {
+          "name": "user_data_type_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_data_created_at_idx": {
+          "name": "user_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_data_version_idx": {
+          "name": "user_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_specific_data_user_id_base_users_id_fk": {
+          "name": "base_user_specific_data_user_id_base_users_id_fk",
+          "tableFrom": "base_user_specific_data",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_user_specific_data_user_id_key_unique": {
+          "name": "base_user_specific_data_user_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_chunks": {
+      "name": "base_knowledge_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_entry_id": {
+          "name": "knowledge_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "text_embedding_1536": {
+          "name": "text_embedding_1536",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_embedding_1024": {
+          "name": "text_embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "knowledge_chunks_knowledge_entry_id_idx": {
+          "name": "knowledge_chunks_knowledge_entry_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_created_at_idx": {
+          "name": "knowledge_chunks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_header_idx": {
+          "name": "knowledge_chunks_header_idx",
+          "columns": [
+            {
+              "expression": "header",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_chunks_knowledge_entry_id_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_chunks_knowledge_entry_id_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_chunks",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "knowledge_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_chunks_embedding_required": {
+          "name": "knowledge_chunks_embedding_required",
+          "value": "text_embedding_1536 IS NOT NULL OR text_embedding_1024 IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_entry": {
+      "name": "base_knowledge_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_owned": {
+          "name": "user_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "knowledge_group_id": {
+          "name": "knowledge_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "version_text": {
+          "name": "version_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "knowledgeentry_name_idx": {
+          "name": "knowledgeentry_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_created_at_idx": {
+          "name": "knowledgeentry_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_updated_at_idx": {
+          "name": "knowledgeentry_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_deleted_at_idx": {
+          "name": "knowledgeentry_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_tenant_id_idx": {
+          "name": "knowledgeentry_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_entry_team_id_idx": {
+          "name": "knowledge_entry_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_entry_user_id_idx": {
+          "name": "knowledge_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_entry_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_entry_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_entry_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_user_id_base_users_id_fk": {
+          "name": "base_knowledge_entry_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_knowledge_group_id_base_knowledge_group_id_fk": {
+          "name": "base_knowledge_entry_knowledge_group_id_base_knowledge_group_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_knowledge_group",
+          "columnsFrom": [
+            "knowledge_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_parentId_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_entry_parentId_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_entry_description_max_length": {
+          "name": "knowledge_entry_description_max_length",
+          "value": "length(description) <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_filters": {
+      "name": "base_knowledge_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_filters_name_type_unique": {
+          "name": "knowledge_filters_name_type_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_filters_category_name_idx": {
+          "name": "knowledge_filters_category_name_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_filters_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_filters_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_filters",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_group": {
+      "name": "base_knowledge_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide_access": {
+          "name": "tenant_wide_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_group_tenant_id_idx": {
+          "name": "knowledge_group_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_group_user_id_idx": {
+          "name": "knowledge_group_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_group_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_group_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_group",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_group_user_id_base_users_id_fk": {
+          "name": "base_knowledge_group_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_group",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_group_name_org_idx": {
+          "name": "knowledge_group_name_org_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "tenant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_group_team_assignments": {
+      "name": "base_knowledge_group_team_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_group_id": {
+          "name": "knowledge_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_group_team_assignment_knowledge_group_id_idx": {
+          "name": "knowledge_group_team_assignment_knowledge_group_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_group_team_assignment_team_id_idx": {
+          "name": "knowledge_group_team_assignment_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_group_team_assignments_knowledge_group_id_base_knowledge_group_id_fk": {
+          "name": "base_knowledge_group_team_assignments_knowledge_group_id_base_knowledge_group_id_fk",
+          "tableFrom": "base_knowledge_group_team_assignments",
+          "tableTo": "base_knowledge_group",
+          "columnsFrom": [
+            "knowledge_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_group_team_assignments_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_group_team_assignments_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_group_team_assignments",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_group_team_assignment_unique": {
+          "name": "knowledge_group_team_assignment_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "knowledge_group_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text": {
+      "name": "base_knowledge_text",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "knowledge_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_enabled": {
+          "name": "embedding_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "knowledge_entry_id": {
+          "name": "knowledge_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "knowledge_text_created_at_idx": {
+          "name": "knowledge_text_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_updated_at_idx": {
+          "name": "knowledge_text_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_deleted_at_idx": {
+          "name": "knowledge_text_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_title_idx": {
+          "name": "knowledge_text_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_tenant_id_idx": {
+          "name": "knowledge_text_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_team_id_idx": {
+          "name": "knowledge_text_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_user_id_idx": {
+          "name": "knowledge_text_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_parent_id_idx": {
+          "name": "knowledge_text_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_text_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_user_id_base_users_id_fk": {
+          "name": "base_knowledge_text_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_parent_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_parent_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_knowledge_entry_id_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_text_knowledge_entry_id_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "knowledge_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_block": {
+      "name": "base_knowledge_text_block",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_text_id": {
+          "name": "knowledge_text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "knowledge_block_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'markdown'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_block_page_position_idx": {
+          "name": "knowledge_text_block_page_position_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_block_knowledge_text_id_idx": {
+          "name": "knowledge_text_block_knowledge_text_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_block_tenant_id_idx": {
+          "name": "knowledge_text_block_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_block_knowledge_text_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_block_knowledge_text_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_block",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "knowledge_text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_block_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_block_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_block",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_history": {
+      "name": "base_knowledge_text_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_text_id": {
+          "name": "knowledge_text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "knowledge_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_history_knowledge_text_id_idx": {
+          "name": "knowledge_text_history_knowledge_text_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_history_tenant_id_idx": {
+          "name": "knowledge_text_history_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_history_created_at_idx": {
+          "name": "knowledge_text_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_history_knowledge_text_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_history_knowledge_text_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "knowledge_text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_history_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_text_history_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_user_id_base_users_id_fk": {
+          "name": "base_knowledge_text_history_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_jobs": {
+      "name": "base_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_created_at_idx": {
+          "name": "jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_user_id_idx": {
+          "name": "jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_status_idx": {
+          "name": "jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_scheduled_at_idx": {
+          "name": "jobs_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_jobs_user_id_base_users_id_fk": {
+          "name": "base_jobs_user_id_base_users_id_fk",
+          "tableFrom": "base_jobs",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_jobs_tenant_id_base_tenants_id_fk": {
+          "name": "base_jobs_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_jobs",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_app_logs": {
+      "name": "base_app_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_logs_level_idx": {
+          "name": "app_logs_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_category_idx": {
+          "name": "app_logs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_source_idx": {
+          "name": "app_logs_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_created_at_idx": {
+          "name": "app_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_version_idx": {
+          "name": "app_logs_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_tenant_id_idx": {
+          "name": "app_logs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_app_logs_tenant_id_base_tenants_id_fk": {
+          "name": "base_app_logs_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_app_logs",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_webhooks": {
+      "name": "base_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "webhook_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "webhook_event",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "webhook_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POST'"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_tenant_id_idx": {
+          "name": "webhooks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_name_tenant_id_idx": {
+          "name": "webhooks_name_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "webhook_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_webhooks_user_id_base_users_id_fk": {
+          "name": "base_webhooks_user_id_base_users_id_fk",
+          "tableFrom": "base_webhooks",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_webhooks_tenant_id_base_tenants_id_fk": {
+          "name": "base_webhooks_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_webhooks",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_server_keys": {
+      "name": "base_server_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_server_settings": {
+      "name": "base_server_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_key": {
+          "name": "unique_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_api_tokens": {
+      "name": "base_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "auto_delete": {
+          "name": "auto_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "api_tokens_user_id_idx": {
+          "name": "api_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_tenant_id_idx": {
+          "name": "api_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_auto_delete_idx": {
+          "name": "api_tokens_auto_delete_idx",
+          "columns": [
+            {
+              "expression": "auto_delete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_api_tokens_user_id_base_users_id_fk": {
+          "name": "base_api_tokens_user_id_base_users_id_fk",
+          "tableFrom": "base_api_tokens",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_api_tokens_tenant_id_base_tenants_id_fk": {
+          "name": "base_api_tokens_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_api_tokens",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_idx": {
+          "name": "api_tokens_token_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_connections": {
+      "name": "base_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_connection_id": {
+          "name": "remote_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_public_key": {
+          "name": "remote_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_tenant_id": {
+          "name": "remote_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "initiated_by",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "role": {
+          "name": "role",
+          "type": "connection_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'leading'"
+        },
+        "status": {
+          "name": "status",
+          "type": "connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "connections_tenant_idx": {
+          "name": "connections_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_remote_url_idx": {
+          "name": "connections_remote_url_idx",
+          "columns": [
+            {
+              "expression": "remote_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_tenant_name_initiated_by_unique_idx": {
+          "name": "connections_tenant_name_initiated_by_unique_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "initiated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_tenant_remote_connection_id_initiated_by_unique_idx": {
+          "name": "connections_tenant_remote_connection_id_initiated_by_unique_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "initiated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_connections_tenant_id_base_tenants_id_fk": {
+          "name": "base_connections_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_connections",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_clients": {
+      "name": "base_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_type": {
+          "name": "client_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confidential'"
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_clients_tenant_id_idx": {
+          "name": "oauth_clients_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_clients_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_clients_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_clients",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_clients_created_by_base_users_id_fk": {
+          "name": "base_oauth_clients_created_by_base_users_id_fk",
+          "tableFrom": "base_oauth_clients",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_auth_codes": {
+      "name": "base_oauth_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_auth_codes_code_hash_idx": {
+          "name": "oauth_auth_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_auth_codes_expires_at_idx": {
+          "name": "oauth_auth_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_auth_codes_user_id_base_users_id_fk": {
+          "name": "base_oauth_auth_codes_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_auth_codes",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_auth_codes_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_auth_codes_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_auth_codes",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_refresh_tokens": {
+      "name": "base_oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotated_to": {
+          "name": "rotated_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_refresh_tokens_user_id_base_users_id_fk": {
+          "name": "base_oauth_refresh_tokens_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_refresh_tokens",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_refresh_tokens_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_refresh_tokens_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_refresh_tokens",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_consents": {
+      "name": "base_oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consents_user_client_idx": {
+          "name": "oauth_consents_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consents_user_id_idx": {
+          "name": "oauth_consents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_consents_user_id_base_users_id_fk": {
+          "name": "base_oauth_consents_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_consents",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_email_login_codes": {
+      "name": "base_email_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oauth_login'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_login_codes_email_idx": {
+          "name": "email_login_codes_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_login_codes_expires_at_idx": {
+          "name": "email_login_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_settings": {
+      "name": "base_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_user_settings_key_unique": {
+          "name": "base_user_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.magic_link_purpose": {
+      "name": "magic_link_purpose",
+      "schema": "public",
+      "values": [
+        "login",
+        "email_verification",
+        "password_reset"
+      ]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error"
+      ]
+    },
+    "public.permission_type": {
+      "name": "permission_type",
+      "schema": "public",
+      "values": [
+        "regex"
+      ]
+    },
+    "public.team_member_role": {
+      "name": "team_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.tenant_invitation_status": {
+      "name": "tenant_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined"
+      ]
+    },
+    "public.tenant_member_role": {
+      "name": "tenant_member_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.tenant_origin": {
+      "name": "tenant_origin",
+      "schema": "public",
+      "values": [
+        "local",
+        "remote"
+      ]
+    },
+    "public.user_provider": {
+      "name": "user_provider",
+      "schema": "public",
+      "values": [
+        "local",
+        "google",
+        "microsoft",
+        "auth0",
+        "hanko"
+      ]
+    },
+    "public.file_source_type": {
+      "name": "file_source_type",
+      "schema": "public",
+      "values": [
+        "db",
+        "local",
+        "url",
+        "text",
+        "finetuning",
+        "plugin",
+        "external"
+      ]
+    },
+    "public.knowledge_block_type": {
+      "name": "knowledge_block_type",
+      "schema": "public",
+      "values": [
+        "markdown",
+        "html"
+      ]
+    },
+    "public.knowledge_content_mode": {
+      "name": "knowledge_content_mode",
+      "schema": "public",
+      "values": [
+        "text",
+        "blocks"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ]
+    },
+    "public.webhook_event": {
+      "name": "webhook_event",
+      "schema": "public",
+      "values": [
+        "chat-output",
+        "tool"
+      ]
+    },
+    "public.webhook_method": {
+      "name": "webhook_method",
+      "schema": "public",
+      "values": [
+        "POST",
+        "GET"
+      ]
+    },
+    "public.webhook_type": {
+      "name": "webhook_type",
+      "schema": "public",
+      "values": [
+        "n8n"
+      ]
+    },
+    "public.connection_role": {
+      "name": "connection_role",
+      "schema": "public",
+      "values": [
+        "leading",
+        "following"
+      ]
+    },
+    "public.connection_status": {
+      "name": "connection_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disconnected",
+        "revoked"
+      ]
+    },
+    "public.initiated_by": {
+      "name": "initiated_by",
+      "schema": "public",
+      "values": [
+        "local",
+        "remote"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-sql/meta/_journal.json
+++ b/drizzle-sql/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1782751275425,
       "tag": "0016_luxuriant_darwin",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1783861346982,
+      "tag": "0017_handy_thunderball",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema/knowledge.ts
+++ b/src/lib/db/schema/knowledge.ts
@@ -35,6 +35,21 @@ export const fileSourceTypeEnum = pgEnum("file_source_type", [
   "external",
 ]);
 
+// How the content of a knowledgeText entry is stored:
+// - "text": single markdown blob in the `text` column (legacy / simple entries)
+// - "blocks": content lives in knowledge_text_block rows; `text` is a
+//   materialized cache assembled from the blocks on every block save
+export const knowledgeContentModeEnum = pgEnum("knowledge_content_mode", [
+  "text",
+  "blocks",
+]);
+
+// Type of a single content block inside a knowledgeText page
+export const knowledgeBlockTypeEnum = pgEnum("knowledge_block_type", [
+  "markdown",
+  "html",
+]);
+
 // Table to store input texts
 export const knowledgeText = pgBaseTable(
   "knowledge_text",
@@ -61,6 +76,23 @@ export const knowledgeText = pgBaseTable(
     title: varchar("title", { length: 1000 }).notNull().default(""),
     meta: jsonb("meta").notNull().default("{}"),
     hidden: boolean("hidden").notNull().default(false),
+    // "text" = plain markdown blob; "blocks" = block-editor page whose content
+    // lives in knowledge_text_block and is materialized into `text` on save
+    contentMode: knowledgeContentModeEnum("content_mode")
+      .notNull()
+      .default("text"),
+    // fractional-index key for manual ordering among sibling pages in the
+    // wiki tree; null = unsorted (falls back to title sort)
+    position: varchar("position", { length: 64 }),
+    // opt-in: mirror this page into the RAG pipeline (knowledge_entry +
+    // knowledge_chunks) so it shows up in similarity search
+    embeddingEnabled: boolean("embedding_enabled").notNull().default(false),
+    // link to the knowledge_entry created by the embedding sync, so re-syncs
+    // replace chunks in place and page deletion can clean the entry up
+    knowledgeEntryId: uuid("knowledge_entry_id").references(
+      (): AnyPgColumn => knowledgeEntry.id,
+      { onDelete: "set null" }
+    ),
     createdAt: timestamp("created_at", { mode: "string" })
       .notNull()
       .defaultNow(),
@@ -102,6 +134,12 @@ export const knowledgeTextHistory = pgBaseTable(
     title: varchar("title", { length: 1000 }).notNull().default(""),
     meta: jsonb("meta").notNull().default("{}"),
     hidden: boolean("hidden").notNull().default(false),
+    contentMode: knowledgeContentModeEnum("content_mode")
+      .notNull()
+      .default("text"),
+    // Snapshot of the page's blocks at the time of history creation
+    // (null for plain text entries)
+    blocks: jsonb("blocks").$type<KnowledgeTextBlockSnapshot[] | null>(),
     createdAt: timestamp("created_at", { mode: "string" })
       .notNull()
       .defaultNow(), // When this history entry was created
@@ -137,7 +175,70 @@ export type KnowledgeTextMeta = {
   sourceUri?: string;
   textLength?: number;
   includesLocalImages?: boolean; // when the document has mardown ![image](image.png) which can be found in the storage
+  // sha256 of the materialized content at the time of the last embedding
+  // sync; used to skip re-embedding unchanged pages
+  embeddingContentHash?: string;
 };
+
+// Shape of a block snapshot stored in knowledge_text_history.blocks
+export type KnowledgeTextBlockSnapshot = {
+  id: string;
+  type: "markdown" | "html";
+  content: string;
+  position: string;
+  meta?: Record<string, unknown>;
+};
+
+// Content blocks of a knowledgeText page (contentMode = "blocks").
+// One row = one block in the block editor. Ordering inside a page uses
+// fractional-index keys (see lib/utils/fractional-index.ts), so moving a
+// block is a single-row update instead of renumbering the whole page.
+export const knowledgeTextBlock = pgBaseTable(
+  "knowledge_text_block",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    knowledgeTextId: uuid("knowledge_text_id")
+      .notNull()
+      .references(() => knowledgeText.id, { onDelete: "cascade" }),
+    // denormalized for direct tenant filtering without a join
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    type: knowledgeBlockTypeEnum("type").notNull().default("markdown"),
+    content: text("content").notNull().default(""),
+    // fractional-index key; unique per page, lexicographic order = block order
+    position: varchar("position", { length: 64 }).notNull(),
+    // editor props per block, e.g. { language: "ts" } for code blocks
+    meta: jsonb("meta").notNull().default("{}"),
+    createdAt: timestamp("created_at", { mode: "string" })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "string" })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("knowledge_text_block_page_position_idx").on(
+      table.knowledgeTextId,
+      table.position
+    ),
+    index("knowledge_text_block_knowledge_text_id_idx").on(
+      table.knowledgeTextId
+    ),
+    index("knowledge_text_block_tenant_id_idx").on(table.tenantId),
+  ]
+);
+
+export type KnowledgeTextBlockSelect = typeof knowledgeTextBlock.$inferSelect;
+export type KnowledgeTextBlockInsert = typeof knowledgeTextBlock.$inferInsert;
+
+export const knowledgeTextBlockSchema = createSelectSchema(knowledgeTextBlock);
+export const knowledgeTextBlockInsertSchema =
+  createInsertSchema(knowledgeTextBlock);
+export const knowledgeTextBlockUpdateSchema =
+  createUpdateSchema(knowledgeTextBlock);
 
 // Table for knowledge groups (grouping of knowledge entries)
 export const knowledgeGroup = pgBaseTable(
@@ -463,6 +564,25 @@ export const knowledgeTextRelations = relations(
       references: [users.id],
     }),
     history: many(knowledgeTextHistory),
+    blocks: many(knowledgeTextBlock),
+    knowledgeEntry: one(knowledgeEntry, {
+      fields: [knowledgeText.knowledgeEntryId],
+      references: [knowledgeEntry.id],
+    }),
+  })
+);
+
+export const knowledgeTextBlockRelations = relations(
+  knowledgeTextBlock,
+  ({ one }) => ({
+    knowledgeText: one(knowledgeText, {
+      fields: [knowledgeTextBlock.knowledgeTextId],
+      references: [knowledgeText.id],
+    }),
+    tenant: one(tenants, {
+      fields: [knowledgeTextBlock.tenantId],
+      references: [tenants.id],
+    }),
   })
 );
 

--- a/src/lib/knowledge/knowledge-text-blocks.test.ts
+++ b/src/lib/knowledge/knowledge-text-blocks.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import {
+  getKnowledgeTextBlocks,
+  syncKnowledgeTextBlocks,
+  convertKnowledgeTextToBlocks,
+  materializeBlocksText,
+} from "./knowledge-text-blocks";
+import {
+  createKnowledgeText,
+  getKnowledgeTextById,
+  getKnowledgeTextHistory,
+  deleteKnowledgeText,
+} from "./knowledge-texts";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+
+const ctx = { tenantId: TEST_ORGANISATION_1.id };
+
+const createPage = async (overrides?: Record<string, unknown>) =>
+  await createKnowledgeText({
+    text: "",
+    title: `Block Test Page ${crypto.randomUUID()}`,
+    tenantId: TEST_ORGANISATION_1.id,
+    ...overrides,
+  });
+
+describe("materializeBlocksText", () => {
+  it("joins markdown blocks with blank lines", () => {
+    const text = materializeBlocksText([
+      { type: "markdown", content: "# Heading" },
+      { type: "markdown", content: "Some paragraph." },
+    ]);
+    expect(text).toBe("# Heading\n\nSome paragraph.");
+  });
+
+  it("converts html blocks to markdown", () => {
+    const text = materializeBlocksText([
+      { type: "html", content: "<h2>Title</h2><p>Hello <strong>world</strong></p>" },
+    ]);
+    expect(text).toContain("## Title");
+    expect(text).toContain("**world**");
+  });
+
+  it("skips empty blocks", () => {
+    const text = materializeBlocksText([
+      { type: "markdown", content: "A" },
+      { type: "markdown", content: "   " },
+      { type: "markdown", content: "B" },
+    ]);
+    expect(text).toBe("A\n\nB");
+  });
+});
+
+describe("Knowledge Text Blocks", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("returns an empty block list for a plain text page", async () => {
+    const page = await createPage({ text: "plain text" });
+    const blocks = await getKnowledgeTextBlocks(page.id, ctx);
+    expect(blocks).toEqual([]);
+  });
+
+  it("creates blocks via sync and switches the page to block mode", async () => {
+    const page = await createPage();
+
+    const result = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "# Hello" },
+        { type: "html", content: "<p>World</p>" },
+      ],
+      ctx
+    );
+
+    expect(result.changes).toEqual({ inserted: 2, updated: 0, deleted: 0 });
+    expect(result.blocks.length).toBe(2);
+    expect(result.blocks[0]?.type).toBe("markdown");
+    expect(result.blocks[1]?.type).toBe("html");
+    expect(result.blocks[0]!.position < result.blocks[1]!.position).toBe(true);
+    expect(result.knowledgeText.contentMode).toBe("blocks");
+    // text cache materialized (html converted to markdown)
+    expect(result.knowledgeText.text).toBe("# Hello\n\nWorld");
+  });
+
+  it("keeps client-provided block ids", async () => {
+    const page = await createPage();
+    const clientId = crypto.randomUUID();
+
+    const result = await syncKnowledgeTextBlocks(
+      page.id,
+      [{ id: clientId, type: "markdown", content: "tracked" }],
+      ctx
+    );
+
+    expect(result.blocks[0]?.id).toBe(clientId);
+  });
+
+  it("updates changed blocks and leaves unchanged ones untouched", async () => {
+    const page = await createPage();
+    const first = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "one" },
+        { type: "markdown", content: "two" },
+      ],
+      ctx
+    );
+    const [b1, b2] = first.blocks;
+
+    const second = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { id: b1!.id, type: "markdown", content: "one" },
+        { id: b2!.id, type: "markdown", content: "two changed" },
+      ],
+      ctx
+    );
+
+    expect(second.changes).toEqual({ inserted: 0, updated: 1, deleted: 0 });
+    expect(second.blocks[0]?.id).toBe(b1!.id);
+    expect(second.blocks[0]?.position).toBe(b1!.position); // untouched
+    expect(second.blocks[1]?.content).toBe("two changed");
+    expect(second.knowledgeText.text).toBe("one\n\ntwo changed");
+  });
+
+  it("is a no-op when the same block list is saved again", async () => {
+    const page = await createPage();
+    const first = await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: "stable" }],
+      ctx
+    );
+
+    const second = await syncKnowledgeTextBlocks(
+      page.id,
+      [{ id: first.blocks[0]!.id, type: "markdown", content: "stable" }],
+      ctx
+    );
+
+    expect(second.changes).toEqual({ inserted: 0, updated: 0, deleted: 0 });
+    expect(second.historyCreated).toBe(false);
+    expect(second.blocks[0]?.position).toBe(first.blocks[0]!.position);
+  });
+
+  it("deletes blocks missing from the payload", async () => {
+    const page = await createPage();
+    const first = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "keep" },
+        { type: "markdown", content: "remove" },
+      ],
+      ctx
+    );
+
+    const second = await syncKnowledgeTextBlocks(
+      page.id,
+      [{ id: first.blocks[0]!.id, type: "markdown", content: "keep" }],
+      ctx
+    );
+
+    expect(second.changes.deleted).toBe(1);
+    expect(second.blocks.length).toBe(1);
+    expect(second.knowledgeText.text).toBe("keep");
+  });
+
+  it("reorders blocks while keeping ids stable", async () => {
+    const page = await createPage();
+    const first = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "A" },
+        { type: "markdown", content: "B" },
+        { type: "markdown", content: "C" },
+      ],
+      ctx
+    );
+    const [a, b, c] = first.blocks;
+
+    // move C to the front
+    const second = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { id: c!.id, type: "markdown", content: "C" },
+        { id: a!.id, type: "markdown", content: "A" },
+        { id: b!.id, type: "markdown", content: "B" },
+      ],
+      ctx
+    );
+
+    expect(second.blocks.map((blk) => blk.content)).toEqual(["C", "A", "B"]);
+    expect(second.blocks.map((blk) => blk.id).sort()).toEqual(
+      [a!.id, b!.id, c!.id].sort()
+    );
+    expect(second.knowledgeText.text).toBe("C\n\nA\n\nB");
+    // ordering is strictly ascending
+    for (let i = 1; i < second.blocks.length; i++) {
+      expect(
+        second.blocks[i - 1]!.position < second.blocks[i]!.position
+      ).toBe(true);
+    }
+  });
+
+  it("inserts a new block between existing ones without moving them", async () => {
+    const page = await createPage();
+    const first = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "top" },
+        { type: "markdown", content: "bottom" },
+      ],
+      ctx
+    );
+    const [top, bottom] = first.blocks;
+
+    const second = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { id: top!.id, type: "markdown", content: "top" },
+        { type: "markdown", content: "middle" },
+        { id: bottom!.id, type: "markdown", content: "bottom" },
+      ],
+      ctx
+    );
+
+    expect(second.changes).toEqual({ inserted: 1, updated: 0, deleted: 0 });
+    // existing blocks kept their positions
+    expect(second.blocks[0]?.position).toBe(top!.position);
+    expect(second.blocks[2]?.position).toBe(bottom!.position);
+    expect(second.blocks.map((blk) => blk.content)).toEqual([
+      "top",
+      "middle",
+      "bottom",
+    ]);
+  });
+
+  it("stores block meta and detects meta-only changes", async () => {
+    const page = await createPage();
+    const first = await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: "code", meta: { language: "ts" } }],
+      ctx
+    );
+    expect(first.blocks[0]?.meta).toEqual({ language: "ts" });
+
+    const second = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        {
+          id: first.blocks[0]!.id,
+          type: "markdown",
+          content: "code",
+          meta: { language: "python" },
+        },
+      ],
+      ctx
+    );
+    expect(second.changes.updated).toBe(1);
+    expect(second.blocks[0]?.meta).toEqual({ language: "python" });
+  });
+
+  it("writes a history snapshot of the previous state including blocks", async () => {
+    const page = await createPage();
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: "version 1" }],
+      ctx,
+      { historyCoalesceMinutes: 0 }
+    );
+
+    const second = await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: "version 2" }],
+      ctx,
+      { historyCoalesceMinutes: 0 }
+    );
+    expect(second.historyCreated).toBe(true);
+
+    const history = await getKnowledgeTextHistory(page.id, ctx);
+    expect(history.length).toBeGreaterThanOrEqual(2);
+    // newest history entry contains the previous ("version 1") state
+    expect(history[0]?.text).toBe("version 1");
+    expect(history[0]?.contentMode).toBe("blocks");
+    expect(Array.isArray(history[0]?.blocks)).toBe(true);
+    expect((history[0]?.blocks as any[])[0]?.content).toBe("version 1");
+    // the very first snapshot preserved the empty text-mode state
+    expect(history[history.length - 1]?.contentMode).toBe("text");
+    expect(history[history.length - 1]?.blocks).toBeNull();
+  });
+
+  it("coalesces history snapshots within the window", async () => {
+    const page = await createPage();
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: "v1" }],
+      ctx
+    );
+    const baseline = (await getKnowledgeTextHistory(page.id, ctx)).length;
+
+    // rapid autosaves — all inside the coalescing window
+    for (const content of ["v2", "v3", "v4"]) {
+      const result = await syncKnowledgeTextBlocks(
+        page.id,
+        [{ type: "markdown", content }],
+        ctx
+      );
+      expect(result.historyCreated).toBe(false);
+    }
+
+    const after = (await getKnowledgeTextHistory(page.id, ctx)).length;
+    expect(after).toBe(baseline);
+  });
+
+  it("converts a legacy text page into a single markdown block", async () => {
+    const page = await createPage({ text: "# Legacy\n\ncontent here" });
+    expect(page.contentMode).toBe("text");
+
+    const result = await convertKnowledgeTextToBlocks(page.id, ctx);
+
+    expect(result.knowledgeText.contentMode).toBe("blocks");
+    expect(result.blocks.length).toBe(1);
+    expect(result.blocks[0]?.type).toBe("markdown");
+    expect(result.blocks[0]?.content).toBe("# Legacy\n\ncontent here");
+    // text cache unchanged
+    expect(result.knowledgeText.text).toBe("# Legacy\n\ncontent here");
+    // conversion left a restore point of the text version
+    const history = await getKnowledgeTextHistory(page.id, ctx);
+    expect(history[0]?.contentMode).toBe("text");
+
+    // converting again is a no-op
+    const again = await convertKnowledgeTextToBlocks(page.id, ctx);
+    expect(again.changes).toEqual({ inserted: 0, updated: 0, deleted: 0 });
+    expect(again.blocks.length).toBe(1);
+  });
+
+  it("converts an empty text page into zero blocks", async () => {
+    const page = await createPage({ text: "" });
+    const result = await convertKnowledgeTextToBlocks(page.id, ctx);
+    expect(result.knowledgeText.contentMode).toBe("blocks");
+    expect(result.blocks.length).toBe(0);
+  });
+
+  it("cascade-deletes blocks when the page is deleted", async () => {
+    const page = await createPage();
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: "to be deleted" }],
+      ctx
+    );
+
+    await deleteKnowledgeText(page.id, ctx);
+
+    await expect(getKnowledgeTextById(page.id, ctx)).rejects.toThrow();
+  });
+
+  it("rejects access from a different tenant", async () => {
+    const page = await createPage();
+    await expect(
+      getKnowledgeTextBlocks(page.id, {
+        tenantId: "00000000-1111-1111-1111-000000000002",
+      })
+    ).rejects.toThrow();
+    await expect(
+      syncKnowledgeTextBlocks(
+        page.id,
+        [{ type: "markdown", content: "x" }],
+        { tenantId: "00000000-1111-1111-1111-000000000002" }
+      )
+    ).rejects.toThrow();
+  });
+});

--- a/src/lib/knowledge/knowledge-text-blocks.ts
+++ b/src/lib/knowledge/knowledge-text-blocks.ts
@@ -1,0 +1,387 @@
+/**
+ * Block-based content for knowledgeText wiki pages (Notion-style).
+ *
+ * A page in `contentMode = "blocks"` stores its content as ordered
+ * knowledge_text_block rows (markdown or html for now). The page's `text`
+ * column is kept as a materialized cache assembled from the blocks on every
+ * save, so full-text consumers (search, export, embedding) keep reading a
+ * single column.
+ *
+ * Saving goes through `syncKnowledgeTextBlocks`: the client (block editor)
+ * sends the full desired block list, the server diffs against the stored
+ * blocks by id (insert / update / delete), reuses fractional-index positions
+ * where the order is unchanged, snapshots history (coalesced, since block
+ * editors autosave), and optionally re-syncs the page's embedding mirror.
+ */
+
+import { asc, eq, and, desc, inArray, sql } from "drizzle-orm";
+import TurndownService from "turndown";
+import { gfm } from "turndown-plugin-gfm";
+import { getDb } from "../db/db-connection";
+import {
+  knowledgeText,
+  knowledgeTextBlock,
+  knowledgeTextHistory,
+  type KnowledgeTextBlockSelect,
+  type KnowledgeTextBlockSnapshot,
+  type KnowledgeTextHistoryInsert,
+  type KnowledgeTextSelect,
+} from "../db/schema/knowledge";
+import { assignPositions } from "../utils/fractional-index";
+import { getKnowledgeTextById } from "./knowledge-texts";
+import { checkTenantMemberRole } from "../usermanagement/tenants";
+import { checkTeamMemberRole } from "../usermanagement/teams";
+import { syncKnowledgeTextEmbeddingSafe } from "./knowledge-text-embedding";
+
+/** Minimum age of the newest history entry before a new snapshot is written */
+export const HISTORY_COALESCE_MINUTES = 10;
+
+export type KnowledgeTextBlockInput = {
+  /** existing block id; omit for new blocks */
+  id?: string;
+  type: "markdown" | "html";
+  content: string;
+  meta?: Record<string, unknown>;
+};
+
+export type SyncKnowledgeTextBlocksOptions = {
+  /** skip the embedding re-sync after saving (default: run it) */
+  skipEmbeddingSync?: boolean;
+  /** override the history coalescing window, in minutes; 0 = always snapshot */
+  historyCoalesceMinutes?: number;
+};
+
+type Context = {
+  tenantId: string;
+  userId?: string;
+  teamId?: string;
+  workspaceId?: string;
+  includeHidden?: boolean;
+};
+
+let turndown: TurndownService | null = null;
+const getTurndown = (): TurndownService => {
+  if (!turndown) {
+    turndown = new TurndownService({
+      headingStyle: "atx",
+      codeBlockStyle: "fenced",
+    });
+    turndown.use(gfm);
+  }
+  return turndown;
+};
+
+/**
+ * Assemble the page's materialized `text` from its blocks. HTML blocks are
+ * converted to markdown so the cache stays homogeneous for search/embedding.
+ */
+export const materializeBlocksText = (
+  blocks: Pick<KnowledgeTextBlockInput, "type" | "content">[]
+): string => {
+  return blocks
+    .map((block) =>
+      block.type === "html"
+        ? getTurndown().turndown(block.content).trim()
+        : block.content.trim()
+    )
+    .filter((part) => part.length > 0)
+    .join("\n\n");
+};
+
+const toSnapshot = (
+  block: KnowledgeTextBlockSelect
+): KnowledgeTextBlockSnapshot => ({
+  id: block.id,
+  type: block.type,
+  content: block.content,
+  position: block.position,
+  meta: (block.meta ?? {}) as Record<string, unknown>,
+});
+
+/** Same write-permission rule as updateKnowledgeText */
+const checkWritePermission = async (
+  page: KnowledgeTextSelect,
+  context: Context
+) => {
+  if (!context.userId) return;
+  if (page.tenantWide) {
+    await checkTenantMemberRole(context.tenantId, context.userId, [
+      "admin",
+      "owner",
+    ]);
+  } else if (page.teamId) {
+    await checkTeamMemberRole(page.teamId, context.userId, ["admin"]);
+  }
+};
+
+/**
+ * Get all blocks of a page in display order.
+ * Returns an empty list for pages still in `contentMode = "text"`.
+ */
+export const getKnowledgeTextBlocks = async (
+  knowledgeTextId: string,
+  context: Context
+): Promise<KnowledgeTextBlockSelect[]> => {
+  // permission check (throws if not visible to this user)
+  await getKnowledgeTextById(knowledgeTextId, context);
+
+  return await getDb()
+    .select()
+    .from(knowledgeTextBlock)
+    .where(eq(knowledgeTextBlock.knowledgeTextId, knowledgeTextId))
+    .orderBy(asc(knowledgeTextBlock.position));
+};
+
+/**
+ * Write a coalesced history snapshot of the page's CURRENT state (before the
+ * pending update), including its current blocks. Skipped when the newest
+ * history entry is younger than the coalescing window, so autosaving editors
+ * don't flood the history table.
+ */
+const snapshotHistoryCoalesced = async (
+  page: KnowledgeTextSelect,
+  currentBlocks: KnowledgeTextBlockSelect[],
+  coalesceMinutes: number
+) => {
+  if (coalesceMinutes > 0) {
+    const newest = await getDb()
+      .select({ createdAt: knowledgeTextHistory.createdAt })
+      .from(knowledgeTextHistory)
+      .where(eq(knowledgeTextHistory.knowledgeTextId, page.id))
+      .orderBy(desc(knowledgeTextHistory.createdAt))
+      .limit(1);
+
+    if (newest[0]) {
+      const ageMs = Date.now() - new Date(newest[0].createdAt).getTime();
+      if (ageMs < coalesceMinutes * 60 * 1000) {
+        return false;
+      }
+    }
+  }
+
+  const historyEntry: KnowledgeTextHistoryInsert = {
+    knowledgeTextId: page.id,
+    tenantId: page.tenantId,
+    tenantWide: page.tenantWide,
+    teamId: page.teamId,
+    userId: page.userId,
+    parentId: page.parentId,
+    text: page.text,
+    title: page.title,
+    meta: page.meta,
+    hidden: page.hidden,
+    contentMode: page.contentMode,
+    blocks:
+      page.contentMode === "blocks" ? currentBlocks.map(toSnapshot) : null,
+  };
+  await getDb().insert(knowledgeTextHistory).values(historyEntry);
+  return true;
+};
+
+export type SyncKnowledgeTextBlocksResult = {
+  knowledgeText: KnowledgeTextSelect;
+  blocks: KnowledgeTextBlockSelect[];
+  /** counts of what the diff actually changed */
+  changes: { inserted: number; updated: number; deleted: number };
+  historyCreated: boolean;
+};
+
+/**
+ * Batch-save the full block list of a page (the block editor sends its
+ * complete document state). Diffs against the stored blocks by id:
+ *
+ *   - blocks without id (or with an unknown id) are inserted
+ *   - blocks whose content/type/meta/position changed are updated
+ *   - stored blocks missing from the payload are deleted
+ *
+ * Existing fractional-index positions are reused where the relative order
+ * still holds, so an unchanged list results in zero row writes. The page's
+ * `text` cache is re-materialized, `contentMode` switches to "blocks", a
+ * coalesced history snapshot of the previous state is written, and the
+ * embedding mirror is re-synced (if enabled).
+ */
+export const syncKnowledgeTextBlocks = async (
+  knowledgeTextId: string,
+  blocks: KnowledgeTextBlockInput[],
+  context: Context,
+  options?: SyncKnowledgeTextBlocksOptions
+): Promise<SyncKnowledgeTextBlocksResult> => {
+  const page = await getKnowledgeTextById(knowledgeTextId, context);
+  await checkWritePermission(page, context);
+
+  const db = getDb();
+  const existing = await db
+    .select()
+    .from(knowledgeTextBlock)
+    .where(eq(knowledgeTextBlock.knowledgeTextId, knowledgeTextId))
+    .orderBy(asc(knowledgeTextBlock.position));
+  const existingById = new Map(existing.map((b) => [b.id, b]));
+
+  // resolve which incoming blocks refer to a stored block
+  const desired = blocks.map((input) => ({
+    input,
+    current: input.id ? (existingById.get(input.id) ?? null) : null,
+  }));
+
+  // reuse positions where the order is unchanged, generate keys for the rest
+  const positions = assignPositions(
+    desired.map((d) => ({ position: d.current?.position ?? null }))
+  );
+
+  const inserts: (typeof knowledgeTextBlock.$inferInsert)[] = [];
+  const updates: {
+    id: string;
+    content: string;
+    type: "markdown" | "html";
+    position: string;
+    meta: Record<string, unknown>;
+  }[] = [];
+
+  const seenIds = new Set<string>();
+  desired.forEach(({ input, current }, i) => {
+    const position = positions[i]!;
+    if (!current) {
+      inserts.push({
+        // a client-generated uuid is kept so the editor can track its blocks
+        ...(input.id ? { id: input.id } : {}),
+        knowledgeTextId,
+        tenantId: page.tenantId,
+        type: input.type,
+        content: input.content,
+        position,
+        meta: input.meta ?? {},
+      });
+      return;
+    }
+    seenIds.add(current.id);
+    const metaChanged =
+      JSON.stringify(input.meta ?? {}) !== JSON.stringify(current.meta ?? {});
+    if (
+      current.content !== input.content ||
+      current.type !== input.type ||
+      current.position !== position ||
+      metaChanged
+    ) {
+      updates.push({
+        id: current.id,
+        content: input.content,
+        type: input.type,
+        position,
+        meta: input.meta ?? {},
+      });
+    }
+  });
+
+  const deleteIds = existing
+    .filter((b) => !seenIds.has(b.id))
+    .map((b) => b.id);
+
+  const newText = materializeBlocksText(blocks);
+  const pageChanged =
+    page.text !== newText || page.contentMode !== "blocks";
+  const nothingToDo =
+    inserts.length === 0 &&
+    updates.length === 0 &&
+    deleteIds.length === 0 &&
+    !pageChanged;
+
+  let historyCreated = false;
+  if (!nothingToDo) {
+    // snapshot the PREVIOUS state before touching anything
+    historyCreated = await snapshotHistoryCoalesced(
+      page,
+      existing,
+      options?.historyCoalesceMinutes ?? HISTORY_COALESCE_MINUTES
+    );
+
+    await db.transaction(async (trx) => {
+      if (deleteIds.length > 0) {
+        await trx
+          .delete(knowledgeTextBlock)
+          .where(inArray(knowledgeTextBlock.id, deleteIds));
+      }
+      // apply position updates before inserts so the unique
+      // (page, position) index never sees a transient collision
+      for (const update of updates) {
+        await trx
+          .update(knowledgeTextBlock)
+          .set({
+            content: update.content,
+            type: update.type,
+            position: update.position,
+            meta: update.meta,
+            updatedAt: sql`now()`,
+          })
+          .where(eq(knowledgeTextBlock.id, update.id));
+      }
+      if (inserts.length > 0) {
+        await trx.insert(knowledgeTextBlock).values(inserts);
+      }
+      await trx
+        .update(knowledgeText)
+        .set({
+          text: newText,
+          contentMode: "blocks",
+          updatedAt: sql`now()`,
+        })
+        .where(eq(knowledgeText.id, knowledgeTextId));
+    });
+
+    if (page.embeddingEnabled && !options?.skipEmbeddingSync) {
+      await syncKnowledgeTextEmbeddingSafe(knowledgeTextId, page.tenantId);
+    }
+  }
+
+  const finalPage = await getKnowledgeTextById(knowledgeTextId, context);
+  const finalBlocks = await db
+    .select()
+    .from(knowledgeTextBlock)
+    .where(eq(knowledgeTextBlock.knowledgeTextId, knowledgeTextId))
+    .orderBy(asc(knowledgeTextBlock.position));
+
+  return {
+    knowledgeText: finalPage,
+    blocks: finalBlocks,
+    changes: {
+      inserted: inserts.length,
+      updated: updates.length,
+      deleted: deleteIds.length,
+    },
+    historyCreated,
+  };
+};
+
+/**
+ * Convert a legacy `contentMode = "text"` page into block mode by wrapping
+ * its text into a single markdown block. No-op (returns existing blocks)
+ * for pages already in block mode.
+ */
+export const convertKnowledgeTextToBlocks = async (
+  knowledgeTextId: string,
+  context: Context
+): Promise<SyncKnowledgeTextBlocksResult> => {
+  const page = await getKnowledgeTextById(knowledgeTextId, context);
+
+  if (page.contentMode === "blocks") {
+    const blocks = await getKnowledgeTextBlocks(knowledgeTextId, context);
+    return {
+      knowledgeText: page,
+      blocks,
+      changes: { inserted: 0, updated: 0, deleted: 0 },
+      historyCreated: false,
+    };
+  }
+
+  const initialBlocks: KnowledgeTextBlockInput[] =
+    page.text.trim().length > 0
+      ? [{ type: "markdown", content: page.text }]
+      : [];
+
+  return await syncKnowledgeTextBlocks(
+    knowledgeTextId,
+    initialBlocks,
+    context,
+    // conversion should always leave a restore point of the text version
+    { historyCoalesceMinutes: 0 }
+  );
+};

--- a/src/lib/knowledge/knowledge-text-embedding.test.ts
+++ b/src/lib/knowledge/knowledge-text-embedding.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import { eq } from "drizzle-orm";
+import {
+  syncKnowledgeTextEmbedding,
+  syncKnowledgeTextEmbeddingSafe,
+  knowledgeTextSourceIdentifier,
+} from "./knowledge-text-embedding";
+import {
+  createKnowledgeText,
+  getKnowledgeTextById,
+  updateKnowledgeText,
+  deleteKnowledgeText,
+} from "./knowledge-texts";
+import { syncKnowledgeTextBlocks } from "./knowledge-text-blocks";
+import { getDb } from "../db/db-connection";
+import { knowledgeEntry, knowledgeChunks } from "../db/schema/knowledge";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+
+const ctx = { tenantId: TEST_ORGANISATION_1.id };
+
+// The full sync path needs a real embedding provider (same pattern as
+// add-knowledge.test.ts, which runs in CI where MISTRAL_API_KEY is set)
+const hasEmbeddingProvider = !!process.env.MISTRAL_API_KEY;
+
+const createPage = async (overrides?: Record<string, unknown>) =>
+  await createKnowledgeText({
+    text: "",
+    title: `Embedding Test Page ${crypto.randomUUID()}`,
+    tenantId: TEST_ORGANISATION_1.id,
+    ...overrides,
+  });
+
+describe("Knowledge Text Embedding (no provider required)", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("does nothing for a page with embedding disabled", async () => {
+    const page = await createPage({ text: "some content" });
+    const result = await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
+    expect(result.synced).toBe(false);
+    expect(result.removed).toBe(false);
+    expect(result.knowledgeEntryId).toBeNull();
+  });
+
+  it("does nothing for an enabled page with empty text", async () => {
+    const page = await createPage({ text: "", embeddingEnabled: true });
+    const result = await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
+    expect(result.synced).toBe(false);
+    expect(result.removed).toBe(false);
+  });
+
+  it("throws for an unknown page and the safe variant swallows it", async () => {
+    const unknownId = crypto.randomUUID();
+    await expect(
+      syncKnowledgeTextEmbedding(unknownId, ctx.tenantId)
+    ).rejects.toThrow();
+    const safe = await syncKnowledgeTextEmbeddingSafe(unknownId, ctx.tenantId);
+    expect(safe).toBeNull();
+  });
+
+  it("block saves on a page without embedding do not fail", async () => {
+    const page = await createPage();
+    const result = await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: "no embedding here" }],
+      ctx
+    );
+    expect(result.knowledgeText.knowledgeEntryId).toBeNull();
+  });
+
+  it("builds a stable source identifier", () => {
+    expect(knowledgeTextSourceIdentifier("abc")).toBe("knowledge-text:abc");
+  });
+});
+
+describe.skipIf(!hasEmbeddingProvider)(
+  "Knowledge Text Embedding (full sync, needs MISTRAL_API_KEY)",
+  () => {
+    beforeAll(async () => {
+      await initTests();
+    });
+
+    it("creates a knowledge entry on first sync and links it", async () => {
+      const page = await createPage({
+        text: "This wiki page explains our vacation policy in detail.",
+        embeddingEnabled: true,
+      });
+
+      const result = await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
+      expect(result.synced).toBe(true);
+      expect(result.knowledgeEntryId).toBeDefined();
+
+      const fresh = await getKnowledgeTextById(page.id, ctx);
+      expect(fresh.knowledgeEntryId).toBe(result.knowledgeEntryId!);
+      expect((fresh.meta as any).embeddingContentHash).toBeDefined();
+
+      // chunks exist for the entry
+      const chunks = await getDb()
+        .select()
+        .from(knowledgeChunks)
+        .where(eq(knowledgeChunks.knowledgeEntryId, result.knowledgeEntryId!));
+      expect(chunks.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it("skips unchanged content and re-syncs in place on change", async () => {
+      const page = await createPage({
+        text: "Original content for the change detection test.",
+        embeddingEnabled: true,
+      });
+
+      const first = await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
+      expect(first.synced).toBe(true);
+
+      // same content again → skipped
+      const second = await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
+      expect(second.unchanged).toBe(true);
+      expect(second.knowledgeEntryId).toBe(first.knowledgeEntryId!);
+
+      // block save changes the text → re-sync replaces the SAME entry
+      await syncKnowledgeTextBlocks(
+        page.id,
+        [{ type: "markdown", content: "Completely new content." }],
+        ctx
+      );
+      const fresh = await getKnowledgeTextById(page.id, ctx);
+      expect(fresh.knowledgeEntryId).toBe(first.knowledgeEntryId!);
+
+      const chunks = await getDb()
+        .select()
+        .from(knowledgeChunks)
+        .where(eq(knowledgeChunks.knowledgeEntryId, first.knowledgeEntryId!));
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks[0]?.text).toContain("Completely new content");
+    }, 60000);
+
+    it("removes the entry when embedding is disabled", async () => {
+      const page = await createPage({
+        text: "Content that will be un-embedded.",
+        embeddingEnabled: true,
+      });
+      const synced = await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
+      expect(synced.synced).toBe(true);
+
+      await updateKnowledgeText(
+        page.id,
+        { embeddingEnabled: false },
+        ctx
+      );
+
+      const fresh = await getKnowledgeTextById(page.id, ctx);
+      expect(fresh.knowledgeEntryId).toBeNull();
+
+      const entries = await getDb()
+        .select()
+        .from(knowledgeEntry)
+        .where(eq(knowledgeEntry.id, synced.knowledgeEntryId!));
+      expect(entries.length).toBe(0);
+    }, 30000);
+
+    it("removes the entry when the page is deleted", async () => {
+      const page = await createPage({
+        text: "Content of a page that will be deleted.",
+        embeddingEnabled: true,
+      });
+      const synced = await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
+      expect(synced.synced).toBe(true);
+
+      await deleteKnowledgeText(page.id, ctx);
+
+      const entries = await getDb()
+        .select()
+        .from(knowledgeEntry)
+        .where(eq(knowledgeEntry.id, synced.knowledgeEntryId!));
+      expect(entries.length).toBe(0);
+    }, 30000);
+  }
+);

--- a/src/lib/knowledge/knowledge-text-embedding.ts
+++ b/src/lib/knowledge/knowledge-text-embedding.ts
@@ -1,0 +1,170 @@
+/**
+ * Optional embedding sync for knowledgeText wiki pages.
+ *
+ * Pages with `embeddingEnabled = true` are mirrored into the RAG pipeline
+ * (knowledge_entry + knowledge_chunks) so they show up in similarity search.
+ * The sync goes through `upsertKnowledgeFromText` with the stable source
+ * identifier `knowledge-text:<pageId>`, so re-syncs replace the chunks of
+ * the same knowledge entry in place instead of piling up duplicates.
+ *
+ * A sha256 hash of the materialized content is stored in
+ * `meta.embeddingContentHash` to skip re-embedding unchanged pages —
+ * important because block editors autosave frequently.
+ */
+
+import { createHash } from "node:crypto";
+import { eq, and } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import {
+  knowledgeText,
+  knowledgeEntry,
+  type KnowledgeTextSelect,
+  type KnowledgeTextMeta,
+} from "../db/schema/knowledge";
+import { upsertKnowledgeFromText } from "./upsert-knowledge";
+import log from "../log";
+
+/** Stable upsert key linking a wiki page to its knowledge entry */
+export const knowledgeTextSourceIdentifier = (knowledgeTextId: string) =>
+  `knowledge-text:${knowledgeTextId}`;
+
+const contentHash = (title: string, text: string) =>
+  createHash("sha256").update(`${title}\n${text}`).digest("hex");
+
+export type KnowledgeTextEmbeddingSyncResult = {
+  /** true if an embedding upsert was performed */
+  synced: boolean;
+  /** true if a previously linked knowledge entry was removed */
+  removed: boolean;
+  /** true if the sync was skipped because the content is unchanged */
+  unchanged: boolean;
+  knowledgeEntryId: string | null;
+};
+
+/**
+ * Delete the knowledge entry linked to a page (if any) and clear the link.
+ * Used when embedding gets disabled, the page text becomes empty, or the
+ * page is deleted.
+ */
+export const removeKnowledgeTextEmbedding = async (
+  page: Pick<KnowledgeTextSelect, "id" | "tenantId" | "knowledgeEntryId">
+): Promise<boolean> => {
+  if (!page.knowledgeEntryId) return false;
+
+  // chunks are removed by the FK cascade on knowledge_chunks
+  await getDb()
+    .delete(knowledgeEntry)
+    .where(
+      and(
+        eq(knowledgeEntry.id, page.knowledgeEntryId),
+        eq(knowledgeEntry.tenantId, page.tenantId)
+      )
+    );
+  // the FK on knowledge_text.knowledge_entry_id is ON DELETE SET NULL, but
+  // clear the hash explicitly so a re-enable triggers a fresh sync
+  const meta = (page as KnowledgeTextSelect).meta as KnowledgeTextMeta | null;
+  await getDb()
+    .update(knowledgeText)
+    .set({
+      knowledgeEntryId: null,
+      meta: { ...(meta ?? {}), embeddingContentHash: undefined },
+    })
+    .where(eq(knowledgeText.id, page.id));
+  return true;
+};
+
+/**
+ * Bring the RAG mirror of a page in line with its current state.
+ *
+ * - embedding disabled or empty text → remove a stale entry if present
+ * - content unchanged since last sync → no-op
+ * - otherwise → upsert entry + chunks and store the new content hash
+ *
+ * Permissions must be checked by the caller — this operates directly on the
+ * page row (it is invoked after permission-checked writes).
+ */
+export const syncKnowledgeTextEmbedding = async (
+  knowledgeTextId: string,
+  tenantId: string
+): Promise<KnowledgeTextEmbeddingSyncResult> => {
+  const pages = await getDb()
+    .select()
+    .from(knowledgeText)
+    .where(
+      and(
+        eq(knowledgeText.id, knowledgeTextId),
+        eq(knowledgeText.tenantId, tenantId)
+      )
+    );
+  const page = pages[0];
+  if (!page) {
+    throw new Error("Knowledge text not found");
+  }
+
+  const meta = (page.meta ?? {}) as KnowledgeTextMeta;
+
+  // Disabled or nothing to embed → make sure no stale entry lingers
+  if (!page.embeddingEnabled || page.text.trim().length === 0) {
+    const removed = await removeKnowledgeTextEmbedding(page);
+    return {
+      synced: false,
+      removed,
+      unchanged: false,
+      knowledgeEntryId: null,
+    };
+  }
+
+  const hash = contentHash(page.title, page.text);
+  if (page.knowledgeEntryId && meta.embeddingContentHash === hash) {
+    return {
+      synced: false,
+      removed: false,
+      unchanged: true,
+      knowledgeEntryId: page.knowledgeEntryId,
+    };
+  }
+
+  const result = await upsertKnowledgeFromText({
+    tenantId: page.tenantId,
+    sourceIdentifier: knowledgeTextSourceIdentifier(page.id),
+    title: page.title,
+    text: page.text,
+    sourceType: "text",
+    sourceId: page.id,
+    userId: page.userId ?? undefined,
+    teamId: page.teamId ?? undefined,
+  });
+
+  await getDb()
+    .update(knowledgeText)
+    .set({
+      knowledgeEntryId: result.id,
+      meta: { ...meta, embeddingContentHash: hash },
+    })
+    .where(eq(knowledgeText.id, page.id));
+
+  return {
+    synced: true,
+    removed: false,
+    unchanged: false,
+    knowledgeEntryId: result.id,
+  };
+};
+
+/**
+ * Fire-and-forget wrapper used after page saves: an embedding failure
+ * (missing API key, provider down) must never fail the save itself.
+ */
+export const syncKnowledgeTextEmbeddingSafe = async (
+  knowledgeTextId: string,
+  tenantId: string
+): Promise<KnowledgeTextEmbeddingSyncResult | null> => {
+  try {
+    return await syncKnowledgeTextEmbedding(knowledgeTextId, tenantId);
+  } catch (error) {
+    log.error(
+      `Embedding sync failed for knowledge text ${knowledgeTextId}: ${error}`
+    );
+    return null;
+  }
+};

--- a/src/lib/knowledge/knowledge-texts.ts
+++ b/src/lib/knowledge/knowledge-texts.ts
@@ -13,7 +13,9 @@ import {
 import { getDb } from "../db/db-connection";
 import {
   knowledgeText,
+  knowledgeTextBlock,
   knowledgeTextHistory,
+  knowledgeEntry,
   type KnowledgeTextInsert,
   type KnowledgeTextHistoryInsert,
 } from "../db/schema/knowledge";
@@ -21,6 +23,7 @@ import { RESPONSES } from "../responses";
 import { teamMembers } from "../db/schema/users";
 import { checkTenantMemberRole } from "../usermanagement/tenants";
 import { checkTeamMemberRole } from "../usermanagement/teams";
+import { syncKnowledgeTextEmbeddingSafe } from "./knowledge-text-embedding";
 
 /**
  * Create a new knowledgeText entry
@@ -95,7 +98,8 @@ export const getKnowledgeText = async (filters: {
     .select({ ...rest })
     .from(knowledgeText)
     .where(and(...permissionConditions))
-    .orderBy(asc(knowledgeText.title)) // Sort alphabetically by title
+    // manual wiki order first (NULLs last in PG), then alphabetically
+    .orderBy(asc(knowledgeText.position), asc(knowledgeText.title))
     .$dynamic();
 
   if (filters.limit) {
@@ -246,6 +250,17 @@ export const updateKnowledgeText = async (
     }
   }
 
+  // For block pages, snapshot the blocks alongside the text so history
+  // entries stay restorable
+  const currentBlocks =
+    currentEntry.contentMode === "blocks"
+      ? await getDb()
+          .select()
+          .from(knowledgeTextBlock)
+          .where(eq(knowledgeTextBlock.knowledgeTextId, currentEntry.id))
+          .orderBy(asc(knowledgeTextBlock.position))
+      : [];
+
   // Create history entry with the current state BEFORE updating
   const historyEntry: KnowledgeTextHistoryInsert = {
     knowledgeTextId: currentEntry.id,
@@ -258,6 +273,17 @@ export const updateKnowledgeText = async (
     title: currentEntry.title,
     meta: currentEntry.meta,
     hidden: currentEntry.hidden,
+    contentMode: currentEntry.contentMode,
+    blocks:
+      currentEntry.contentMode === "blocks"
+        ? currentBlocks.map((b) => ({
+            id: b.id,
+            type: b.type,
+            content: b.content,
+            position: b.position,
+            meta: (b.meta ?? {}) as Record<string, unknown>,
+          }))
+        : null,
   };
 
   await getDb().insert(knowledgeTextHistory).values(historyEntry);
@@ -278,6 +304,20 @@ export const updateKnowledgeText = async (
 
   if (!result[0]) {
     throw new Error("Failed to update knowledge text");
+  }
+
+  // Keep the RAG mirror in sync: covers newly enabled embedding, changed
+  // content, and cleanup after embedding was turned off. No-op otherwise;
+  // failures are logged and never fail the update itself.
+  if (result[0].embeddingEnabled || currentEntry.knowledgeEntryId) {
+    const syncResult = await syncKnowledgeTextEmbeddingSafe(
+      result[0].id,
+      result[0].tenantId
+    );
+    if (syncResult && (syncResult.synced || syncResult.removed)) {
+      // the sync wrote knowledgeEntryId/meta — return the fresh row
+      return await getKnowledgeTextById(id, { ...context, includeHidden: true });
+    }
   }
 
   return result[0];
@@ -309,7 +349,7 @@ export const deleteKnowledgeText = async (
     }
   }
 
-  // Delete the entry (history will be cascade deleted due to foreign key)
+  // Delete the entry (history and blocks are cascade deleted via FKs)
   await getDb()
     .delete(knowledgeText)
     .where(
@@ -318,6 +358,19 @@ export const deleteKnowledgeText = async (
         eq(knowledgeText.tenantId, context.tenantId)
       )
     );
+
+  // Clean up the RAG mirror created by the embedding sync (the FK points
+  // from knowledge_text to knowledge_entry, so it does not cascade)
+  if (item.knowledgeEntryId) {
+    await getDb()
+      .delete(knowledgeEntry)
+      .where(
+        and(
+          eq(knowledgeEntry.id, item.knowledgeEntryId),
+          eq(knowledgeEntry.tenantId, context.tenantId)
+        )
+      );
+  }
 
   return RESPONSES.SUCCESS;
 };

--- a/src/lib/utils/fractional-index.test.ts
+++ b/src/lib/utils/fractional-index.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "bun:test";
+import {
+  generateKeyBetween,
+  generateNKeysBetween,
+  assignPositions,
+} from "./fractional-index";
+
+describe("generateKeyBetween", () => {
+  it("generates a key for an empty list", () => {
+    const key = generateKeyBetween(null, null);
+    expect(key.length).toBeGreaterThan(0);
+    expect(key.endsWith("a")).toBe(false);
+  });
+
+  it("generates keys before and after an existing key", () => {
+    const mid = generateKeyBetween(null, null);
+    const before = generateKeyBetween(null, mid);
+    const after = generateKeyBetween(mid, null);
+    expect(before < mid).toBe(true);
+    expect(mid < after).toBe(true);
+  });
+
+  it("generates a key between two adjacent-looking keys", () => {
+    const key = generateKeyBetween("n", "o");
+    expect(key > "n").toBe(true);
+    expect(key < "o").toBe(true);
+  });
+
+  it("handles prefix bounds (a is prefix of b)", () => {
+    const key = generateKeyBetween("n", "nb");
+    expect(key > "n").toBe(true);
+    expect(key < "nb").toBe(true);
+  });
+
+  it("never produces keys ending with the minimum character", () => {
+    // stress: repeatedly insert at the very beginning
+    let upper: string | null = null;
+    for (let i = 0; i < 200; i++) {
+      const key: string = generateKeyBetween(null, upper);
+      expect(key.endsWith("a")).toBe(false);
+      if (upper !== null) expect(key < upper).toBe(true);
+      upper = key;
+    }
+  });
+
+  it("supports many sequential appends at the end", () => {
+    let last: string | null = null;
+    const keys: string[] = [];
+    for (let i = 0; i < 200; i++) {
+      const key: string = generateKeyBetween(last, null);
+      if (last !== null) expect(key > last).toBe(true);
+      keys.push(key);
+      last = key;
+    }
+    // keys must be strictly ascending
+    const sorted = [...keys].sort();
+    expect(sorted).toEqual(keys);
+  });
+
+  it("supports many repeated midpoint insertions", () => {
+    let a: string | null = "b";
+    let b: string | null = "c";
+    for (let i = 0; i < 100; i++) {
+      const key: string = generateKeyBetween(a, b);
+      expect(key > (a as string)).toBe(true);
+      expect(key < (b as string)).toBe(true);
+      // narrow the interval alternately from both sides
+      if (i % 2 === 0) a = key;
+      else b = key;
+    }
+  });
+
+  it("rejects invalid bounds", () => {
+    expect(() => generateKeyBetween("b", "b")).toThrow();
+    expect(() => generateKeyBetween("c", "b")).toThrow();
+    expect(() => generateKeyBetween("", null)).toThrow();
+    expect(() => generateKeyBetween("na", null)).toThrow(); // ends with "a"
+    expect(() => generateKeyBetween("A1", null)).toThrow(); // outside alphabet
+  });
+});
+
+describe("generateNKeysBetween", () => {
+  it("generates n strictly ascending keys", () => {
+    const keys = generateNKeysBetween(null, null, 10);
+    expect(keys.length).toBe(10);
+    for (let i = 1; i < keys.length; i++) {
+      expect(keys[i - 1]! < keys[i]!).toBe(true);
+    }
+  });
+
+  it("respects the given bounds", () => {
+    const keys = generateNKeysBetween("b", "c", 5);
+    for (const key of keys) {
+      expect(key > "b").toBe(true);
+      expect(key < "c").toBe(true);
+    }
+  });
+
+  it("returns an empty array for count <= 0", () => {
+    expect(generateNKeysBetween(null, null, 0)).toEqual([]);
+  });
+});
+
+describe("assignPositions", () => {
+  it("assigns fresh keys to a new list", () => {
+    const keys = assignPositions([{}, {}, {}]);
+    expect(keys.length).toBe(3);
+    expect(keys[0]! < keys[1]!).toBe(true);
+    expect(keys[1]! < keys[2]!).toBe(true);
+  });
+
+  it("keeps all existing keys when order is unchanged", () => {
+    const existing = ["f", "n", "u"];
+    const keys = assignPositions(existing.map((position) => ({ position })));
+    expect(keys).toEqual(existing);
+  });
+
+  it("only reassigns moved items", () => {
+    // original order: A(f), B(n), C(u) — move C before B => A, C, B
+    const keys = assignPositions([
+      { position: "f" },
+      { position: "u" },
+      { position: "n" },
+    ]);
+    expect(keys[0]).toBe("f"); // untouched
+    expect(keys[1]).toBe("u"); // kept (still > f)
+    expect(keys[2]).not.toBe("n"); // reassigned
+    expect(keys[1]! < keys[2]!).toBe(true);
+  });
+
+  it("inserts a new item between existing ones without touching them", () => {
+    const keys = assignPositions([
+      { position: "f" },
+      {}, // new block inserted in the middle
+      { position: "n" },
+    ]);
+    expect(keys[0]).toBe("f");
+    expect(keys[2]).toBe("n");
+    expect(keys[1]! > "f").toBe(true);
+    expect(keys[1]! < "n").toBe(true);
+  });
+
+  it("produces strictly ascending keys for arbitrary shuffles", () => {
+    const keys = assignPositions([
+      { position: "u" },
+      { position: "n" },
+      {},
+      { position: "f" },
+      { position: null },
+    ]);
+    for (let i = 1; i < keys.length; i++) {
+      expect(keys[i - 1]! < keys[i]!).toBe(true);
+    }
+  });
+
+  it("handles an empty list", () => {
+    expect(assignPositions([])).toEqual([]);
+  });
+});

--- a/src/lib/utils/fractional-index.ts
+++ b/src/lib/utils/fractional-index.ts
@@ -1,0 +1,148 @@
+/**
+ * Fractional indexing for ordered lists (wiki blocks, page trees).
+ *
+ * Keys are lowercase strings over the alphabet a–z. Lexicographic string
+ * order = list order. `generateKeyBetween(a, b)` returns a key strictly
+ * between its two arguments, so inserting or moving an item is always a
+ * single-row update — no renumbering of siblings required.
+ *
+ * Invariants:
+ *   - keys never end with "a" (the minimum character), otherwise no key
+ *     could be generated before them
+ *   - `null` bounds mean "start of list" / "end of list"
+ *
+ * The midpoint algorithm is the well-known "string between two strings"
+ * approach (as used by Figma-style fractional indexing): find the first
+ * differing character, then emit the character halfway between the two
+ * bounds, descending a level when the bounds are adjacent.
+ */
+
+const MIN_CODE = "a".charCodeAt(0); // 97
+const BELOW_MIN = MIN_CODE - 1; // virtual char before "a"
+const MAX_CODE = "z".charCodeAt(0); // 122
+const ABOVE_MAX = MAX_CODE + 1; // virtual char after "z"
+
+const isValidKey = (key: string): boolean =>
+  key.length > 0 && !key.endsWith("a") && /^[a-z]+$/.test(key);
+
+/**
+ * Generate a key strictly between `a` and `b`.
+ * `a = null` means "before everything", `b = null` means "after everything".
+ */
+export const generateKeyBetween = (
+  a: string | null,
+  b: string | null
+): string => {
+  if (a !== null && !isValidKey(a)) {
+    throw new Error(`Invalid fractional-index key: "${a}"`);
+  }
+  if (b !== null && !isValidKey(b)) {
+    throw new Error(`Invalid fractional-index key: "${b}"`);
+  }
+  if (a !== null && b !== null && a >= b) {
+    throw new Error(
+      `generateKeyBetween: lower bound "${a}" must be < upper bound "${b}"`
+    );
+  }
+
+  const prev = a ?? "";
+  const next = b ?? "";
+
+  let p = 0;
+  let n = 0;
+  let pos = 0;
+  // find the first position where the bounds differ
+  for (pos = 0; p === n; pos++) {
+    p = pos < prev.length ? prev.charCodeAt(pos) : BELOW_MIN;
+    n = pos < next.length ? next.charCodeAt(pos) : ABOVE_MAX;
+  }
+
+  let str = prev.slice(0, pos - 1); // shared prefix
+  if (p === BELOW_MIN) {
+    // prev is a prefix of next: descend along next's minimum characters
+    while (n === MIN_CODE) {
+      n = pos < next.length ? next.charCodeAt(pos++) : ABOVE_MAX;
+      str += "a";
+    }
+    if (n === MIN_CODE + 1) {
+      // next character is "b": can't go below "b" without ending in "a",
+      // so descend one more level
+      str += "a";
+      n = ABOVE_MAX;
+    }
+  } else if (p + 1 === n) {
+    // bounds are adjacent at this position: keep prev's char and find a
+    // key above the rest of prev
+    str += String.fromCharCode(p);
+    n = ABOVE_MAX;
+    while ((p = pos < prev.length ? prev.charCodeAt(pos++) : BELOW_MIN) === MAX_CODE) {
+      str += "z";
+    }
+  }
+  return str + String.fromCharCode(Math.ceil((p + n) / 2));
+};
+
+/**
+ * Generate `count` keys strictly between `a` and `b`, evenly nested.
+ */
+export const generateNKeysBetween = (
+  a: string | null,
+  b: string | null,
+  count: number
+): string[] => {
+  if (count <= 0) return [];
+  if (count === 1) return [generateKeyBetween(a, b)];
+  // generate the middle key, then recurse into both halves
+  const midIndex = Math.floor(count / 2);
+  const mid = generateKeyBetween(a, b);
+  return [
+    ...generateNKeysBetween(a, mid, midIndex),
+    mid,
+    ...generateNKeysBetween(mid, b, count - midIndex - 1),
+  ];
+};
+
+/**
+ * Assign positions to an ordered list of items, reusing existing keys where
+ * the relative order still holds so an unchanged list produces zero writes.
+ *
+ * Input: items in their DESIRED order, each optionally carrying the key it
+ * currently has in the database. Output: the final key per item (same order).
+ *
+ * An existing key is kept iff it is strictly greater than the previously
+ * assigned key; otherwise a fresh key is generated between the previous key
+ * and the nearest following reusable key (so kept keys are never jumped over).
+ */
+export const assignPositions = (
+  items: { position?: string | null }[]
+): string[] => {
+  const result: string[] = [];
+  let last: string | null = null;
+
+  for (let i = 0; i < items.length; i++) {
+    const existing = items[i]?.position ?? null;
+    if (existing !== null && isValidKey(existing) && (last === null || existing > last)) {
+      result.push(existing);
+      last = existing;
+      continue;
+    }
+    // upper bound: the smallest existing key after i that is still usable
+    // (greater than `last`) — new keys must stay below every kept key
+    let upper: string | null = null;
+    for (let j = i + 1; j < items.length; j++) {
+      const candidate = items[j]?.position ?? null;
+      if (
+        candidate !== null &&
+        isValidKey(candidate) &&
+        (last === null || candidate > last) &&
+        (upper === null || candidate < upper)
+      ) {
+        upper = candidate;
+      }
+    }
+    const key = generateKeyBetween(last, upper);
+    result.push(key);
+    last = key;
+  }
+  return result;
+};

--- a/src/routes/tenant/[tenantId]/knowledge/texts/blocks.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/blocks.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { testFetcher } from "../../../../../test/fetcher.test";
+import defineRoutes from ".";
+import { initTests, TEST_ORGANISATION_1 } from "../../../../../test/init.test";
+import { Hono } from "hono";
+import type { SFContextVariables } from "../../../../../types";
+import {
+  createDatabaseClient,
+  waitForDbConnection,
+} from "../../../../../lib/db/db-connection";
+
+let app = new Hono<{ Variables: SFContextVariables }>();
+let TEST_USER_1_TOKEN: string;
+let pageId: string;
+let firstBlockId: string;
+let secondBlockId: string;
+
+beforeAll(async () => {
+  await createDatabaseClient();
+  await waitForDbConnection();
+
+  defineRoutes(app, "/api");
+  const { user1Token } = await initTests();
+  TEST_USER_1_TOKEN = user1Token;
+});
+
+describe("Knowledge Text Blocks API", () => {
+  test("Create a page for block editing", async () => {
+    const response = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts`,
+      TEST_USER_1_TOKEN,
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        text: "",
+        title: "Blocks API Test Page",
+      }
+    );
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.contentMode).toBe("text");
+    pageId = response.jsonResponse.id;
+  });
+
+  test("GET blocks of a fresh page returns an empty list", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${pageId}/blocks`,
+      TEST_USER_1_TOKEN
+    );
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse).toEqual([]);
+  });
+
+  test("PUT blocks creates the block list and materializes the text", async () => {
+    const response = await testFetcher.put(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${pageId}/blocks`,
+      TEST_USER_1_TOKEN,
+      {
+        blocks: [
+          { type: "markdown", content: "# Wiki Page" },
+          { type: "html", content: "<p>Rendered <em>rich</em> text</p>" },
+        ],
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.blocks.length).toBe(2);
+    expect(response.jsonResponse.changes.inserted).toBe(2);
+    expect(response.jsonResponse.knowledgeText.contentMode).toBe("blocks");
+    expect(response.jsonResponse.knowledgeText.text).toContain("# Wiki Page");
+    expect(response.jsonResponse.knowledgeText.text).toContain("_rich_");
+
+    firstBlockId = response.jsonResponse.blocks[0].id;
+    secondBlockId = response.jsonResponse.blocks[1].id;
+  });
+
+  test("GET blocks returns the saved blocks in order", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${pageId}/blocks`,
+      TEST_USER_1_TOKEN
+    );
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.length).toBe(2);
+    expect(response.jsonResponse[0].id).toBe(firstBlockId);
+    expect(response.jsonResponse[1].id).toBe(secondBlockId);
+  });
+
+  test("PUT blocks reorders and edits in one save", async () => {
+    const response = await testFetcher.put(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${pageId}/blocks`,
+      TEST_USER_1_TOKEN,
+      {
+        blocks: [
+          { id: secondBlockId, type: "html", content: "<p>Now first</p>" },
+          { id: firstBlockId, type: "markdown", content: "# Now second" },
+        ],
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.blocks[0].id).toBe(secondBlockId);
+    expect(response.jsonResponse.blocks[1].id).toBe(firstBlockId);
+    expect(response.jsonResponse.changes.deleted).toBe(0);
+  });
+
+  test("PUT blocks rejects an invalid block type", async () => {
+    const response = await testFetcher.put(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${pageId}/blocks`,
+      TEST_USER_1_TOKEN,
+      {
+        blocks: [{ type: "video", content: "nope" }],
+      }
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("PUT blocks on an unknown page returns 404", async () => {
+    const response = await testFetcher.put(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${crypto.randomUUID()}/blocks`,
+      TEST_USER_1_TOKEN,
+      { blocks: [] }
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("Convert a legacy text page to blocks", async () => {
+    const createResponse = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts`,
+      TEST_USER_1_TOKEN,
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        text: "# Legacy page\n\nwith old content",
+        title: "Legacy Conversion Test",
+      }
+    );
+    expect(createResponse.status).toBe(200);
+    const legacyId = createResponse.jsonResponse.id;
+
+    const convertResponse = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${legacyId}/convert-to-blocks`,
+      TEST_USER_1_TOKEN,
+      {}
+    );
+    expect(convertResponse.status).toBe(200);
+    expect(convertResponse.jsonResponse.knowledgeText.contentMode).toBe(
+      "blocks"
+    );
+    expect(convertResponse.jsonResponse.blocks.length).toBe(1);
+    expect(convertResponse.jsonResponse.blocks[0].content).toBe(
+      "# Legacy page\n\nwith old content"
+    );
+  });
+
+  test("History endpoint includes block snapshots", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${pageId}/history`,
+      TEST_USER_1_TOKEN
+    );
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.jsonResponse)).toBe(true);
+    expect(response.jsonResponse.length).toBeGreaterThan(0);
+    // newest entry snapshotted the pre-update block state
+    expect(response.jsonResponse[0].contentMode).toBeDefined();
+  });
+});

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -15,6 +15,11 @@ import {
   deleteKnowledgeText,
 } from "../../../../../lib/knowledge/knowledge-texts";
 import {
+  getKnowledgeTextBlocks,
+  syncKnowledgeTextBlocks,
+  convertKnowledgeTextToBlocks,
+} from "../../../../../lib/knowledge/knowledge-text-blocks";
+import {
   authAndSetUsersInfo,
   checkUserPermission,
 } from "../../../../../lib/utils/hono-middlewares";
@@ -25,9 +30,27 @@ import {
   knowledgeEntrySchema,
   knowledgeTextInsertSchema,
   knowledgeTextUpdateSchema,
+  knowledgeTextBlockSchema,
 } from "../../../../../lib/db/db-schema";
 import { isTenantMember } from "../../..";
 import { validateScope } from "../../../../../lib/utils/validate-scope";
+
+const blockInputSchema = v.object({
+  id: v.optional(v.pipe(v.string(), v.uuid())),
+  type: v.picklist(["markdown", "html"]),
+  content: v.string(),
+  meta: v.optional(v.record(v.string(), v.unknown())),
+});
+
+const syncBlocksBodySchema = v.object({
+  blocks: v.array(blockInputSchema),
+});
+
+const contextQuerySchema = v.object({
+  teamId: v.optional(v.string()),
+  workspaceId: v.optional(v.string()),
+  includeHidden: v.optional(v.string()),
+});
 
 export default function defineRoutesForKnowledgeTexts(
   app: SymbiosikaFrameworkHonoApp,
@@ -365,6 +388,157 @@ export default function defineRoutesForKnowledgeTexts(
         return c.json(RESPONSES.SUCCESS);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
+      }
+    }
+  );
+
+  /**
+   * Get all blocks of a knowledge text page in display order
+   */
+  app.get(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/blocks",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary: "Get all content blocks of a knowledge text page in order",
+      responses: {
+        200: {
+          description: "Successful response with the ordered block list",
+          content: {
+            "application/json": {
+              schema: resolver(v.array(knowledgeTextBlockSchema)),
+            },
+          },
+        },
+      },
+    }),
+    validateScope("knowledge:read"),
+    validator("query", contextQuerySchema),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { teamId, workspaceId, includeHidden: includeHiddenStr } =
+          c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const userId = c.get("usersId");
+        const includeHidden = includeHiddenStr === "true";
+
+        const r = await getKnowledgeTextBlocks(id, {
+          tenantId,
+          userId,
+          teamId,
+          workspaceId,
+          includeHidden,
+        });
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
+      }
+    }
+  );
+
+  /**
+   * Batch-save the full block list of a knowledge text page.
+   * The block editor sends its complete document state; the server diffs
+   * by block id (insert/update/delete), re-materializes the text cache,
+   * snapshots history (coalesced) and re-syncs the embedding if enabled.
+   */
+  app.put(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/blocks",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary: "Batch-save the full block list of a knowledge text page",
+      responses: {
+        200: {
+          description:
+            "Successful response with the updated page and its blocks",
+        },
+      },
+    }),
+    validateScope("knowledge:write"),
+    validator("json", syncBlocksBodySchema),
+    validator("query", contextQuerySchema),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { teamId, workspaceId, includeHidden: includeHiddenStr } =
+          c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const { blocks } = c.req.valid("json");
+        const userId = c.get("usersId");
+        const includeHidden = includeHiddenStr === "true";
+
+        const r = await syncKnowledgeTextBlocks(id, blocks, {
+          tenantId,
+          userId,
+          teamId,
+          workspaceId,
+          includeHidden,
+        });
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
+      }
+    }
+  );
+
+  /**
+   * Convert a legacy plain-text page into block mode
+   */
+  app.post(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/convert-to-blocks",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Convert a plain-text knowledge text page into block mode (no-op if already blocks)",
+      responses: {
+        200: {
+          description:
+            "Successful response with the converted page and its blocks",
+        },
+      },
+    }),
+    validateScope("knowledge:write"),
+    validator("query", contextQuerySchema),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { teamId, workspaceId, includeHidden: includeHiddenStr } =
+          c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const userId = c.get("usersId");
+        const includeHidden = includeHiddenStr === "true";
+
+        const r = await convertKnowledgeTextToBlocks(id, {
+          tenantId,
+          userId,
+          teamId,
+          workspaceId,
+          includeHidden,
+        });
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
       }
     }
   );


### PR DESCRIPTION
knowledgeText pages can now store their content as ordered blocks
(markdown/html) for a Notion-style block editor, while staying fully
backwards compatible with plain-text entries:

- New table knowledge_text_block: one row per editor block, ordered by
  fractional-index keys so drag & drop is a single-row update
- knowledge_text: new contentMode (text|blocks), position (manual page
  ordering in the wiki tree), embeddingEnabled and knowledgeEntryId
- text column is kept as a materialized cache assembled from the blocks
  (html converted via turndown), so search/export/embedding keep working
- History snapshots now include the block state and are coalesced
  (default 10 min window) so autosaving editors don't flood the table
- Optional embedding: pages opt in via embeddingEnabled and are mirrored
  into the RAG pipeline through upsertKnowledgeFromText with a stable
  sourceIdentifier; a content hash skips unchanged re-syncs, disabling
  or deleting the page cleans the mirror up
- New routes: GET/PUT .../texts/:id/blocks (batch diff save) and
  POST .../texts/:id/convert-to-blocks for legacy pages

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv