### PR TITLE
Add agent-friendly wiki API: file-like editing, hybrid search, wikilinks

### DIFF
--- a/drizzle-sql/0018_massive_sebastian_shaw.sql
+++ b/drizzle-sql/0018_massive_sebastian_shaw.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "base_knowledge_text_link" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"source_id" uuid NOT NULL,
+	"target_id" uuid,
+	"target_title" varchar(1000) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "knowledge_text_link_source_target_unique" UNIQUE("source_id","target_title")
+);
+--> statement-breakpoint
+ALTER TABLE "base_knowledge_text_link" ADD CONSTRAINT "base_knowledge_text_link_tenant_id_base_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."base_tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "base_knowledge_text_link" ADD CONSTRAINT "base_knowledge_text_link_source_id_base_knowledge_text_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."base_knowledge_text"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "base_knowledge_text_link" ADD CONSTRAINT "base_knowledge_text_link_target_id_base_knowledge_text_id_fk" FOREIGN KEY ("target_id") REFERENCES "public"."base_knowledge_text"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "knowledge_text_link_source_id_idx" ON "base_knowledge_text_link" USING btree ("source_id");--> statement-breakpoint
+CREATE INDEX "knowledge_text_link_target_id_idx" ON "base_knowledge_text_link" USING btree ("target_id");--> statement-breakpoint
+CREATE INDEX "knowledge_text_link_tenant_target_title_idx" ON "base_knowledge_text_link" USING btree ("tenant_id","target_title");--> statement-breakpoint
+CREATE INDEX "knowledge_text_fts_idx" ON "base_knowledge_text" USING gin (to_tsvector('simple', coalesce("title", '') || ' ' || coalesce("text", '')));

--- a/drizzle-sql/meta/0018_snapshot.json
+++ b/drizzle-sql/meta/0018_snapshot.json
@@ -1,0 +1,6179 @@
+{
+  "id": "4f006d48-8e0d-4701-aee2-ca2e1212f354",
+  "prevId": "7e8fb013-ac58-4a43-af17-00b92b70477d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.base_group_permissions": {
+      "name": "base_group_permissions",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "group_permissions_group_id_idx": {
+          "name": "group_permissions_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_permissions_permission_id_idx": {
+          "name": "group_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_group_permissions_group_id_base_user_permission_groups_id_fk": {
+          "name": "base_group_permissions_group_id_base_user_permission_groups_id_fk",
+          "tableFrom": "base_group_permissions",
+          "tableTo": "base_user_permission_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_group_permissions_permission_id_base_path_permissions_id_fk": {
+          "name": "base_group_permissions_permission_id_base_path_permissions_id_fk",
+          "tableFrom": "base_group_permissions",
+          "tableTo": "base_path_permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_group_permissions_group_id_permission_id_pk": {
+          "name": "base_group_permissions_group_id_permission_id_pk",
+          "columns": [
+            "group_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_invitation_codes": {
+      "name": "base_invitation_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": -1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_invitation_code": {
+          "name": "unique_invitation_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_codes_tenant_id_idx": {
+          "name": "invitation_codes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_codes_expires_at_idx": {
+          "name": "invitation_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_invitation_codes_tenant_id_base_tenants_id_fk": {
+          "name": "base_invitation_codes_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_invitation_codes",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_magic_link_sessions": {
+      "name": "base_magic_link_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "magic_link_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login'"
+        }
+      },
+      "indexes": {
+        "unique_token": {
+          "name": "unique_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_sessions_user_id_idx": {
+          "name": "magic_link_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_sessions_expires_at_idx": {
+          "name": "magic_link_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_magic_link_sessions_user_id_base_users_id_fk": {
+          "name": "base_magic_link_sessions_user_id_base_users_id_fk",
+          "tableFrom": "base_magic_link_sessions",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_path_permissions": {
+      "name": "base_path_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "permission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_expression": {
+          "name": "path_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permissions_method_idx": {
+          "name": "permissions_method_idx",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_type_idx": {
+          "name": "permissions_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_path_permissions_tenant_id_base_tenants_id_fk": {
+          "name": "base_path_permissions_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_path_permissions",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_category_name": {
+          "name": "unique_category_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_sessions": {
+      "name": "base_sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_sessions_user_id_base_users_id_fk": {
+          "name": "base_sessions_user_id_base_users_id_fk",
+          "tableFrom": "base_sessions",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_team_members": {
+      "name": "base_team_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_team_members_user_id_base_users_id_fk": {
+          "name": "base_team_members_user_id_base_users_id_fk",
+          "tableFrom": "base_team_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_team_members_team_id_base_teams_id_fk": {
+          "name": "base_team_members_team_id_base_teams_id_fk",
+          "tableFrom": "base_team_members",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_team_members_user_id_team_id_pk": {
+          "name": "base_team_members_user_id_team_id_pk",
+          "columns": [
+            "user_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_teams": {
+      "name": "base_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_teams_tenant_id_base_tenants_id_fk": {
+          "name": "base_teams_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_teams",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_invitations": {
+      "name": "base_tenant_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_invitation": {
+          "name": "unique_invitation",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_idx": {
+          "name": "invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_created_at_idx": {
+          "name": "invitations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_invitations_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_invitations_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_invitations",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_members": {
+      "name": "base_tenant_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_members_user_id_idx": {
+          "name": "tenant_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_members_tenant_id_idx": {
+          "name": "tenant_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_members_user_id_base_users_id_fk": {
+          "name": "base_tenant_members_user_id_base_users_id_fk",
+          "tableFrom": "base_tenant_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_tenant_members_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_members_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_members",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_tenant_members_user_id_tenant_id_pk": {
+          "name": "base_tenant_members_user_id_tenant_id_pk",
+          "columns": [
+            "user_id",
+            "tenant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenants": {
+      "name": "base_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "tenant_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_name_local_unique_idx": {
+          "name": "tenants_name_local_unique_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"base_tenants\".\"origin\" = 'local'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_group_members": {
+      "name": "base_user_group_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_groups_id": {
+          "name": "user_groups_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_user_group_members_user_id_base_users_id_fk": {
+          "name": "base_user_group_members_user_id_base_users_id_fk",
+          "tableFrom": "base_user_group_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_user_group_members_user_groups_id_base_user_permission_groups_id_fk": {
+          "name": "base_user_group_members_user_groups_id_base_user_permission_groups_id_fk",
+          "tableFrom": "base_user_group_members",
+          "tableTo": "base_user_permission_groups",
+          "columnsFrom": [
+            "user_groups_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_user_group_members_user_id_user_groups_id_pk": {
+          "name": "base_user_group_members_user_id_user_groups_id_pk",
+          "columns": [
+            "user_id",
+            "user_groups_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_messages": {
+      "name": "base_user_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_messages_user_id_idx": {
+          "name": "user_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_confirmed_at_idx": {
+          "name": "user_messages_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_created_at_idx": {
+          "name": "user_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_message_type_idx": {
+          "name": "user_messages_message_type_idx",
+          "columns": [
+            {
+              "expression": "message_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_messages_user_id_base_users_id_fk": {
+          "name": "base_user_messages_user_id_base_users_id_fk",
+          "tableFrom": "base_user_messages",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_permission_groups": {
+      "name": "base_user_permission_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_permission_groups_name_idx": {
+          "name": "user_permission_groups_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_permission_groups_created_at_idx": {
+          "name": "user_permission_groups_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_permission_groups_tenant_id_base_tenants_id_fk": {
+          "name": "base_user_permission_groups_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_user_permission_groups",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_users": {
+      "name": "base_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "user_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surname": {
+          "name": "surname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salutation": {
+          "name": "salutation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number_verified": {
+          "name": "phone_number_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone_number_as_number": {
+          "name": "phone_number_as_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_pin_number": {
+          "name": "phone_pin_number",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ext_user_id": {
+          "name": "ext_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_name": {
+          "name": "profile_image_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_content_type": {
+          "name": "profile_image_content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_tenant_id": {
+          "name": "last_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_email": {
+          "name": "unique_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_phone_number": {
+          "name": "unique_phone_number",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_phone_number_as_number": {
+          "name": "unique_phone_number_as_number",
+          "columns": [
+            {
+              "expression": "phone_number_as_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_verified_idx": {
+          "name": "users_email_verified_idx",
+          "columns": [
+            {
+              "expression": "email_verified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_users_last_tenant_id_base_tenants_id_fk": {
+          "name": "base_users_last_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_users",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "last_tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_webauthn_credentials": {
+      "name": "base_webauthn_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webauthn_credentials_credential_id_idx": {
+          "name": "webauthn_credentials_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webauthn_credentials_user_id_idx": {
+          "name": "webauthn_credentials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_webauthn_credentials_user_id_base_users_id_fk": {
+          "name": "base_webauthn_credentials_user_id_base_users_id_fk",
+          "tableFrom": "base_webauthn_credentials",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_secrets": {
+      "name": "base_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference": {
+          "name": "reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "secrets_idx": {
+          "name": "secrets_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_ref_idx": {
+          "name": "secrets_ref_idx",
+          "columns": [
+            {
+              "expression": "reference",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_ref_id_idx": {
+          "name": "secrets_ref_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_name_idx": {
+          "name": "secrets_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_type_idx": {
+          "name": "secrets_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_secrets_tenant_id_base_tenants_id_fk": {
+          "name": "base_secrets_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_secrets",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secrets_reference_name_idx": {
+          "name": "secrets_reference_name_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_files": {
+      "name": "base_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extension": {
+          "name": "extension",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_id_idx": {
+          "name": "files_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_bucket_name_idx": {
+          "name": "files_bucket_name_idx",
+          "columns": [
+            {
+              "expression": "bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_created_at_idx": {
+          "name": "files_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_updated_at_idx": {
+          "name": "files_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_name_idx": {
+          "name": "files_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_expires_at_idx": {
+          "name": "files_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_files_tenant_id_base_tenants_id_fk": {
+          "name": "base_files_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_files",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_app_specific_data": {
+      "name": "base_app_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_data_created_at_idx": {
+          "name": "app_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_data_version_idx": {
+          "name": "app_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_app_specific_data_key_unique": {
+          "name": "base_app_specific_data_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_team_specific_data": {
+      "name": "base_team_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_data_key_idx": {
+          "name": "team_data_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_data_created_at_idx": {
+          "name": "team_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_data_version_idx": {
+          "name": "team_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_team_specific_data_team_id_base_teams_id_fk": {
+          "name": "base_team_specific_data_team_id_base_teams_id_fk",
+          "tableFrom": "base_team_specific_data",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_team_specific_data_team_id_key_unique": {
+          "name": "base_team_specific_data_team_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_specific_data": {
+      "name": "base_tenant_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_data_key_idx": {
+          "name": "tenant_data_key_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_data_created_at_idx": {
+          "name": "tenant_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_data_version_idx": {
+          "name": "tenant_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_specific_data_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_specific_data_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_specific_data",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_tenant_specific_data_tenant_id_category_unique": {
+          "name": "base_tenant_specific_data_tenant_id_category_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "category"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_specific_data": {
+      "name": "base_user_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_data_type_idx": {
+          "name": "user_data_type_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_data_created_at_idx": {
+          "name": "user_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_data_version_idx": {
+          "name": "user_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_specific_data_user_id_base_users_id_fk": {
+          "name": "base_user_specific_data_user_id_base_users_id_fk",
+          "tableFrom": "base_user_specific_data",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_user_specific_data_user_id_key_unique": {
+          "name": "base_user_specific_data_user_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_chunks": {
+      "name": "base_knowledge_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_entry_id": {
+          "name": "knowledge_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "text_embedding_1536": {
+          "name": "text_embedding_1536",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_embedding_1024": {
+          "name": "text_embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "knowledge_chunks_knowledge_entry_id_idx": {
+          "name": "knowledge_chunks_knowledge_entry_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_created_at_idx": {
+          "name": "knowledge_chunks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_header_idx": {
+          "name": "knowledge_chunks_header_idx",
+          "columns": [
+            {
+              "expression": "header",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_chunks_knowledge_entry_id_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_chunks_knowledge_entry_id_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_chunks",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "knowledge_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_chunks_embedding_required": {
+          "name": "knowledge_chunks_embedding_required",
+          "value": "text_embedding_1536 IS NOT NULL OR text_embedding_1024 IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_entry": {
+      "name": "base_knowledge_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_owned": {
+          "name": "user_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "knowledge_group_id": {
+          "name": "knowledge_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "version_text": {
+          "name": "version_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "knowledgeentry_name_idx": {
+          "name": "knowledgeentry_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_created_at_idx": {
+          "name": "knowledgeentry_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_updated_at_idx": {
+          "name": "knowledgeentry_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_deleted_at_idx": {
+          "name": "knowledgeentry_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_tenant_id_idx": {
+          "name": "knowledgeentry_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_entry_team_id_idx": {
+          "name": "knowledge_entry_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_entry_user_id_idx": {
+          "name": "knowledge_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_entry_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_entry_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_entry_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_user_id_base_users_id_fk": {
+          "name": "base_knowledge_entry_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_knowledge_group_id_base_knowledge_group_id_fk": {
+          "name": "base_knowledge_entry_knowledge_group_id_base_knowledge_group_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_knowledge_group",
+          "columnsFrom": [
+            "knowledge_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_parentId_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_entry_parentId_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_entry_description_max_length": {
+          "name": "knowledge_entry_description_max_length",
+          "value": "length(description) <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_filters": {
+      "name": "base_knowledge_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_filters_name_type_unique": {
+          "name": "knowledge_filters_name_type_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_filters_category_name_idx": {
+          "name": "knowledge_filters_category_name_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_filters_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_filters_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_filters",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_group": {
+      "name": "base_knowledge_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide_access": {
+          "name": "tenant_wide_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_group_tenant_id_idx": {
+          "name": "knowledge_group_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_group_user_id_idx": {
+          "name": "knowledge_group_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_group_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_group_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_group",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_group_user_id_base_users_id_fk": {
+          "name": "base_knowledge_group_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_group",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_group_name_org_idx": {
+          "name": "knowledge_group_name_org_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "tenant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_group_team_assignments": {
+      "name": "base_knowledge_group_team_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_group_id": {
+          "name": "knowledge_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_group_team_assignment_knowledge_group_id_idx": {
+          "name": "knowledge_group_team_assignment_knowledge_group_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_group_team_assignment_team_id_idx": {
+          "name": "knowledge_group_team_assignment_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_group_team_assignments_knowledge_group_id_base_knowledge_group_id_fk": {
+          "name": "base_knowledge_group_team_assignments_knowledge_group_id_base_knowledge_group_id_fk",
+          "tableFrom": "base_knowledge_group_team_assignments",
+          "tableTo": "base_knowledge_group",
+          "columnsFrom": [
+            "knowledge_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_group_team_assignments_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_group_team_assignments_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_group_team_assignments",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_group_team_assignment_unique": {
+          "name": "knowledge_group_team_assignment_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "knowledge_group_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text": {
+      "name": "base_knowledge_text",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "knowledge_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_enabled": {
+          "name": "embedding_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "knowledge_entry_id": {
+          "name": "knowledge_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "knowledge_text_created_at_idx": {
+          "name": "knowledge_text_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_updated_at_idx": {
+          "name": "knowledge_text_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_deleted_at_idx": {
+          "name": "knowledge_text_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_title_idx": {
+          "name": "knowledge_text_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_tenant_id_idx": {
+          "name": "knowledge_text_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_team_id_idx": {
+          "name": "knowledge_text_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_user_id_idx": {
+          "name": "knowledge_text_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_parent_id_idx": {
+          "name": "knowledge_text_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_fts_idx": {
+          "name": "knowledge_text_fts_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', coalesce(\"title\", '') || ' ' || coalesce(\"text\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_text_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_user_id_base_users_id_fk": {
+          "name": "base_knowledge_text_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_parent_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_parent_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_knowledge_entry_id_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_text_knowledge_entry_id_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "knowledge_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_block": {
+      "name": "base_knowledge_text_block",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_text_id": {
+          "name": "knowledge_text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "knowledge_block_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'markdown'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_block_page_position_idx": {
+          "name": "knowledge_text_block_page_position_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_block_knowledge_text_id_idx": {
+          "name": "knowledge_text_block_knowledge_text_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_block_tenant_id_idx": {
+          "name": "knowledge_text_block_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_block_knowledge_text_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_block_knowledge_text_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_block",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "knowledge_text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_block_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_block_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_block",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_history": {
+      "name": "base_knowledge_text_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_text_id": {
+          "name": "knowledge_text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "knowledge_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_history_knowledge_text_id_idx": {
+          "name": "knowledge_text_history_knowledge_text_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_history_tenant_id_idx": {
+          "name": "knowledge_text_history_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_history_created_at_idx": {
+          "name": "knowledge_text_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_history_knowledge_text_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_history_knowledge_text_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "knowledge_text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_history_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_text_history_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_user_id_base_users_id_fk": {
+          "name": "base_knowledge_text_history_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_link": {
+      "name": "base_knowledge_text_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_link_source_id_idx": {
+          "name": "knowledge_text_link_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_link_target_id_idx": {
+          "name": "knowledge_text_link_target_id_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_link_tenant_target_title_idx": {
+          "name": "knowledge_text_link_tenant_target_title_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_link_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_link_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_link",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_link_source_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_link_source_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_link",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_link_target_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_link_target_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_link",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_text_link_source_target_unique": {
+          "name": "knowledge_text_link_source_target_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "target_title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_jobs": {
+      "name": "base_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_created_at_idx": {
+          "name": "jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_user_id_idx": {
+          "name": "jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_status_idx": {
+          "name": "jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_scheduled_at_idx": {
+          "name": "jobs_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_jobs_user_id_base_users_id_fk": {
+          "name": "base_jobs_user_id_base_users_id_fk",
+          "tableFrom": "base_jobs",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_jobs_tenant_id_base_tenants_id_fk": {
+          "name": "base_jobs_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_jobs",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_app_logs": {
+      "name": "base_app_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_logs_level_idx": {
+          "name": "app_logs_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_category_idx": {
+          "name": "app_logs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_source_idx": {
+          "name": "app_logs_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_created_at_idx": {
+          "name": "app_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_version_idx": {
+          "name": "app_logs_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_tenant_id_idx": {
+          "name": "app_logs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_app_logs_tenant_id_base_tenants_id_fk": {
+          "name": "base_app_logs_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_app_logs",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_webhooks": {
+      "name": "base_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "webhook_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "webhook_event",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "webhook_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POST'"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_tenant_id_idx": {
+          "name": "webhooks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_name_tenant_id_idx": {
+          "name": "webhooks_name_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "webhook_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_webhooks_user_id_base_users_id_fk": {
+          "name": "base_webhooks_user_id_base_users_id_fk",
+          "tableFrom": "base_webhooks",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_webhooks_tenant_id_base_tenants_id_fk": {
+          "name": "base_webhooks_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_webhooks",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_server_keys": {
+      "name": "base_server_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_server_settings": {
+      "name": "base_server_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_key": {
+          "name": "unique_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_api_tokens": {
+      "name": "base_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "auto_delete": {
+          "name": "auto_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "api_tokens_user_id_idx": {
+          "name": "api_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_tenant_id_idx": {
+          "name": "api_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_auto_delete_idx": {
+          "name": "api_tokens_auto_delete_idx",
+          "columns": [
+            {
+              "expression": "auto_delete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_api_tokens_user_id_base_users_id_fk": {
+          "name": "base_api_tokens_user_id_base_users_id_fk",
+          "tableFrom": "base_api_tokens",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_api_tokens_tenant_id_base_tenants_id_fk": {
+          "name": "base_api_tokens_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_api_tokens",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_idx": {
+          "name": "api_tokens_token_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_connections": {
+      "name": "base_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_connection_id": {
+          "name": "remote_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_public_key": {
+          "name": "remote_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_tenant_id": {
+          "name": "remote_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "initiated_by",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "role": {
+          "name": "role",
+          "type": "connection_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'leading'"
+        },
+        "status": {
+          "name": "status",
+          "type": "connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "connections_tenant_idx": {
+          "name": "connections_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_remote_url_idx": {
+          "name": "connections_remote_url_idx",
+          "columns": [
+            {
+              "expression": "remote_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_tenant_name_initiated_by_unique_idx": {
+          "name": "connections_tenant_name_initiated_by_unique_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "initiated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_tenant_remote_connection_id_initiated_by_unique_idx": {
+          "name": "connections_tenant_remote_connection_id_initiated_by_unique_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "initiated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_connections_tenant_id_base_tenants_id_fk": {
+          "name": "base_connections_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_connections",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_clients": {
+      "name": "base_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_type": {
+          "name": "client_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confidential'"
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_clients_tenant_id_idx": {
+          "name": "oauth_clients_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_clients_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_clients_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_clients",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_clients_created_by_base_users_id_fk": {
+          "name": "base_oauth_clients_created_by_base_users_id_fk",
+          "tableFrom": "base_oauth_clients",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_auth_codes": {
+      "name": "base_oauth_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_auth_codes_code_hash_idx": {
+          "name": "oauth_auth_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_auth_codes_expires_at_idx": {
+          "name": "oauth_auth_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_auth_codes_user_id_base_users_id_fk": {
+          "name": "base_oauth_auth_codes_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_auth_codes",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_auth_codes_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_auth_codes_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_auth_codes",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_refresh_tokens": {
+      "name": "base_oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotated_to": {
+          "name": "rotated_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_refresh_tokens_user_id_base_users_id_fk": {
+          "name": "base_oauth_refresh_tokens_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_refresh_tokens",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_refresh_tokens_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_refresh_tokens_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_refresh_tokens",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_consents": {
+      "name": "base_oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consents_user_client_idx": {
+          "name": "oauth_consents_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consents_user_id_idx": {
+          "name": "oauth_consents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_consents_user_id_base_users_id_fk": {
+          "name": "base_oauth_consents_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_consents",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_email_login_codes": {
+      "name": "base_email_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oauth_login'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_login_codes_email_idx": {
+          "name": "email_login_codes_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_login_codes_expires_at_idx": {
+          "name": "email_login_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_settings": {
+      "name": "base_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_user_settings_key_unique": {
+          "name": "base_user_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.magic_link_purpose": {
+      "name": "magic_link_purpose",
+      "schema": "public",
+      "values": [
+        "login",
+        "email_verification",
+        "password_reset"
+      ]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error"
+      ]
+    },
+    "public.permission_type": {
+      "name": "permission_type",
+      "schema": "public",
+      "values": [
+        "regex"
+      ]
+    },
+    "public.team_member_role": {
+      "name": "team_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.tenant_invitation_status": {
+      "name": "tenant_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined"
+      ]
+    },
+    "public.tenant_member_role": {
+      "name": "tenant_member_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.tenant_origin": {
+      "name": "tenant_origin",
+      "schema": "public",
+      "values": [
+        "local",
+        "remote"
+      ]
+    },
+    "public.user_provider": {
+      "name": "user_provider",
+      "schema": "public",
+      "values": [
+        "local",
+        "google",
+        "microsoft",
+        "auth0",
+        "hanko"
+      ]
+    },
+    "public.file_source_type": {
+      "name": "file_source_type",
+      "schema": "public",
+      "values": [
+        "db",
+        "local",
+        "url",
+        "text",
+        "finetuning",
+        "plugin",
+        "external"
+      ]
+    },
+    "public.knowledge_block_type": {
+      "name": "knowledge_block_type",
+      "schema": "public",
+      "values": [
+        "markdown",
+        "html"
+      ]
+    },
+    "public.knowledge_content_mode": {
+      "name": "knowledge_content_mode",
+      "schema": "public",
+      "values": [
+        "text",
+        "blocks"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ]
+    },
+    "public.webhook_event": {
+      "name": "webhook_event",
+      "schema": "public",
+      "values": [
+        "chat-output",
+        "tool"
+      ]
+    },
+    "public.webhook_method": {
+      "name": "webhook_method",
+      "schema": "public",
+      "values": [
+        "POST",
+        "GET"
+      ]
+    },
+    "public.webhook_type": {
+      "name": "webhook_type",
+      "schema": "public",
+      "values": [
+        "n8n"
+      ]
+    },
+    "public.connection_role": {
+      "name": "connection_role",
+      "schema": "public",
+      "values": [
+        "leading",
+        "following"
+      ]
+    },
+    "public.connection_status": {
+      "name": "connection_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disconnected",
+        "revoked"
+      ]
+    },
+    "public.initiated_by": {
+      "name": "initiated_by",
+      "schema": "public",
+      "values": [
+        "local",
+        "remote"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-sql/meta/_journal.json
+++ b/drizzle-sql/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1783861346982,
       "tag": "0017_handy_thunderball",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1783863956571,
+      "tag": "0018_massive_sebastian_shaw",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema/knowledge.ts
+++ b/src/lib/db/schema/knowledge.ts
@@ -110,6 +110,12 @@ export const knowledgeText = pgBaseTable(
     index("knowledge_text_team_id_idx").on(knowledgeText.teamId),
     index("knowledge_text_user_id_idx").on(knowledgeText.userId),
     index("knowledge_text_parent_id_idx").on(knowledgeText.parentId),
+    // full-text search over title + content ('simple' config: language-
+    // agnostic, works for mixed German/English wikis)
+    index("knowledge_text_fts_idx").using(
+      "gin",
+      sql`to_tsvector('simple', coalesce(${knowledgeText.title}, '') || ' ' || coalesce(${knowledgeText.text}, ''))`
+    ),
   ]
 );
 
@@ -233,6 +239,54 @@ export const knowledgeTextBlock = pgBaseTable(
 
 export type KnowledgeTextBlockSelect = typeof knowledgeTextBlock.$inferSelect;
 export type KnowledgeTextBlockInsert = typeof knowledgeTextBlock.$inferInsert;
+
+// Obsidian-style wikilinks between knowledgeText pages, extracted from
+// [[Target Title]] / [[Target Title|alias]] markers on every content save.
+// targetId is null while the linked title has no matching page yet
+// ("phantom link"); it is resolved automatically when such a page appears
+// and cleared again (ON DELETE SET NULL) when the target is deleted.
+export const knowledgeTextLink = pgBaseTable(
+  "knowledge_text_link",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    tenantId: uuid("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    sourceId: uuid("source_id")
+      .notNull()
+      .references(() => knowledgeText.id, { onDelete: "cascade" }),
+    targetId: uuid("target_id").references(() => knowledgeText.id, {
+      onDelete: "set null",
+    }),
+    // the raw link target as written in the content — survives target
+    // deletion and is used to (re-)resolve the link by title
+    targetTitle: varchar("target_title", { length: 1000 }).notNull(),
+    createdAt: timestamp("created_at", { mode: "string" })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique("knowledge_text_link_source_target_unique").on(
+      table.sourceId,
+      table.targetTitle
+    ),
+    index("knowledge_text_link_source_id_idx").on(table.sourceId),
+    index("knowledge_text_link_target_id_idx").on(table.targetId),
+    index("knowledge_text_link_tenant_target_title_idx").on(
+      table.tenantId,
+      table.targetTitle
+    ),
+  ]
+);
+
+export type KnowledgeTextLinkSelect = typeof knowledgeTextLink.$inferSelect;
+export type KnowledgeTextLinkInsert = typeof knowledgeTextLink.$inferInsert;
+
+export const knowledgeTextLinkSchema = createSelectSchema(knowledgeTextLink);
+export const knowledgeTextLinkInsertSchema =
+  createInsertSchema(knowledgeTextLink);
 
 export const knowledgeTextBlockSchema = createSelectSchema(knowledgeTextBlock);
 export const knowledgeTextBlockInsertSchema =
@@ -568,6 +622,20 @@ export const knowledgeTextRelations = relations(
     knowledgeEntry: one(knowledgeEntry, {
       fields: [knowledgeText.knowledgeEntryId],
       references: [knowledgeEntry.id],
+    }),
+  })
+);
+
+export const knowledgeTextLinkRelations = relations(
+  knowledgeTextLink,
+  ({ one }) => ({
+    source: one(knowledgeText, {
+      fields: [knowledgeTextLink.sourceId],
+      references: [knowledgeText.id],
+    }),
+    target: one(knowledgeText, {
+      fields: [knowledgeTextLink.targetId],
+      references: [knowledgeText.id],
     }),
   })
 );

--- a/src/lib/knowledge/knowledge-text-blocks.ts
+++ b/src/lib/knowledge/knowledge-text-blocks.ts
@@ -32,6 +32,7 @@ import { getKnowledgeTextById } from "./knowledge-texts";
 import { checkTenantMemberRole } from "../usermanagement/tenants";
 import { checkTeamMemberRole } from "../usermanagement/teams";
 import { syncKnowledgeTextEmbeddingSafe } from "./knowledge-text-embedding";
+import { syncKnowledgeTextLinks } from "./knowledge-text-links";
 
 /** Minimum age of the newest history entry before a new snapshot is written */
 export const HISTORY_COALESCE_MINUTES = 10;
@@ -325,6 +326,12 @@ export const syncKnowledgeTextBlocks = async (
           updatedAt: sql`now()`,
         })
         .where(eq(knowledgeText.id, knowledgeTextId));
+    });
+
+    await syncKnowledgeTextLinks({
+      id: knowledgeTextId,
+      tenantId: page.tenantId,
+      text: newText,
     });
 
     if (page.embeddingEnabled && !options?.skipEmbeddingSync) {

--- a/src/lib/knowledge/knowledge-text-edit.test.ts
+++ b/src/lib/knowledge/knowledge-text-edit.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import {
+  readKnowledgeTextContent,
+  editKnowledgeTextContent,
+} from "./knowledge-text-edit";
+import { createKnowledgeText } from "./knowledge-texts";
+import {
+  syncKnowledgeTextBlocks,
+  getKnowledgeTextBlocks,
+} from "./knowledge-text-blocks";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+
+const ctx = { tenantId: TEST_ORGANISATION_1.id };
+
+const createPage = async (text: string) =>
+  await createKnowledgeText({
+    title: `Edit Test ${crypto.randomUUID()}`,
+    text,
+    tenantId: TEST_ORGANISATION_1.id,
+  });
+
+describe("Knowledge Text Read (file-like)", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("reads the full content with line metadata", async () => {
+    const page = await createPage("line one\nline two\nline three");
+    const view = await readKnowledgeTextContent(page.id, ctx);
+
+    expect(view.content).toBe("line one\nline two\nline three");
+    expect(view.fromLine).toBe(1);
+    expect(view.toLine).toBe(3);
+    expect(view.totalLines).toBe(3);
+    expect(view.contentMode).toBe("text");
+  });
+
+  it("reads a line range", async () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`);
+    const page = await createPage(lines.join("\n"));
+
+    const view = await readKnowledgeTextContent(page.id, ctx, {
+      fromLine: 5,
+      maxLines: 3,
+    });
+
+    expect(view.content).toBe("line 5\nline 6\nline 7");
+    expect(view.fromLine).toBe(5);
+    expect(view.toLine).toBe(7);
+    expect(view.totalLines).toBe(20);
+  });
+
+  it("rejects fromLine beyond the end", async () => {
+    const page = await createPage("only one line");
+    await expect(
+      readKnowledgeTextContent(page.id, ctx, { fromLine: 99 })
+    ).rejects.toThrow("beyond the end");
+  });
+});
+
+describe("Knowledge Text Edit (string replacement)", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("replaces a unique string in a text page", async () => {
+    const page = await createPage("The old value should change.");
+    const result = await editKnowledgeTextContent(
+      page.id,
+      { oldString: "old value", newString: "new value" },
+      ctx
+    );
+
+    expect(result.replacements).toBe(1);
+    expect(result.content).toBe("The new value should change.");
+  });
+
+  it("rejects a non-unique string without replaceAll", async () => {
+    const page = await createPage("dup here and dup there");
+    await expect(
+      editKnowledgeTextContent(
+        page.id,
+        { oldString: "dup", newString: "x" },
+        ctx
+      )
+    ).rejects.toThrow("not unique");
+  });
+
+  it("replaces all occurrences with replaceAll", async () => {
+    const page = await createPage("dup here and dup there");
+    const result = await editKnowledgeTextContent(
+      page.id,
+      { oldString: "dup", newString: "item", replaceAll: true },
+      ctx
+    );
+    expect(result.replacements).toBe(2);
+    expect(result.content).toBe("item here and item there");
+  });
+
+  it("rejects a string that does not exist", async () => {
+    const page = await createPage("some content");
+    await expect(
+      editKnowledgeTextContent(
+        page.id,
+        { oldString: "missing", newString: "x" },
+        ctx
+      )
+    ).rejects.toThrow("not found in the document");
+  });
+
+  it("edits inside the affected block of a block page", async () => {
+    const page = await createPage("");
+    const saved = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "# Stable heading" },
+        { type: "markdown", content: "Body with a typo_here inside." },
+      ],
+      ctx
+    );
+
+    const result = await editKnowledgeTextContent(
+      page.id,
+      { oldString: "typo_here", newString: "correction" },
+      ctx
+    );
+    expect(result.replacements).toBe(1);
+    expect(result.content).toContain("correction");
+
+    // only the affected block changed, ids stayed stable
+    const blocks = await getKnowledgeTextBlocks(page.id, ctx);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0]?.id).toBe(saved.blocks[0]!.id);
+    expect(blocks[0]?.content).toBe("# Stable heading");
+    expect(blocks[1]?.id).toBe(saved.blocks[1]!.id);
+    expect(blocks[1]?.content).toBe("Body with a correction inside.");
+  });
+
+  it("rejects an oldString that spans block boundaries", async () => {
+    const page = await createPage("");
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "end of first" },
+        { type: "markdown", content: "start of second" },
+      ],
+      ctx
+    );
+
+    // this string only exists in the materialized text across the block gap
+    await expect(
+      editKnowledgeTextContent(
+        page.id,
+        { oldString: "end of first\n\nstart of second", newString: "x" },
+        ctx
+      )
+    ).rejects.toThrow("spans multiple blocks");
+  });
+
+  it("counts occurrences across blocks for uniqueness", async () => {
+    const page = await createPage("");
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "shared word" },
+        { type: "markdown", content: "another shared word" },
+      ],
+      ctx
+    );
+
+    await expect(
+      editKnowledgeTextContent(
+        page.id,
+        { oldString: "shared", newString: "x" },
+        ctx
+      )
+    ).rejects.toThrow("not unique");
+
+    const result = await editKnowledgeTextContent(
+      page.id,
+      { oldString: "shared", newString: "common", replaceAll: true },
+      ctx
+    );
+    expect(result.replacements).toBe(2);
+  });
+
+  it("rejects empty or identical strings", async () => {
+    const page = await createPage("content");
+    await expect(
+      editKnowledgeTextContent(
+        page.id,
+        { oldString: "", newString: "x" },
+        ctx
+      )
+    ).rejects.toThrow("must not be empty");
+    await expect(
+      editKnowledgeTextContent(
+        page.id,
+        { oldString: "content", newString: "content" },
+        ctx
+      )
+    ).rejects.toThrow("identical");
+  });
+});

--- a/src/lib/knowledge/knowledge-text-edit.ts
+++ b/src/lib/knowledge/knowledge-text-edit.ts
@@ -1,0 +1,188 @@
+/**
+ * Filesystem-like content access for knowledgeText pages, designed for AI
+ * agents that work with pages the way coding agents work with files:
+ *
+ *   - `readKnowledgeTextContent` — read the page text, optionally a line
+ *     range (like `Read` with offset/limit), with line-count metadata so
+ *     the agent can page through long documents
+ *   - `editKnowledgeTextContent` — exact string replacement (like `Edit`
+ *     with old_string/new_string/replaceAll), applied safely to both plain
+ *     text pages and block pages
+ *
+ * Edits on block pages are applied inside the affected block(s), then run
+ * through the normal block sync, so text cache, history, wikilinks and the
+ * embedding mirror all stay consistent.
+ */
+
+import {
+  getKnowledgeTextById,
+  updateKnowledgeText,
+} from "./knowledge-texts";
+import {
+  getKnowledgeTextBlocks,
+  syncKnowledgeTextBlocks,
+} from "./knowledge-text-blocks";
+
+type Context = {
+  tenantId: string;
+  userId?: string;
+  teamId?: string;
+  workspaceId?: string;
+  includeHidden?: boolean;
+};
+
+export type KnowledgeTextContentView = {
+  id: string;
+  title: string;
+  contentMode: "text" | "blocks";
+  /** requested slice of the content */
+  content: string;
+  /** 1-based line number of the first returned line */
+  fromLine: number;
+  /** 1-based line number of the last returned line */
+  toLine: number;
+  totalLines: number;
+};
+
+/**
+ * Read a page's content, optionally restricted to a line range.
+ * `fromLine` is 1-based; `maxLines` limits how many lines are returned.
+ */
+export const readKnowledgeTextContent = async (
+  id: string,
+  context: Context,
+  options?: { fromLine?: number; maxLines?: number }
+): Promise<KnowledgeTextContentView> => {
+  const page = await getKnowledgeTextById(id, context);
+  const lines = page.text.split("\n");
+  const totalLines = lines.length;
+
+  const fromLine = Math.max(1, options?.fromLine ?? 1);
+  const maxLines = options?.maxLines ?? totalLines;
+  if (options?.fromLine !== undefined && fromLine > totalLines) {
+    throw new Error(
+      `fromLine ${fromLine} is beyond the end of the document (${totalLines} lines)`
+    );
+  }
+  const slice = lines.slice(fromLine - 1, fromLine - 1 + Math.max(0, maxLines));
+
+  return {
+    id: page.id,
+    title: page.title,
+    contentMode: page.contentMode,
+    content: slice.join("\n"),
+    fromLine,
+    toLine: fromLine + Math.max(0, slice.length - 1),
+    totalLines,
+  };
+};
+
+const countOccurrences = (haystack: string, needle: string): number => {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let index = 0;
+  while ((index = haystack.indexOf(needle, index)) !== -1) {
+    count++;
+    index += needle.length;
+  }
+  return count;
+};
+
+const replaceAllOccurrences = (
+  haystack: string,
+  needle: string,
+  replacement: string
+): string => haystack.split(needle).join(replacement);
+
+export type EditKnowledgeTextResult = {
+  id: string;
+  replacements: number;
+  /** the page text after the edit */
+  content: string;
+};
+
+/**
+ * Exact string replacement in a page's content.
+ *
+ * - `oldString` must occur in the page; with `replaceAll: false` (default)
+ *   it must occur exactly once, otherwise the edit is rejected with a
+ *   descriptive error (agents then send a longer, unique string)
+ * - on block pages the replacement happens inside the affected blocks; an
+ *   `oldString` spanning two blocks is rejected with a clear error
+ */
+export const editKnowledgeTextContent = async (
+  id: string,
+  edit: { oldString: string; newString: string; replaceAll?: boolean },
+  context: Context
+): Promise<EditKnowledgeTextResult> => {
+  const { oldString, newString, replaceAll = false } = edit;
+  if (oldString.length === 0) {
+    throw new Error("oldString must not be empty");
+  }
+  if (oldString === newString) {
+    throw new Error("oldString and newString are identical");
+  }
+
+  const page = await getKnowledgeTextById(id, context);
+
+  // ----- plain text pages -------------------------------------------------
+  if (page.contentMode === "text") {
+    const occurrences = countOccurrences(page.text, oldString);
+    if (occurrences === 0) {
+      throw new Error("oldString not found in the document");
+    }
+    if (occurrences > 1 && !replaceAll) {
+      throw new Error(
+        `oldString is not unique (${occurrences} occurrences). ` +
+          "Provide more surrounding context or set replaceAll: true"
+      );
+    }
+    const newText = replaceAllOccurrences(page.text, oldString, newString);
+    const updated = await updateKnowledgeText(id, { text: newText }, context);
+    return { id, replacements: occurrences, content: updated.text };
+  }
+
+  // ----- block pages ------------------------------------------------------
+  const blocks = await getKnowledgeTextBlocks(id, context);
+  const occurrencesPerBlock = blocks.map((block) =>
+    countOccurrences(block.content, oldString)
+  );
+  const totalOccurrences = occurrencesPerBlock.reduce((a, b) => a + b, 0);
+
+  if (totalOccurrences === 0) {
+    // distinguish "not present at all" from "spans block boundaries"
+    if (countOccurrences(page.text, oldString) > 0) {
+      throw new Error(
+        "oldString spans multiple blocks. Edit the blocks individually " +
+          "(PUT .../blocks) or use a shorter string within one block"
+      );
+    }
+    throw new Error("oldString not found in the document");
+  }
+  if (totalOccurrences > 1 && !replaceAll) {
+    throw new Error(
+      `oldString is not unique (${totalOccurrences} occurrences). ` +
+        "Provide more surrounding context or set replaceAll: true"
+    );
+  }
+
+  const result = await syncKnowledgeTextBlocks(
+    id,
+    blocks.map((block, i) => ({
+      id: block.id,
+      type: block.type,
+      content:
+        occurrencesPerBlock[i]! > 0
+          ? replaceAllOccurrences(block.content, oldString, newString)
+          : block.content,
+      meta: (block.meta ?? {}) as Record<string, unknown>,
+    })),
+    context
+  );
+
+  return {
+    id,
+    replacements: totalOccurrences,
+    content: result.knowledgeText.text,
+  };
+};

--- a/src/lib/knowledge/knowledge-text-embedding.test.ts
+++ b/src/lib/knowledge/knowledge-text-embedding.test.ts
@@ -72,6 +72,17 @@ describe("Knowledge Text Embedding (no provider required)", () => {
   it("builds a stable source identifier", () => {
     expect(knowledgeTextSourceIdentifier("abc")).toBe("knowledge-text:abc");
   });
+
+  it("creating an embedding-enabled page never fails without a provider", async () => {
+    // the initial sync on create is best-effort: without a provider it
+    // logs and the page is still created
+    const page = await createPage({
+      text: "content that would be embedded",
+      embeddingEnabled: true,
+    });
+    expect(page.id).toBeDefined();
+    expect(page.knowledgeEntryId).toBeNull();
+  });
 });
 
 describe.skipIf(!hasEmbeddingProvider)(
@@ -81,14 +92,24 @@ describe.skipIf(!hasEmbeddingProvider)(
       await initTests();
     });
 
+    it("embeds a page directly on create when embeddingEnabled is set", async () => {
+      const page = await createPage({
+        text: "Pages created with embedding on are synced immediately.",
+        embeddingEnabled: true,
+      });
+      // create already ran the initial sync
+      expect(page.knowledgeEntryId).toBeDefined();
+      expect(page.knowledgeEntryId).not.toBeNull();
+    }, 30000);
+
     it("creates a knowledge entry on first sync and links it", async () => {
       const page = await createPage({
         text: "This wiki page explains our vacation policy in detail.",
-        embeddingEnabled: true,
+        embeddingEnabled: false,
       });
+      await updateKnowledgeText(page.id, { embeddingEnabled: true }, ctx);
 
       const result = await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
-      expect(result.synced).toBe(true);
       expect(result.knowledgeEntryId).toBeDefined();
 
       const fresh = await getKnowledgeTextById(page.id, ctx);

--- a/src/lib/knowledge/knowledge-text-links.test.ts
+++ b/src/lib/knowledge/knowledge-text-links.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import {
+  extractWikilinkTargets,
+  getKnowledgeTextLinks,
+  getKnowledgeTextBacklinks,
+  getRelatedKnowledgeTexts,
+} from "./knowledge-text-links";
+import {
+  createKnowledgeText,
+  updateKnowledgeText,
+  deleteKnowledgeText,
+} from "./knowledge-texts";
+import { syncKnowledgeTextBlocks } from "./knowledge-text-blocks";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+
+const ctx = { tenantId: TEST_ORGANISATION_1.id };
+
+const uniqueTitle = (name: string) => `${name} ${crypto.randomUUID()}`;
+
+describe("extractWikilinkTargets", () => {
+  it("extracts plain and aliased wikilinks", () => {
+    const targets = extractWikilinkTargets(
+      "See [[Vacation Policy]] and [[Home Office|working from home]]."
+    );
+    expect(targets).toEqual(["Vacation Policy", "Home Office"]);
+  });
+
+  it("deduplicates and trims targets", () => {
+    const targets = extractWikilinkTargets(
+      "[[ Onboarding ]] then [[Onboarding]] again"
+    );
+    expect(targets).toEqual(["Onboarding"]);
+  });
+
+  it("ignores malformed markers", () => {
+    expect(extractWikilinkTargets("[[]] [[|only alias]] [not a link]")).toEqual(
+      []
+    );
+  });
+});
+
+describe("Knowledge Text Links", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("resolves links to existing pages on save", async () => {
+    const targetTitle = uniqueTitle("Link Target");
+    const target = await createKnowledgeText({
+      title: targetTitle,
+      text: "target content",
+      tenantId: ctx.tenantId,
+    });
+
+    const source = await createKnowledgeText({
+      title: uniqueTitle("Link Source"),
+      text: `Please read [[${targetTitle}]] first.`,
+      tenantId: ctx.tenantId,
+    });
+
+    const links = await getKnowledgeTextLinks(source.id, ctx);
+    expect(links.length).toBe(1);
+    expect(links[0]?.resolved).toBe(true);
+    expect(links[0]?.page?.id).toBe(target.id);
+
+    const backlinks = await getKnowledgeTextBacklinks(target.id, ctx);
+    expect(backlinks.some((b) => b.page.id === source.id)).toBe(true);
+  });
+
+  it("keeps phantom links and resolves them when the page appears", async () => {
+    const futureTitle = uniqueTitle("Future Page");
+    const source = await createKnowledgeText({
+      title: uniqueTitle("Early Bird"),
+      text: `This links to [[${futureTitle}]] which does not exist yet.`,
+      tenantId: ctx.tenantId,
+    });
+
+    let links = await getKnowledgeTextLinks(source.id, ctx);
+    expect(links[0]?.resolved).toBe(false);
+    expect(links[0]?.page).toBeNull();
+    expect(links[0]?.targetTitle).toBe(futureTitle);
+
+    // now the target page gets created → the phantom link snaps into place
+    const target = await createKnowledgeText({
+      title: futureTitle,
+      text: "now I exist",
+      tenantId: ctx.tenantId,
+    });
+
+    links = await getKnowledgeTextLinks(source.id, ctx);
+    expect(links[0]?.resolved).toBe(true);
+    expect(links[0]?.page?.id).toBe(target.id);
+  });
+
+  it("resolves phantom links on rename", async () => {
+    const wantedTitle = uniqueTitle("Renamed Target");
+    const source = await createKnowledgeText({
+      title: uniqueTitle("Waiting Source"),
+      text: `Link to [[${wantedTitle}]].`,
+      tenantId: ctx.tenantId,
+    });
+    const page = await createKnowledgeText({
+      title: uniqueTitle("Old Name"),
+      text: "content",
+      tenantId: ctx.tenantId,
+    });
+
+    await updateKnowledgeText(page.id, { title: wantedTitle }, ctx);
+
+    const links = await getKnowledgeTextLinks(source.id, ctx);
+    expect(links[0]?.resolved).toBe(true);
+    expect(links[0]?.page?.id).toBe(page.id);
+  });
+
+  it("turns links back into phantom links when the target is deleted", async () => {
+    const targetTitle = uniqueTitle("Doomed Page");
+    const target = await createKnowledgeText({
+      title: targetTitle,
+      text: "soon gone",
+      tenantId: ctx.tenantId,
+    });
+    const source = await createKnowledgeText({
+      title: uniqueTitle("Survivor"),
+      text: `Points at [[${targetTitle}]].`,
+      tenantId: ctx.tenantId,
+    });
+
+    await deleteKnowledgeText(target.id, ctx);
+
+    const links = await getKnowledgeTextLinks(source.id, ctx);
+    expect(links[0]?.resolved).toBe(false);
+    expect(links[0]?.targetTitle).toBe(targetTitle);
+  });
+
+  it("updates links when content is edited via block sync", async () => {
+    const firstTitle = uniqueTitle("First Target");
+    const secondTitle = uniqueTitle("Second Target");
+    await createKnowledgeText({
+      title: firstTitle,
+      text: "a",
+      tenantId: ctx.tenantId,
+    });
+    const second = await createKnowledgeText({
+      title: secondTitle,
+      text: "b",
+      tenantId: ctx.tenantId,
+    });
+
+    const page = await createKnowledgeText({
+      title: uniqueTitle("Block Linker"),
+      text: "",
+      tenantId: ctx.tenantId,
+    });
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: `Linking [[${firstTitle}]]` }],
+      ctx
+    );
+    let links = await getKnowledgeTextLinks(page.id, ctx);
+    expect(links.map((l) => l.targetTitle)).toEqual([firstTitle]);
+
+    // replace the content → old link disappears, new link appears
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: `Linking [[${secondTitle}]] now` }],
+      ctx
+    );
+    links = await getKnowledgeTextLinks(page.id, ctx);
+    expect(links.map((l) => l.targetTitle)).toEqual([secondTitle]);
+    expect(links[0]?.page?.id).toBe(second.id);
+  });
+
+  it("resolves titles case-insensitively", async () => {
+    const title = uniqueTitle("CaseSensitive Page");
+    const target = await createKnowledgeText({
+      title,
+      text: "x",
+      tenantId: ctx.tenantId,
+    });
+    const source = await createKnowledgeText({
+      title: uniqueTitle("Case Linker"),
+      text: `See [[${title.toUpperCase()}]]`,
+      tenantId: ctx.tenantId,
+    });
+
+    const links = await getKnowledgeTextLinks(source.id, ctx);
+    expect(links[0]?.resolved).toBe(true);
+    expect(links[0]?.page?.id).toBe(target.id);
+  });
+
+  it("returns empty related list for pages without embeddings", async () => {
+    const page = await createKnowledgeText({
+      title: uniqueTitle("No Embedding"),
+      text: "content without embedding",
+      tenantId: ctx.tenantId,
+    });
+    const related = await getRelatedKnowledgeTexts(page.id, ctx);
+    expect(related).toEqual([]);
+  });
+});

--- a/src/lib/knowledge/knowledge-text-links.ts
+++ b/src/lib/knowledge/knowledge-text-links.ts
@@ -1,0 +1,313 @@
+/**
+ * Obsidian-style wikilinks between knowledgeText pages.
+ *
+ * Pages link to each other with `[[Target Title]]` (or `[[Target Title|shown
+ * text]]`) anywhere in their markdown/html content. On every content save the
+ * links of the page are re-extracted and stored in knowledge_text_link:
+ *
+ *   - resolved links carry the target page's id
+ *   - links to titles that don't exist yet are kept as "phantom links"
+ *     (targetId = null) and resolve automatically once a page with that
+ *     title is created or renamed to it — exactly like Obsidian
+ *   - deleting a target page turns its incoming links back into phantom
+ *     links (FK ON DELETE SET NULL)
+ *
+ * On top of the explicit link graph, `getRelatedKnowledgeTexts` suggests
+ * semantically similar pages via the stored chunk embeddings (no query
+ * embedding needed, so it works without an embedding provider at runtime).
+ */
+
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import {
+  knowledgeText,
+  knowledgeTextLink,
+  knowledgeChunks,
+  type KnowledgeTextLinkSelect,
+} from "../db/schema/knowledge";
+import {
+  getKnowledgeTextById,
+  buildKnowledgeTextVisibilityConditions,
+} from "./knowledge-texts";
+
+type Context = {
+  tenantId: string;
+  userId?: string;
+  teamId?: string;
+  workspaceId?: string;
+  includeHidden?: boolean;
+};
+
+/** [[Target]] or [[Target|alias]] — target must not contain [, ] or | */
+const WIKILINK_PATTERN = /\[\[([^\[\]|]+)(?:\|[^\[\]]*)?\]\]/g;
+
+/** Extract the distinct wikilink targets from a page's content */
+export const extractWikilinkTargets = (content: string): string[] => {
+  const targets = new Set<string>();
+  for (const match of content.matchAll(WIKILINK_PATTERN)) {
+    const target = match[1]?.trim();
+    if (target) targets.add(target);
+  }
+  return [...targets];
+};
+
+/** Case-insensitive title → page id lookup within a tenant */
+const resolveTitles = async (
+  tenantId: string,
+  titles: string[]
+): Promise<Map<string, string>> => {
+  if (titles.length === 0) return new Map();
+  const rows = await getDb()
+    .select({ id: knowledgeText.id, title: knowledgeText.title })
+    .from(knowledgeText)
+    .where(
+      and(
+        eq(knowledgeText.tenantId, tenantId),
+        inArray(
+          sql`lower(${knowledgeText.title})`,
+          titles.map((t) => t.toLowerCase())
+        )
+      )
+    );
+  const byLowerTitle = new Map<string, string>();
+  for (const row of rows) {
+    // first match wins on duplicate titles
+    if (!byLowerTitle.has(row.title.toLowerCase())) {
+      byLowerTitle.set(row.title.toLowerCase(), row.id);
+    }
+  }
+  const resolved = new Map<string, string>();
+  for (const title of titles) {
+    const id = byLowerTitle.get(title.toLowerCase());
+    if (id) resolved.set(title, id);
+  }
+  return resolved;
+};
+
+/**
+ * Re-extract and store the outgoing links of a page from its content.
+ * Called after every content write (create, update, block sync, edit).
+ */
+export const syncKnowledgeTextLinks = async (page: {
+  id: string;
+  tenantId: string;
+  text: string;
+}): Promise<void> => {
+  const targets = extractWikilinkTargets(page.text).filter(
+    (t) => t.length <= 1000
+  );
+  const resolved = await resolveTitles(page.tenantId, targets);
+
+  await getDb()
+    .delete(knowledgeTextLink)
+    .where(eq(knowledgeTextLink.sourceId, page.id));
+
+  if (targets.length === 0) return;
+
+  await getDb().insert(knowledgeTextLink).values(
+    targets.map((targetTitle) => {
+      const targetId = resolved.get(targetTitle) ?? null;
+      return {
+        tenantId: page.tenantId,
+        sourceId: page.id,
+        // self-links are kept as phantom links pointing nowhere
+        targetId: targetId === page.id ? null : targetId,
+        targetTitle,
+      };
+    })
+  );
+};
+
+/**
+ * Resolve phantom links that point at `title` to the given page.
+ * Called when a page is created or renamed, so links written before the
+ * target existed snap into place — Obsidian behaviour.
+ */
+export const resolvePhantomLinks = async (page: {
+  id: string;
+  tenantId: string;
+  title: string;
+}): Promise<number> => {
+  if (!page.title) return 0;
+  const updated = await getDb()
+    .update(knowledgeTextLink)
+    .set({ targetId: page.id })
+    .where(
+      and(
+        eq(knowledgeTextLink.tenantId, page.tenantId),
+        isNull(knowledgeTextLink.targetId),
+        sql`lower(${knowledgeTextLink.targetTitle}) = ${page.title.toLowerCase()}`,
+        // never resolve a page's link to itself
+        sql`${knowledgeTextLink.sourceId} != ${page.id}`
+      )
+    )
+    .returning({ id: knowledgeTextLink.id });
+  return updated.length;
+};
+
+export type KnowledgeTextLinkView = {
+  /** the link row itself */
+  targetTitle: string;
+  resolved: boolean;
+  /** target/source page — null for phantom links or invisible pages */
+  page: { id: string; title: string } | null;
+};
+
+/**
+ * Outgoing links of a page. Resolved targets the caller may not see are
+ * reported as unresolved rather than leaking their existence.
+ */
+export const getKnowledgeTextLinks = async (
+  id: string,
+  context: Context
+): Promise<KnowledgeTextLinkView[]> => {
+  await getKnowledgeTextById(id, context); // permission check
+
+  const links: KnowledgeTextLinkSelect[] = await getDb()
+    .select()
+    .from(knowledgeTextLink)
+    .where(eq(knowledgeTextLink.sourceId, id));
+
+  const targetIds = links
+    .map((l) => l.targetId)
+    .filter((t): t is string => t !== null);
+  const visibleTargets = new Map<string, string>();
+  if (targetIds.length > 0) {
+    const rows = await getDb()
+      .select({ id: knowledgeText.id, title: knowledgeText.title })
+      .from(knowledgeText)
+      .where(
+        and(
+          ...buildKnowledgeTextVisibilityConditions(context),
+          inArray(knowledgeText.id, targetIds)
+        )
+      );
+    for (const row of rows) visibleTargets.set(row.id, row.title);
+  }
+
+  return links.map((link) => {
+    const visibleTitle = link.targetId
+      ? visibleTargets.get(link.targetId)
+      : undefined;
+    return {
+      targetTitle: link.targetTitle,
+      resolved: visibleTitle !== undefined,
+      page:
+        link.targetId && visibleTitle !== undefined
+          ? { id: link.targetId, title: visibleTitle }
+          : null,
+    };
+  });
+};
+
+export type KnowledgeTextBacklinkView = {
+  page: { id: string; title: string };
+  /** the link target as written in the linking page */
+  targetTitle: string;
+};
+
+/**
+ * Incoming links: every page (visible to the caller) that links here.
+ */
+export const getKnowledgeTextBacklinks = async (
+  id: string,
+  context: Context
+): Promise<KnowledgeTextBacklinkView[]> => {
+  await getKnowledgeTextById(id, context); // permission check
+
+  const rows = await getDb()
+    .select({
+      sourceId: knowledgeText.id,
+      sourceTitle: knowledgeText.title,
+      targetTitle: knowledgeTextLink.targetTitle,
+    })
+    .from(knowledgeTextLink)
+    .innerJoin(
+      knowledgeText,
+      eq(knowledgeTextLink.sourceId, knowledgeText.id)
+    )
+    .where(
+      and(
+        eq(knowledgeTextLink.targetId, id),
+        ...buildKnowledgeTextVisibilityConditions(context)
+      )
+    );
+
+  return rows.map((row) => ({
+    page: { id: row.sourceId, title: row.sourceTitle },
+    targetTitle: row.targetTitle,
+  }));
+};
+
+export type RelatedKnowledgeText = {
+  id: string;
+  title: string;
+  /** cosine-style distance of the closest chunk pair (smaller = closer) */
+  distance: number;
+};
+
+/**
+ * Semantically related pages, computed from the stored chunk embeddings of
+ * embedding-enabled pages (nearest chunks to this page's chunk centroid).
+ * Returns [] when this page (or no other page) has embeddings.
+ */
+export const getRelatedKnowledgeTexts = async (
+  id: string,
+  context: Context,
+  options?: { limit?: number }
+): Promise<RelatedKnowledgeText[]> => {
+  const page = await getKnowledgeTextById(id, context);
+  if (!page.knowledgeEntryId) return [];
+  const limit = options?.limit ?? 5;
+
+  // load this page's chunk vectors and compute their centroid in JS
+  const ownChunks = await getDb()
+    .select({
+      dimensions: knowledgeChunks.dimensions,
+      textEmbedding1536: knowledgeChunks.textEmbedding1536,
+      textEmbedding1024: knowledgeChunks.textEmbedding1024,
+    })
+    .from(knowledgeChunks)
+    .where(eq(knowledgeChunks.knowledgeEntryId, page.knowledgeEntryId));
+
+  const vectors = ownChunks
+    .map((c) =>
+      c.dimensions === 1536 ? c.textEmbedding1536 : c.textEmbedding1024
+    )
+    .filter((v): v is number[] => Array.isArray(v) && v.length > 0);
+  if (vectors.length === 0) return [];
+
+  const dimensions = vectors[0]!.length;
+  const centroid = new Array(dimensions).fill(0);
+  for (const vector of vectors) {
+    for (let i = 0; i < dimensions; i++) centroid[i] += vector[i]!;
+  }
+  for (let i = 0; i < dimensions; i++) centroid[i] /= vectors.length;
+
+  const embeddingColumn =
+    dimensions === 1536
+      ? knowledgeChunks.textEmbedding1536
+      : knowledgeChunks.textEmbedding1024;
+
+  const visibility = and(...buildKnowledgeTextVisibilityConditions(context));
+  const rows = await getDb().execute<RelatedKnowledgeText>(sql`
+    SELECT
+      ${knowledgeText.id} AS "id",
+      ${knowledgeText.title} AS "title",
+      MIN(${embeddingColumn} <-> ${sql.raw(`'[${centroid.join(",")}]'`)}) AS "distance"
+    FROM ${knowledgeChunks}
+    JOIN ${knowledgeText}
+      ON ${knowledgeText.knowledgeEntryId} = ${knowledgeChunks.knowledgeEntryId}
+    WHERE ${visibility}
+      AND ${knowledgeChunks.knowledgeEntryId} != ${page.knowledgeEntryId}
+      AND ${embeddingColumn} IS NOT NULL
+    GROUP BY ${knowledgeText.id}, ${knowledgeText.title}
+    ORDER BY "distance" ASC
+    LIMIT ${limit};
+  `);
+
+  return (rows as RelatedKnowledgeText[]).map((row) => ({
+    ...row,
+    distance: Number(row.distance),
+  }));
+};

--- a/src/lib/knowledge/knowledge-text-search.test.ts
+++ b/src/lib/knowledge/knowledge-text-search.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import { searchKnowledgeTexts } from "./knowledge-text-search";
+import { createKnowledgeText } from "./knowledge-texts";
+import { syncKnowledgeTextEmbedding } from "./knowledge-text-embedding";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+
+const ctx = { tenantId: TEST_ORGANISATION_1.id };
+
+// unique per test run so searches only hit this run's fixtures
+const RUN_TAG = `zqx${crypto.randomUUID().slice(0, 8)}`;
+
+const hasEmbeddingProvider = !!process.env.MISTRAL_API_KEY;
+
+describe("Knowledge Text Search (full-text)", () => {
+  beforeAll(async () => {
+    await initTests();
+
+    await createKnowledgeText({
+      title: `Vacation Policy ${RUN_TAG}`,
+      text: `Employees get 30 days of paid vacation per year. Requests go through the HR portal. ${RUN_TAG}`,
+      tenantId: ctx.tenantId,
+    });
+    await createKnowledgeText({
+      title: `Home Office Rules ${RUN_TAG}`,
+      text: `Working from home is allowed three days per week after approval. ${RUN_TAG}`,
+      tenantId: ctx.tenantId,
+    });
+    await createKnowledgeText({
+      title: `Hidden Handbook ${RUN_TAG}`,
+      text: `Secret vacation exceptions for admins. ${RUN_TAG}`,
+      tenantId: ctx.tenantId,
+      hidden: true,
+    });
+  });
+
+  it("finds pages by content words", async () => {
+    const results = await searchKnowledgeTexts(`vacation ${RUN_TAG}`, ctx, {
+      mode: "fulltext",
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.title).toBe(`Vacation Policy ${RUN_TAG}`);
+    expect(results[0]?.matchedBy).toEqual(["fulltext"]);
+    expect(results[0]?.snippet.toLowerCase()).toContain("vacation");
+    expect(results[0]?.score).toBeGreaterThan(0);
+  });
+
+  it("supports websearch syntax (quoted phrases, exclusion)", async () => {
+    const phrase = await searchKnowledgeTexts(
+      `"paid vacation" ${RUN_TAG}`,
+      ctx,
+      { mode: "fulltext" }
+    );
+    expect(phrase.some((r) => r.title.startsWith("Vacation Policy"))).toBe(
+      true
+    );
+
+    const excluded = await searchKnowledgeTexts(
+      `${RUN_TAG} -vacation`,
+      ctx,
+      { mode: "fulltext" }
+    );
+    expect(excluded.some((r) => r.title.startsWith("Vacation Policy"))).toBe(
+      false
+    );
+    expect(excluded.some((r) => r.title.startsWith("Home Office"))).toBe(true);
+  });
+
+  it("falls back to substring matching for partial words", async () => {
+    // "vacat" is no full token — FTS misses it, the ILIKE fallback catches it
+    const results = await searchKnowledgeTexts(`vacat`, ctx, {
+      mode: "fulltext",
+      limit: 50,
+    });
+    expect(
+      results.some((r) => r.title === `Vacation Policy ${RUN_TAG}`)
+    ).toBe(true);
+  });
+
+  it("excludes hidden pages by default and includes them on request", async () => {
+    const withoutHidden = await searchKnowledgeTexts(
+      `vacation ${RUN_TAG}`,
+      ctx,
+      { mode: "fulltext", limit: 50 }
+    );
+    expect(
+      withoutHidden.some((r) => r.title.startsWith("Hidden Handbook"))
+    ).toBe(false);
+
+    const withHidden = await searchKnowledgeTexts(
+      `vacation ${RUN_TAG}`,
+      { ...ctx, includeHidden: true },
+      { mode: "fulltext", limit: 50 }
+    );
+    expect(
+      withHidden.some((r) => r.title.startsWith("Hidden Handbook"))
+    ).toBe(true);
+  });
+
+  it("returns [] for an empty query", async () => {
+    expect(await searchKnowledgeTexts("   ", ctx)).toEqual([]);
+  });
+
+  it("hybrid mode works without an embedding provider (degrades to fulltext)", async () => {
+    const results = await searchKnowledgeTexts(`vacation ${RUN_TAG}`, ctx, {
+      mode: "hybrid",
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.title).toBe(`Vacation Policy ${RUN_TAG}`);
+  });
+
+  it("respects the limit", async () => {
+    const results = await searchKnowledgeTexts(RUN_TAG, ctx, {
+      mode: "fulltext",
+      limit: 1,
+    });
+    expect(results.length).toBe(1);
+  });
+});
+
+describe.skipIf(!hasEmbeddingProvider)(
+  "Knowledge Text Search (hybrid with embeddings, needs MISTRAL_API_KEY)",
+  () => {
+    beforeAll(async () => {
+      await initTests();
+
+      const page = await createKnowledgeText({
+        title: `Team Events ${RUN_TAG}`,
+        text: `Every quarter we organize a company offsite with workshops and social activities. ${RUN_TAG}`,
+        tenantId: ctx.tenantId,
+        embeddingEnabled: true,
+      });
+      await syncKnowledgeTextEmbedding(page.id, ctx.tenantId);
+    });
+
+    it("finds semantically similar pages without exact word overlap", async () => {
+      // "celebration gathering" shares no token with the page text
+      const results = await searchKnowledgeTexts(
+        "quarterly celebration gathering colleagues",
+        ctx,
+        { mode: "semantic", limit: 20 }
+      );
+      expect(
+        results.some((r) => r.title === `Team Events ${RUN_TAG}`)
+      ).toBe(true);
+      expect(results[0]?.matchedBy).toContain("semantic");
+    }, 30000);
+
+    it("hybrid fuses both legs and flags pages found by both", async () => {
+      const results = await searchKnowledgeTexts(
+        `offsite workshops ${RUN_TAG}`,
+        ctx,
+        { mode: "hybrid", limit: 20 }
+      );
+      const hit = results.find((r) => r.title === `Team Events ${RUN_TAG}`);
+      expect(hit).toBeDefined();
+      expect(hit?.matchedBy).toContain("fulltext");
+      expect(hit?.matchedBy).toContain("semantic");
+    }, 30000);
+  }
+);

--- a/src/lib/knowledge/knowledge-text-search.ts
+++ b/src/lib/knowledge/knowledge-text-search.ts
@@ -1,0 +1,213 @@
+/**
+ * Hybrid search over knowledgeText wiki pages.
+ *
+ * Combines two retrieval signals with Reciprocal Rank Fusion (RRF), the
+ * standard recipe for hybrid lexical + semantic search:
+ *
+ *   1. Full-text search: Postgres tsvector over title + content with
+ *      `websearch_to_tsquery` (supports quoted phrases, OR, -exclusion),
+ *      backed by a GIN index. Uses the 'simple' config so mixed German/
+ *      English wikis behave predictably. Falls back to substring matching
+ *      when the FTS query yields nothing (partial words).
+ *
+ *   2. Semantic search: query embedding vs. the stored chunk embeddings of
+ *      embedding-enabled pages (same pgvector index the RAG pipeline uses).
+ *
+ * The semantic leg needs an embedding provider; if it is unavailable or no
+ * page has embeddings, the search degrades gracefully to full-text only.
+ */
+
+import { sql, and } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { knowledgeText, knowledgeChunks } from "../db/schema/knowledge";
+import { buildKnowledgeTextVisibilityConditions } from "./knowledge-texts";
+import { generateEmbedding } from "./embedding";
+import log from "../log";
+
+type Context = {
+  tenantId: string;
+  userId?: string;
+  teamId?: string;
+  workspaceId?: string;
+  includeHidden?: boolean;
+};
+
+export type KnowledgeTextSearchMode = "hybrid" | "fulltext" | "semantic";
+
+export type KnowledgeTextSearchResult = {
+  id: string;
+  title: string;
+  /** fused RRF score (higher = better) */
+  score: number;
+  /** short excerpt around the best match */
+  snippet: string;
+  /** which retrieval legs found this page */
+  matchedBy: ("fulltext" | "semantic")[];
+};
+
+const RRF_K = 60;
+
+type RankedHit = { id: string; title: string; snippet: string };
+
+/** Full-text leg: websearch query with ts_headline snippets */
+const fulltextSearch = async (
+  query: string,
+  context: Context,
+  limit: number
+): Promise<RankedHit[]> => {
+  const visibility = and(...buildKnowledgeTextVisibilityConditions(context));
+  const document = sql`to_tsvector('simple', coalesce(${knowledgeText.title}, '') || ' ' || coalesce(${knowledgeText.text}, ''))`;
+  const tsQuery = sql`websearch_to_tsquery('simple', ${query})`;
+
+  const rows = (await getDb().execute<RankedHit>(sql`
+    SELECT
+      ${knowledgeText.id} AS "id",
+      ${knowledgeText.title} AS "title",
+      ts_headline(
+        'simple',
+        ${knowledgeText.text},
+        ${tsQuery},
+        'MaxWords=40, MinWords=10, MaxFragments=1'
+      ) AS "snippet"
+    FROM ${knowledgeText}
+    WHERE ${visibility} AND ${document} @@ ${tsQuery}
+    ORDER BY ts_rank_cd(${document}, ${tsQuery}) DESC
+    LIMIT ${limit};
+  `)) as RankedHit[];
+
+  if (rows.length > 0) return rows;
+
+  // fallback for partial words the tokenizer can't match (e.g. "Urlaub"
+  // inside "Urlaubsregelung"): case-insensitive substring search
+  const pattern = `%${query.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_")}%`;
+  const fallbackRows = (await getDb().execute<
+    RankedHit & { text: string }
+  >(sql`
+    SELECT
+      ${knowledgeText.id} AS "id",
+      ${knowledgeText.title} AS "title",
+      ${knowledgeText.text} AS "text",
+      '' AS "snippet"
+    FROM ${knowledgeText}
+    WHERE ${visibility}
+      AND (${knowledgeText.title} ILIKE ${pattern} OR ${knowledgeText.text} ILIKE ${pattern})
+    ORDER BY ${knowledgeText.title} ASC
+    LIMIT ${limit};
+  `)) as (RankedHit & { text: string })[];
+
+  return fallbackRows.map((row) => {
+    const index = row.text.toLowerCase().indexOf(query.toLowerCase());
+    const start = Math.max(0, index - 60);
+    const snippet =
+      index >= 0
+        ? row.text.slice(start, index + query.length + 120).trim()
+        : row.text.slice(0, 180).trim();
+    return { id: row.id, title: row.title, snippet };
+  });
+};
+
+/** Semantic leg: query embedding vs. stored chunk embeddings, best chunk per page */
+const semanticSearch = async (
+  query: string,
+  context: Context,
+  limit: number
+): Promise<RankedHit[]> => {
+  const embed = await generateEmbedding(query, {
+    tenantId: context.tenantId,
+    userId: context.userId,
+  });
+  const embeddingColumn =
+    embed.dimensions === 1536
+      ? knowledgeChunks.textEmbedding1536
+      : knowledgeChunks.textEmbedding1024;
+  const queryVector = sql.raw(`'[${embed.embedding}]'`);
+  const visibility = and(...buildKnowledgeTextVisibilityConditions(context));
+
+  const rows = (await getDb().execute<RankedHit>(sql`
+    SELECT
+      "id", "title", "snippet"
+    FROM (
+      SELECT DISTINCT ON (${knowledgeText.id})
+        ${knowledgeText.id} AS "id",
+        ${knowledgeText.title} AS "title",
+        ${knowledgeChunks.text} AS "snippet",
+        ${embeddingColumn} <-> ${queryVector} AS "distance"
+      FROM ${knowledgeChunks}
+      JOIN ${knowledgeText}
+        ON ${knowledgeText.knowledgeEntryId} = ${knowledgeChunks.knowledgeEntryId}
+      WHERE ${visibility} AND ${embeddingColumn} IS NOT NULL
+      ORDER BY ${knowledgeText.id}, "distance" ASC
+    ) AS best_chunk_per_page
+    ORDER BY "distance" ASC
+    LIMIT ${limit};
+  `)) as RankedHit[];
+
+  return rows.map((row) => ({
+    ...row,
+    snippet: row.snippet.length > 240 ? row.snippet.slice(0, 240) + "…" : row.snippet,
+  }));
+};
+
+/**
+ * Search wiki pages. `mode` (default "hybrid"):
+ *   - "fulltext": lexical only, no embedding provider needed
+ *   - "semantic": embeddings only (embedding-enabled pages)
+ *   - "hybrid": both, fused with Reciprocal Rank Fusion
+ */
+export const searchKnowledgeTexts = async (
+  query: string,
+  context: Context,
+  options?: { mode?: KnowledgeTextSearchMode; limit?: number }
+): Promise<KnowledgeTextSearchResult[]> => {
+  const mode = options?.mode ?? "hybrid";
+  const limit = options?.limit ?? 10;
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return [];
+
+  // fetch more per leg than requested so the fusion has material to rank
+  const perLeg = Math.max(limit * 2, 20);
+
+  const [fulltextHits, semanticHits] = await Promise.all([
+    mode !== "semantic"
+      ? fulltextSearch(trimmed, context, perLeg)
+      : Promise.resolve([]),
+    mode !== "fulltext"
+      ? semanticSearch(trimmed, context, perLeg).catch((error) => {
+          if (mode === "semantic") throw error;
+          // hybrid degrades gracefully to fulltext when no provider is
+          // configured or embedding generation fails
+          log.debug(`Semantic search leg unavailable: ${error}`);
+          return [] as RankedHit[];
+        })
+      : Promise.resolve([]),
+  ]);
+
+  // Reciprocal Rank Fusion
+  const fused = new Map<string, KnowledgeTextSearchResult>();
+  const addLeg = (hits: RankedHit[], leg: "fulltext" | "semantic") => {
+    hits.forEach((hit, rank) => {
+      const existing = fused.get(hit.id);
+      const contribution = 1 / (RRF_K + rank + 1);
+      if (existing) {
+        existing.score += contribution;
+        existing.matchedBy.push(leg);
+        // prefer the fulltext headline as the shown snippet
+        if (leg === "fulltext" && hit.snippet) existing.snippet = hit.snippet;
+      } else {
+        fused.set(hit.id, {
+          id: hit.id,
+          title: hit.title,
+          score: contribution,
+          snippet: hit.snippet,
+          matchedBy: [leg],
+        });
+      }
+    });
+  };
+  addLeg(fulltextHits, "fulltext");
+  addLeg(semanticHits, "semantic");
+
+  return [...fused.values()]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+};

--- a/src/lib/knowledge/knowledge-texts.ts
+++ b/src/lib/knowledge/knowledge-texts.ts
@@ -24,6 +24,10 @@ import { teamMembers } from "../db/schema/users";
 import { checkTenantMemberRole } from "../usermanagement/tenants";
 import { checkTeamMemberRole } from "../usermanagement/teams";
 import { syncKnowledgeTextEmbeddingSafe } from "./knowledge-text-embedding";
+import {
+  syncKnowledgeTextLinks,
+  resolvePhantomLinks,
+} from "./knowledge-text-links";
 
 /**
  * Create a new knowledgeText entry
@@ -43,6 +47,12 @@ export const createKnowledgeText = async (data: KnowledgeTextInsert) => {
   if (!e[0]) {
     throw new Error("Failed to create knowledge text");
   }
+
+  // wikilink bookkeeping: extract this page's outgoing links and snap
+  // phantom links of other pages that were waiting for this title
+  await syncKnowledgeTextLinks(e[0]);
+  await resolvePhantomLinks(e[0]);
+
   return e[0];
 };
 
@@ -291,6 +301,14 @@ export const updateKnowledgeText = async (
 
   if (!result[0]) {
     throw new Error("Failed to update knowledge text");
+  }
+
+  // wikilink bookkeeping
+  if (data.text !== undefined) {
+    await syncKnowledgeTextLinks(result[0]);
+  }
+  if (data.title !== undefined && data.title !== currentEntry.title) {
+    await resolvePhantomLinks(result[0]);
   }
 
   // Keep the RAG mirror in sync: covers newly enabled embedding, changed

--- a/src/lib/knowledge/knowledge-texts.ts
+++ b/src/lib/knowledge/knowledge-texts.ts
@@ -53,6 +53,22 @@ export const createKnowledgeText = async (data: KnowledgeTextInsert) => {
   await syncKnowledgeTextLinks(e[0]);
   await resolvePhantomLinks(e[0]);
 
+  // initial embedding sync for pages created with embedding already on
+  if (e[0].embeddingEnabled) {
+    const syncResult = await syncKnowledgeTextEmbeddingSafe(
+      e[0].id,
+      e[0].tenantId
+    );
+    if (syncResult?.synced) {
+      // the sync wrote knowledgeEntryId/meta — return the fresh row
+      const fresh = await getDb()
+        .select()
+        .from(knowledgeText)
+        .where(eq(knowledgeText.id, e[0].id));
+      return fresh[0] ?? e[0];
+    }
+  }
+
   return e[0];
 };
 

--- a/src/routes/tenant/[tenantId]/knowledge/texts/agent-api.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/agent-api.test.ts
@@ -1,0 +1,185 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { testFetcher } from "../../../../../test/fetcher.test";
+import defineRoutes from ".";
+import { initTests, TEST_ORGANISATION_1 } from "../../../../../test/init.test";
+import { Hono } from "hono";
+import type { SFContextVariables } from "../../../../../types";
+import {
+  createDatabaseClient,
+  waitForDbConnection,
+} from "../../../../../lib/db/db-connection";
+
+let app = new Hono<{ Variables: SFContextVariables }>();
+let TEST_USER_1_TOKEN: string;
+let guideId: string;
+let targetId: string;
+
+// unique tag so searches only match this run's fixtures
+const RUN_TAG = `agenttest${crypto.randomUUID().slice(0, 8)}`;
+
+beforeAll(async () => {
+  await createDatabaseClient();
+  await waitForDbConnection();
+
+  defineRoutes(app, "/api");
+  const { user1Token } = await initTests();
+  TEST_USER_1_TOKEN = user1Token;
+});
+
+describe("Agent API: file-like access, search and links", () => {
+  test("Setup: create linked pages", async () => {
+    const targetResponse = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts`,
+      TEST_USER_1_TOKEN,
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        title: `Security Handbook ${RUN_TAG}`,
+        text: `All passwords must be rotated every 90 days. ${RUN_TAG}`,
+      }
+    );
+    expect(targetResponse.status).toBe(200);
+    targetId = targetResponse.jsonResponse.id;
+
+    const guideResponse = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts`,
+      TEST_USER_1_TOKEN,
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        title: `Onboarding Guide ${RUN_TAG}`,
+        text: `line 1 intro\nline 2 details\nline 3 see [[Security Handbook ${RUN_TAG}]]\nline 4 outro ${RUN_TAG}`,
+      }
+    );
+    expect(guideResponse.status).toBe(200);
+    guideId = guideResponse.jsonResponse.id;
+  });
+
+  test("GET content reads a line range with metadata", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${guideId}/content?fromLine=2&maxLines=2`,
+      TEST_USER_1_TOKEN
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.content).toBe(
+      `line 2 details\nline 3 see [[Security Handbook ${RUN_TAG}]]`
+    );
+    expect(response.jsonResponse.fromLine).toBe(2);
+    expect(response.jsonResponse.toLine).toBe(3);
+    expect(response.jsonResponse.totalLines).toBe(4);
+  });
+
+  test("PATCH content performs an exact string replacement", async () => {
+    const response = await testFetcher.patch(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${guideId}/content`,
+      TEST_USER_1_TOKEN,
+      {
+        oldString: "line 2 details",
+        newString: "line 2 much better details",
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.replacements).toBe(1);
+    expect(response.jsonResponse.content).toContain(
+      "line 2 much better details"
+    );
+  });
+
+  test("PATCH content returns 409 for ambiguous or missing strings", async () => {
+    const missing = await testFetcher.patch(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${guideId}/content`,
+      TEST_USER_1_TOKEN,
+      { oldString: "does not exist anywhere", newString: "x" }
+    );
+    expect(missing.status).toBe(409);
+
+    const ambiguous = await testFetcher.patch(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${guideId}/content`,
+      TEST_USER_1_TOKEN,
+      { oldString: "line", newString: "row" }
+    );
+    expect(ambiguous.status).toBe(409);
+  });
+
+  test("GET search finds pages via full-text", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/search?q=${encodeURIComponent(
+        `passwords ${RUN_TAG}`
+      )}&mode=fulltext`,
+      TEST_USER_1_TOKEN
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.length).toBeGreaterThan(0);
+    expect(response.jsonResponse[0].title).toBe(
+      `Security Handbook ${RUN_TAG}`
+    );
+    expect(response.jsonResponse[0].snippet.toLowerCase()).toContain(
+      "passwords"
+    );
+    expect(response.jsonResponse[0].matchedBy).toEqual(["fulltext"]);
+  });
+
+  test("GET search requires a query", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/search`,
+      TEST_USER_1_TOKEN
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("GET links returns the resolved wikilink", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${guideId}/links`,
+      TEST_USER_1_TOKEN
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.length).toBe(1);
+    expect(response.jsonResponse[0].resolved).toBe(true);
+    expect(response.jsonResponse[0].page.id).toBe(targetId);
+  });
+
+  test("GET backlinks returns the linking page", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${targetId}/backlinks`,
+      TEST_USER_1_TOKEN
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.length).toBe(1);
+    expect(response.jsonResponse[0].page.id).toBe(guideId);
+    expect(response.jsonResponse[0].page.title).toBe(
+      `Onboarding Guide ${RUN_TAG}`
+    );
+  });
+
+  test("GET related returns [] for pages without embeddings", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${guideId}/related`,
+      TEST_USER_1_TOKEN
+    );
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse).toEqual([]);
+  });
+
+  test("GET content on an unknown page returns 404", async () => {
+    const response = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${crypto.randomUUID()}/content`,
+      TEST_USER_1_TOKEN
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -21,6 +21,16 @@ import {
 } from "../../../../../lib/knowledge/knowledge-text-blocks";
 import { getSimplifiedKnowledgeText } from "../../../../../lib/knowledge/knowledge-text-simplified";
 import {
+  readKnowledgeTextContent,
+  editKnowledgeTextContent,
+} from "../../../../../lib/knowledge/knowledge-text-edit";
+import { searchKnowledgeTexts } from "../../../../../lib/knowledge/knowledge-text-search";
+import {
+  getKnowledgeTextLinks,
+  getKnowledgeTextBacklinks,
+  getRelatedKnowledgeTexts,
+} from "../../../../../lib/knowledge/knowledge-text-links";
+import {
   authAndSetUsersInfo,
   checkUserPermission,
 } from "../../../../../lib/utils/hono-middlewares";
@@ -162,6 +172,75 @@ export default function defineRoutesForKnowledgeTexts(
           workspaceId,
           includeHidden,
         });
+        return c.json(r);
+      } catch (e) {
+        throw new HTTPException(400, { message: e + "" });
+      }
+    }
+  );
+
+  /**
+   * Hybrid search over wiki pages (full-text + semantic, RRF-fused).
+   * IMPORTANT: hono matches routes in registration order, so this static
+   * "/search" route MUST be registered before GET /texts/:id — otherwise
+   * ":id" swallows the request.
+   */
+  app.get(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/search",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Search knowledge text pages: hybrid full-text + semantic search with Reciprocal Rank Fusion (mode=hybrid|fulltext|semantic)",
+      responses: {
+        200: {
+          description:
+            "Ranked results with id, title, score, snippet and matchedBy legs",
+        },
+      },
+    }),
+    validateScope("knowledge:read"),
+    validator(
+      "query",
+      v.object({
+        q: v.pipe(v.string(), v.minLength(1)),
+        mode: v.optional(v.picklist(["hybrid", "fulltext", "semantic"])),
+        limit: v.optional(v.string()),
+        teamId: v.optional(v.string()),
+        workspaceId: v.optional(v.string()),
+        includeHidden: v.optional(v.string()),
+      })
+    ),
+    validator("param", v.object({ tenantId: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const {
+          q,
+          mode,
+          limit: limitStr,
+          teamId,
+          workspaceId,
+          includeHidden: includeHiddenStr,
+        } = c.req.valid("query");
+        const { tenantId } = c.req.valid("param");
+        const userId = c.get("usersId");
+
+        const r = await searchKnowledgeTexts(
+          q,
+          {
+            tenantId,
+            userId,
+            teamId,
+            workspaceId,
+            includeHidden: includeHiddenStr === "true",
+          },
+          {
+            mode,
+            limit: limitStr ? parseInt(limitStr) : undefined,
+          }
+        );
         return c.json(r);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
@@ -398,6 +477,290 @@ export default function defineRoutesForKnowledgeTexts(
         return c.json(RESPONSES.SUCCESS);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
+      }
+    }
+  );
+
+  /**
+   * Read a page's content like a file: optional line range with metadata
+   * so agents can page through long documents
+   */
+  app.get(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/content",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Read a page's text content, optionally a line range (fromLine/maxLines), with line metadata",
+      responses: {
+        200: {
+          description:
+            "Content slice with fromLine, toLine and totalLines metadata",
+        },
+      },
+    }),
+    validateScope("knowledge:read"),
+    validator(
+      "query",
+      v.object({
+        fromLine: v.optional(v.string()),
+        maxLines: v.optional(v.string()),
+        teamId: v.optional(v.string()),
+        workspaceId: v.optional(v.string()),
+        includeHidden: v.optional(v.string()),
+      })
+    ),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const {
+          fromLine: fromLineStr,
+          maxLines: maxLinesStr,
+          teamId,
+          workspaceId,
+          includeHidden: includeHiddenStr,
+        } = c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const userId = c.get("usersId");
+
+        const r = await readKnowledgeTextContent(
+          id,
+          {
+            tenantId,
+            userId,
+            teamId,
+            workspaceId,
+            includeHidden: includeHiddenStr === "true",
+          },
+          {
+            fromLine: fromLineStr ? parseInt(fromLineStr) : undefined,
+            maxLines: maxLinesStr ? parseInt(maxLinesStr) : undefined,
+          }
+        );
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
+      }
+    }
+  );
+
+  /**
+   * Edit a page's content like a file: exact string replacement.
+   * Works on plain text pages and inside the blocks of block pages.
+   */
+  app.patch(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/content",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Edit a page via exact string replacement (oldString/newString, optional replaceAll)",
+      responses: {
+        200: {
+          description:
+            "Successful response with replacement count and the new content",
+        },
+      },
+    }),
+    validateScope("knowledge:write"),
+    validator(
+      "json",
+      v.object({
+        oldString: v.pipe(v.string(), v.minLength(1)),
+        newString: v.string(),
+        replaceAll: v.optional(v.boolean()),
+      })
+    ),
+    validator("query", contextQuerySchema),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { teamId, workspaceId, includeHidden: includeHiddenStr } =
+          c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const { oldString, newString, replaceAll } = c.req.valid("json");
+        const userId = c.get("usersId");
+
+        const r = await editKnowledgeTextContent(
+          id,
+          { oldString, newString, replaceAll },
+          {
+            tenantId,
+            userId,
+            teamId,
+            workspaceId,
+            includeHidden: includeHiddenStr === "true",
+          }
+        );
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found in the document")) {
+          // edit conflicts are client errors with actionable messages
+          throw new HTTPException(409, { message: errorMsg });
+        }
+        if (errorMsg.includes("not unique") || errorMsg.includes("spans multiple blocks")) {
+          throw new HTTPException(409, { message: errorMsg });
+        }
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
+      }
+    }
+  );
+
+  /**
+   * Outgoing wikilinks of a page ([[Title]] markers in its content)
+   */
+  app.get(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/links",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Get the outgoing wikilinks of a page (resolved and phantom links)",
+      responses: {
+        200: { description: "List of outgoing links" },
+      },
+    }),
+    validateScope("knowledge:read"),
+    validator("query", contextQuerySchema),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { teamId, workspaceId, includeHidden: includeHiddenStr } =
+          c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const userId = c.get("usersId");
+
+        const r = await getKnowledgeTextLinks(id, {
+          tenantId,
+          userId,
+          teamId,
+          workspaceId,
+          includeHidden: includeHiddenStr === "true",
+        });
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
+      }
+    }
+  );
+
+  /**
+   * Backlinks: every visible page that links to this page
+   */
+  app.get(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/backlinks",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary: "Get all pages that link to this page (backlinks)",
+      responses: {
+        200: { description: "List of linking pages" },
+      },
+    }),
+    validateScope("knowledge:read"),
+    validator("query", contextQuerySchema),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { teamId, workspaceId, includeHidden: includeHiddenStr } =
+          c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const userId = c.get("usersId");
+
+        const r = await getKnowledgeTextBacklinks(id, {
+          tenantId,
+          userId,
+          teamId,
+          workspaceId,
+          includeHidden: includeHiddenStr === "true",
+        });
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
+      }
+    }
+  );
+
+  /**
+   * Semantically related pages via stored chunk embeddings
+   */
+  app.get(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/related",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Get semantically related pages (embedding similarity; requires embedding-enabled pages)",
+      responses: {
+        200: { description: "List of related pages ordered by similarity" },
+      },
+    }),
+    validateScope("knowledge:read"),
+    validator(
+      "query",
+      v.object({
+        limit: v.optional(v.string()),
+        teamId: v.optional(v.string()),
+        workspaceId: v.optional(v.string()),
+        includeHidden: v.optional(v.string()),
+      })
+    ),
+    validator("param", v.object({ tenantId: v.string(), id: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const {
+          limit: limitStr,
+          teamId,
+          workspaceId,
+          includeHidden: includeHiddenStr,
+        } = c.req.valid("query");
+        const { tenantId, id } = c.req.valid("param");
+        const userId = c.get("usersId");
+
+        const r = await getRelatedKnowledgeTexts(
+          id,
+          {
+            tenantId,
+            userId,
+            teamId,
+            workspaceId,
+            includeHidden: includeHiddenStr === "true",
+          },
+          { limit: limitStr ? parseInt(limitStr) : undefined }
+        );
+        return c.json(r);
+      } catch (e) {
+        const errorMsg = e + "";
+        if (errorMsg.includes("not found") || errorMsg.includes("access denied")) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
       }
     }
   );


### PR DESCRIPTION
## Summary

Makes the knowledgeText wiki fully workable for AI agents — the API now behaves like a file system with search and an Obsidian-style link graph on top.

### 1. File-like content access

Agents read and edit pages the way coding agents work with files:

```
GET   …/texts/:id/content?fromLine=5&maxLines=50
PATCH …/texts/:id/content   { "oldString": "…", "newString": "…", "replaceAll": false }
```

- **Partial read** returns the requested line slice plus `fromLine` / `toLine` / `totalLines`, so agents can page through long documents instead of loading everything
- **Partial edit** is an exact string replacement. On block pages the edit is applied inside the affected block(s); the request is rejected with an actionable `409` when `oldString` is missing, not unique (agent should send more context or `replaceAll: true`), or spans block boundaries
- Edits run through the normal update/block-sync paths, so **history, wikilinks and the embedding mirror stay consistent automatically**

### 2. Hybrid search (full-text + semantic, RRF-fused)

```
GET …/texts/search?q=vacation+policy&mode=hybrid&limit=10
```

- **Full-text leg**: Postgres tsvector with `websearch_to_tsquery` ('simple' config — predictable for mixed German/English wikis; supports `"quoted phrases"`, `-exclusion`, OR), backed by a new GIN index, `ts_headline` snippets, plus an ILIKE substring fallback for partial words
- **Semantic leg**: query embedding vs. the stored chunk embeddings of embedding-enabled pages (reuses the existing pgvector data of the RAG pipeline)
- Both legs are fused with **Reciprocal Rank Fusion** (k=60) — the standard hybrid-retrieval recipe; each result reports `matchedBy: ["fulltext", "semantic"]`
- `mode=fulltext|semantic|hybrid`; hybrid **degrades gracefully to full-text** when no embedding provider is configured
- Visibility rules identical to all other knowledgeText reads

### 3. Obsidian-style wikilinks

Pages link to each other with `[[Target Title]]` / `[[Target Title|shown text]]` anywhere in their content:

- Links are extracted into the new `knowledge_text_link` table on **every** content save (create, update, block sync, string edit)
- Links to not-yet-existing titles are kept as **phantom links** and snap into place automatically when a page with that title is created or renamed — and deleting a target turns its incoming links back into phantom links (exactly like Obsidian)
- `GET …/texts/:id/links` (outgoing, resolved + phantom), `GET …/texts/:id/backlinks` (incoming, visibility-filtered), `GET …/texts/:id/related` (semantically similar pages via stored chunk embeddings — works at runtime **without** an embedding provider)

### Migration

`0018_massive_sebastian_shaw.sql`: new `knowledge_text_link` table + GIN full-text index on `knowledge_text`. Non-breaking.

## Tests

- `knowledge-text-edit.test.ts` — 11 tests: line-range reads, unique/ambiguous/missing/spanning replacements on text and block pages
- `knowledge-text-search.test.ts` — 10 tests: FTS ranking, websearch syntax, substring fallback, hidden filtering, graceful hybrid degradation; 2 embedding tests run in CI (`skipIf` without `MISTRAL_API_KEY`)
- `knowledge-text-links.test.ts` — 10 tests: extraction, resolution, phantom links (create/rename/delete), block-sync updates, case-insensitivity
- `agent-api.test.ts` — 10 HTTP-level tests incl. 409/404 semantics
- Full knowledge regression suite re-run locally against PGlite: failure set identical to the unchanged baseline (only the known `MISTRAL_API_KEY`-dependent tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv

---
_Generated by [Claude Code](https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv)_