### PR TITLE
Add simplified LLM-friendly endpoint for knowledge text pages

### DIFF
--- a/src/lib/knowledge/knowledge-text-simplified.test.ts
+++ b/src/lib/knowledge/knowledge-text-simplified.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import { getSimplifiedKnowledgeText } from "./knowledge-text-simplified";
+import { createKnowledgeText, updateKnowledgeText } from "./knowledge-texts";
+import { syncKnowledgeTextBlocks } from "./knowledge-text-blocks";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+
+const ctx = { tenantId: TEST_ORGANISATION_1.id };
+
+const createPage = async (overrides?: Record<string, unknown>) =>
+  await createKnowledgeText({
+    text: "",
+    title: `Simplified Test ${crypto.randomUUID()}`,
+    tenantId: TEST_ORGANISATION_1.id,
+    ...overrides,
+  });
+
+describe("Simplified Knowledge Text", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("returns only id, title and content for a plain text page", async () => {
+    const page = await createPage({
+      title: "Plain Page",
+      text: "# Plain\n\ncontent",
+    });
+
+    const result = await getSimplifiedKnowledgeText(page.id, ctx);
+
+    expect(result).toEqual({
+      id: page.id,
+      title: "Plain Page",
+      content: "# Plain\n\ncontent",
+    });
+    expect("children" in result).toBe(false);
+  });
+
+  it("merges all blocks into content for a block page", async () => {
+    const page = await createPage({ title: "Block Page" });
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "# Heading" },
+        { type: "html", content: "<p>From <strong>html</strong></p>" },
+      ],
+      ctx
+    );
+
+    const result = await getSimplifiedKnowledgeText(page.id, ctx);
+
+    expect(result.content).toBe("# Heading\n\nFrom **html**");
+    expect(result.title).toBe("Block Page");
+    // no block structure leaks into the simplified shape
+    expect(Object.keys(result).sort()).toEqual(["content", "id", "title"]);
+  });
+
+  it("returns the full nested subtree with recursive=true", async () => {
+    const root = await createPage({ title: "Root", text: "root content" });
+    const childA = await createPage({
+      title: "A Child",
+      text: "child a",
+      parentId: root.id,
+    });
+    const childB = await createPage({
+      title: "B Child",
+      text: "child b",
+      parentId: root.id,
+    });
+    const grandchild = await createPage({
+      title: "Grandchild",
+      text: "deep content",
+      parentId: childA.id,
+    });
+
+    const result = await getSimplifiedKnowledgeText(root.id, ctx, {
+      recursive: true,
+    });
+
+    expect(result.id).toBe(root.id);
+    expect(result.content).toBe("root content");
+    expect(result.children?.length).toBe(2);
+    // no position set → ordered by title
+    expect(result.children?.[0]?.id).toBe(childA.id);
+    expect(result.children?.[1]?.id).toBe(childB.id);
+    expect(result.children?.[0]?.children?.length).toBe(1);
+    expect(result.children?.[0]?.children?.[0]?.id).toBe(grandchild.id);
+    expect(result.children?.[0]?.children?.[0]?.content).toBe("deep content");
+    // leaves carry an empty children array in recursive mode
+    expect(result.children?.[1]?.children).toEqual([]);
+  });
+
+  it("orders children by manual position before title", async () => {
+    const root = await createPage({ title: "Ordered Root" });
+    const first = await createPage({
+      title: "Z Should Be First",
+      parentId: root.id,
+      position: "f",
+    });
+    const second = await createPage({
+      title: "A Should Be Second",
+      parentId: root.id,
+      position: "n",
+    });
+    const unpositioned = await createPage({
+      title: "B Unpositioned Goes Last",
+      parentId: root.id,
+    });
+
+    const result = await getSimplifiedKnowledgeText(root.id, ctx, {
+      recursive: true,
+    });
+
+    expect(result.children?.map((c) => c.id)).toEqual([
+      first.id,
+      second.id,
+      unpositioned.id,
+    ]);
+  });
+
+  it("omits hidden sub-pages including their subtrees", async () => {
+    const root = await createPage({ title: "Hidden Test Root" });
+    const visible = await createPage({
+      title: "Visible Child",
+      parentId: root.id,
+    });
+    const hidden = await createPage({
+      title: "Hidden Child",
+      parentId: root.id,
+      hidden: true,
+    });
+    await createPage({
+      title: "Child Of Hidden",
+      parentId: hidden.id,
+    });
+
+    const result = await getSimplifiedKnowledgeText(root.id, ctx, {
+      recursive: true,
+    });
+    expect(result.children?.map((c) => c.id)).toEqual([visible.id]);
+
+    // includeHidden brings the hidden subtree back
+    const withHidden = await getSimplifiedKnowledgeText(
+      root.id,
+      { ...ctx, includeHidden: true },
+      { recursive: true }
+    );
+    expect(withHidden.children?.length).toBe(2);
+    const hiddenNode = withHidden.children?.find((c) => c.id === hidden.id);
+    expect(hiddenNode?.children?.length).toBe(1);
+  });
+
+  it("survives a parentId cycle without infinite recursion", async () => {
+    const a = await createPage({ title: "Cycle A", text: "a" });
+    const b = await createPage({
+      title: "Cycle B",
+      text: "b",
+      parentId: a.id,
+    });
+    // create the cycle: A's parent becomes B
+    await updateKnowledgeText(a.id, { parentId: b.id }, ctx);
+
+    const result = await getSimplifiedKnowledgeText(a.id, ctx, {
+      recursive: true,
+    });
+    expect(result.id).toBe(a.id);
+    expect(result.children?.[0]?.id).toBe(b.id);
+    // the loop back to A is cut off
+    expect(result.children?.[0]?.children).toEqual([]);
+  });
+
+  it("rejects access from a different tenant", async () => {
+    const page = await createPage();
+    await expect(
+      getSimplifiedKnowledgeText(page.id, {
+        tenantId: "00000000-1111-1111-1111-000000000002",
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/src/lib/knowledge/knowledge-text-simplified.ts
+++ b/src/lib/knowledge/knowledge-text-simplified.ts
@@ -1,0 +1,119 @@
+/**
+ * LLM-friendly simplified view of knowledgeText wiki pages.
+ *
+ * Returns a page reduced to `{ id, title, content }`, where `content` is the
+ * page's full text: for block pages this is the materialized `text` cache
+ * (all blocks merged to markdown), for legacy pages the plain text — so a
+ * consumer never has to deal with the block structure.
+ *
+ * With `recursive: true` the page's sub-pages (wiki tree via `parentId`) are
+ * nested under `children`, ordered like the wiki sidebar (manual `position`
+ * first, then title). Pages the caller is not allowed to see are silently
+ * omitted together with their subtrees.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { knowledgeText } from "../db/schema/knowledge";
+import {
+  getKnowledgeTextById,
+  buildKnowledgeTextVisibilityConditions,
+} from "./knowledge-texts";
+
+export type SimplifiedKnowledgeText = {
+  id: string;
+  title: string;
+  content: string;
+  /** only present when requested with `recursive: true` */
+  children?: SimplifiedKnowledgeText[];
+};
+
+type Context = {
+  tenantId: string;
+  userId?: string;
+  teamId?: string;
+  workspaceId?: string;
+  includeHidden?: boolean;
+};
+
+type PageRow = {
+  id: string;
+  title: string;
+  text: string;
+  parentId: string | null;
+  position: string | null;
+};
+
+/** Wiki sidebar order: manual position first (nulls last), then title */
+const byWikiOrder = (a: PageRow, b: PageRow): number => {
+  if (a.position !== null && b.position !== null) {
+    if (a.position !== b.position) return a.position < b.position ? -1 : 1;
+  } else if (a.position !== b.position) {
+    return a.position !== null ? -1 : 1;
+  }
+  return a.title.localeCompare(b.title);
+};
+
+/**
+ * Get a page as `{ id, title, content }`. With `recursive: true` the whole
+ * subtree is included as nested `children`.
+ */
+export const getSimplifiedKnowledgeText = async (
+  id: string,
+  context: Context,
+  options?: { recursive?: boolean }
+): Promise<SimplifiedKnowledgeText> => {
+  // permission check for the root (throws if not visible)
+  const root = await getKnowledgeTextById(id, context);
+
+  if (!options?.recursive) {
+    return { id: root.id, title: root.title, content: root.text };
+  }
+
+  // One query for every page the caller may see in this tenant; the tree is
+  // assembled in memory. This avoids N+1 queries per tree level and makes
+  // cycle protection trivial.
+  const rows: PageRow[] = await getDb()
+    .select({
+      id: knowledgeText.id,
+      title: knowledgeText.title,
+      text: knowledgeText.text,
+      parentId: knowledgeText.parentId,
+      position: knowledgeText.position,
+    })
+    .from(knowledgeText)
+    .where(and(...buildKnowledgeTextVisibilityConditions(context)));
+
+  const byParent = new Map<string, PageRow[]>();
+  for (const row of rows) {
+    if (!row.parentId) continue;
+    const siblings = byParent.get(row.parentId) ?? [];
+    siblings.push(row);
+    byParent.set(row.parentId, siblings);
+  }
+  for (const siblings of byParent.values()) {
+    siblings.sort(byWikiOrder);
+  }
+
+  const visited = new Set<string>();
+  const buildNode = (row: PageRow): SimplifiedKnowledgeText => {
+    visited.add(row.id);
+    const children = (byParent.get(row.id) ?? [])
+      .filter((child) => !visited.has(child.id)) // cycle protection
+      .map(buildNode);
+    return {
+      id: row.id,
+      title: row.title,
+      content: row.text,
+      children,
+    };
+  };
+
+  return buildNode({
+    id: root.id,
+    title: root.title,
+    text: root.text,
+    parentId: root.parentId,
+    position: root.position,
+  });
+};

--- a/src/lib/knowledge/knowledge-texts.ts
+++ b/src/lib/knowledge/knowledge-texts.ts
@@ -47,19 +47,16 @@ export const createKnowledgeText = async (data: KnowledgeTextInsert) => {
 };
 
 /**
- * Get list of all knowledge text entries WITHOUT text content
- * Sorted alphabetically by title
+ * Build the WHERE conditions that decide which knowledgeText entries are
+ * visible in a given context (tenant, hidden flag, user/team access).
+ * Shared by every read path so the visibility rules cannot drift apart.
  */
-export const getKnowledgeText = async (filters: {
+export const buildKnowledgeTextVisibilityConditions = (filters: {
   tenantId: string;
   teamId?: string;
   userId?: string;
-  workspaceId?: string;
-  limit?: number;
-  page?: number;
-  includeHidden?: boolean; // Optional: include system/hidden entries
-}) => {
-  // Exclude 'text' field to reduce payload size
+  includeHidden?: boolean;
+}): SQLWrapper[] => {
   const permissionConditions: SQLWrapper[] = [
     eq(knowledgeText.tenantId, filters.tenantId),
   ];
@@ -92,6 +89,25 @@ export const getKnowledgeText = async (filters: {
   if (filters.teamId) {
     permissionConditions.push(eq(knowledgeText.teamId, filters.teamId));
   }
+
+  return permissionConditions;
+};
+
+/**
+ * Get list of all knowledge text entries WITHOUT text content
+ * Sorted alphabetically by title
+ */
+export const getKnowledgeText = async (filters: {
+  tenantId: string;
+  teamId?: string;
+  userId?: string;
+  workspaceId?: string;
+  limit?: number;
+  page?: number;
+  includeHidden?: boolean; // Optional: include system/hidden entries
+}) => {
+  // Exclude 'text' field to reduce payload size
+  const permissionConditions = buildKnowledgeTextVisibilityConditions(filters);
 
   const { text, ...rest } = getTableColumns(knowledgeText); // exclude "text" column
   const query = getDb()
@@ -126,38 +142,9 @@ export const getKnowledgeTextById = async (
   }
 ) => {
   const permissionConditions: SQLWrapper[] = [
-    eq(knowledgeText.tenantId, context.tenantId),
+    ...buildKnowledgeTextVisibilityConditions(context),
     eq(knowledgeText.id, id),
   ];
-
-  // Check hidden flag unless explicitly allowed
-  if (!context.includeHidden) {
-    permissionConditions.push(eq(knowledgeText.hidden, false));
-  }
-
-  if (context.userId) {
-    permissionConditions.push(
-      or(
-        eq(knowledgeText.userId, context.userId),
-        and(isNull(knowledgeText.teamId), eq(knowledgeText.tenantWide, true)),
-        exists(
-          getDb()
-            .select()
-            .from(teamMembers)
-            .where(
-              and(
-                eq(teamMembers.userId, context.userId),
-                eq(teamMembers.teamId, knowledgeText.teamId)
-              )
-            )
-        )
-      )!
-    );
-  }
-
-  if (context.teamId) {
-    permissionConditions.push(eq(knowledgeText.teamId, context.teamId));
-  }
 
   const result = await getDb()
     .select()

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -19,6 +19,7 @@ import {
   syncKnowledgeTextBlocks,
   convertKnowledgeTextToBlocks,
 } from "../../../../../lib/knowledge/knowledge-text-blocks";
+import { getSimplifiedKnowledgeText } from "../../../../../lib/knowledge/knowledge-text-simplified";
 import {
   authAndSetUsersInfo,
   checkUserPermission,
@@ -50,6 +51,15 @@ const contextQuerySchema = v.object({
   teamId: v.optional(v.string()),
   workspaceId: v.optional(v.string()),
   includeHidden: v.optional(v.string()),
+});
+
+const simplifiedKnowledgeTextSchema: v.GenericSchema = v.object({
+  id: v.string(),
+  title: v.string(),
+  content: v.string(),
+  children: v.optional(
+    v.array(v.lazy(() => simplifiedKnowledgeTextSchema))
+  ),
 });
 
 export default function defineRoutesForKnowledgeTexts(
@@ -388,6 +398,71 @@ export default function defineRoutesForKnowledgeTexts(
         return c.json(RESPONSES.SUCCESS);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
+      }
+    }
+  );
+
+  /**
+   * Get a page in a simplified, LLM-friendly shape: { id, title, content }.
+   * `content` is the full page text with all blocks already merged.
+   * With ?recursive=true the whole subtree is nested under `children`.
+   */
+  app.get(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/simplified",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Get a knowledge text page as simplified JSON (id, title, content); ?recursive=true nests all sub-pages under children",
+      responses: {
+        200: {
+          description: "Successful response with the simplified page",
+          content: {
+            "application/json": {
+              schema: resolver(simplifiedKnowledgeTextSchema),
+            },
+          },
+        },
+      },
+    }),
+    validateScope("knowledge:read"),
+    validator(
+      "query",
+      v.object({
+        recursive: v.optional(v.string()),
+        teamId: v.optional(v.string()),
+        workspaceId: v.optional(v.string()),
+        includeHidden: v.optional(v.string()),
+      })
+    ),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const {
+          recursive: recursiveStr,
+          teamId,
+          workspaceId,
+          includeHidden: includeHiddenStr,
+        } = c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const userId = c.get("usersId");
+        const includeHidden = includeHiddenStr === "true";
+        const recursive = recursiveStr === "true";
+
+        const r = await getSimplifiedKnowledgeText(
+          id,
+          { tenantId, userId, teamId, workspaceId, includeHidden },
+          { recursive }
+        );
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
       }
     }
   );

--- a/src/routes/tenant/[tenantId]/knowledge/texts/simplified.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/simplified.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { testFetcher } from "../../../../../test/fetcher.test";
+import defineRoutes from ".";
+import { initTests, TEST_ORGANISATION_1 } from "../../../../../test/init.test";
+import { Hono } from "hono";
+import type { SFContextVariables } from "../../../../../types";
+import {
+  createDatabaseClient,
+  waitForDbConnection,
+} from "../../../../../lib/db/db-connection";
+
+let app = new Hono<{ Variables: SFContextVariables }>();
+let TEST_USER_1_TOKEN: string;
+let rootId: string;
+let childId: string;
+
+beforeAll(async () => {
+  await createDatabaseClient();
+  await waitForDbConnection();
+
+  defineRoutes(app, "/api");
+  const { user1Token } = await initTests();
+  TEST_USER_1_TOKEN = user1Token;
+});
+
+describe("Simplified Knowledge Text API", () => {
+  test("Create a parent page with blocks and a sub-page", async () => {
+    const rootResponse = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts`,
+      TEST_USER_1_TOKEN,
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        text: "",
+        title: "Simplified API Root",
+      }
+    );
+    expect(rootResponse.status).toBe(200);
+    rootId = rootResponse.jsonResponse.id;
+
+    const blocksResponse = await testFetcher.put(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${rootId}/blocks`,
+      TEST_USER_1_TOKEN,
+      {
+        blocks: [
+          { type: "markdown", content: "# Root Heading" },
+          { type: "html", content: "<p>Root body</p>" },
+        ],
+      }
+    );
+    expect(blocksResponse.status).toBe(200);
+
+    const childResponse = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts`,
+      TEST_USER_1_TOKEN,
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        text: "child page content",
+        title: "Simplified API Child",
+        parentId: rootId,
+      }
+    );
+    expect(childResponse.status).toBe(200);
+    childId = childResponse.jsonResponse.id;
+  });
+
+  test("GET simplified returns id, title and merged content only", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${rootId}/simplified`,
+      TEST_USER_1_TOKEN
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse).toEqual({
+      id: rootId,
+      title: "Simplified API Root",
+      content: "# Root Heading\n\nRoot body",
+    });
+  });
+
+  test("GET simplified?recursive=true nests sub-pages under children", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${rootId}/simplified?recursive=true`,
+      TEST_USER_1_TOKEN
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.id).toBe(rootId);
+    expect(response.jsonResponse.children.length).toBe(1);
+    expect(response.jsonResponse.children[0]).toEqual({
+      id: childId,
+      title: "Simplified API Child",
+      content: "child page content",
+      children: [],
+    });
+  });
+
+  test("GET simplified on an unknown page returns 404", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${crypto.randomUUID()}/simplified`,
+      TEST_USER_1_TOKEN
+    );
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

New endpoint that returns wiki pages in a shape that is easy for LLMs to consume:

```
GET /tenant/:tenantId/knowledge/texts/:id/simplified
```

returns the page reduced to

```json
{ "id": "…", "title": "…", "content": "…" }
```

`content` is the full page text with all blocks already merged to markdown (HTML blocks converted), so consumers never have to deal with the block structure.

### Recursive mode

```
GET …/texts/:id/simplified?recursive=true
```

returns the page **including its whole wiki subtree** as nested JSON — call it on a parent page and get the complete structure in one request:

```json
{
  "id": "…", "title": "Handbook", "content": "…",
  "children": [
    { "id": "…", "title": "Chapter 1", "content": "…", "children": [] }
  ]
}
```

- Children are ordered like the wiki sidebar: manual `position` first, then title
- Visibility rules are identical to all other knowledgeText reads — hidden pages and pages the caller cannot access are omitted together with their subtrees
- The tree is assembled from a single query (no N+1) and is safe against `parentId` cycles

### Refactoring

The knowledgeText visibility conditions (tenant, hidden flag, user/team access) were extracted into a shared `buildKnowledgeTextVisibilityConditions` helper, now used by the list query, get-by-id and the new tree query so the rules cannot drift apart.

## Tests

- `src/lib/knowledge/knowledge-text-simplified.test.ts` — 7 tests: plain/block pages, recursive tree shape, ordering, hidden subtrees, cycle protection, cross-tenant rejection
- `src/routes/tenant/[tenantId]/knowledge/texts/simplified.test.ts` — 4 HTTP-level tests incl. 404 handling
- All existing knowledge suites re-run locally against PGlite: no regressions (only the known MISTRAL_API_KEY-dependent tests fail locally; they run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv

---
_Generated by [Claude Code](https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv)_