### PR TITLE
Align knowledgeText write permissions with the wiki sharing model

### DIFF
--- a/src/lib/knowledge/knowledge-text-blocks.ts
+++ b/src/lib/knowledge/knowledge-text-blocks.ts
@@ -28,9 +28,10 @@ import {
   type KnowledgeTextSelect,
 } from "../db/schema/knowledge";
 import { assignPositions } from "../utils/fractional-index";
-import { getKnowledgeTextById } from "./knowledge-texts";
-import { checkTenantMemberRole } from "../usermanagement/tenants";
-import { checkTeamMemberRole } from "../usermanagement/teams";
+import {
+  getKnowledgeTextById,
+  checkKnowledgeTextWritePermission,
+} from "./knowledge-texts";
 import { syncKnowledgeTextEmbeddingSafe } from "./knowledge-text-embedding";
 import { syncKnowledgeTextLinks } from "./knowledge-text-links";
 
@@ -98,22 +99,6 @@ const toSnapshot = (
   position: block.position,
   meta: (block.meta ?? {}) as Record<string, unknown>,
 });
-
-/** Same write-permission rule as updateKnowledgeText */
-const checkWritePermission = async (
-  page: KnowledgeTextSelect,
-  context: Context
-) => {
-  if (!context.userId) return;
-  if (page.tenantWide) {
-    await checkTenantMemberRole(context.tenantId, context.userId, [
-      "admin",
-      "owner",
-    ]);
-  } else if (page.teamId) {
-    await checkTeamMemberRole(page.teamId, context.userId, ["admin"]);
-  }
-};
 
 /**
  * Get all blocks of a page in display order.
@@ -208,7 +193,7 @@ export const syncKnowledgeTextBlocks = async (
   options?: SyncKnowledgeTextBlocksOptions
 ): Promise<SyncKnowledgeTextBlocksResult> => {
   const page = await getKnowledgeTextById(knowledgeTextId, context);
-  await checkWritePermission(page, context);
+  await checkKnowledgeTextWritePermission(page, context);
 
   const db = getDb();
   const existing = await db

--- a/src/lib/knowledge/knowledge-text-permissions.test.ts
+++ b/src/lib/knowledge/knowledge-text-permissions.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import {
+  createKnowledgeText,
+  getKnowledgeTextById,
+  updateKnowledgeText,
+  deleteKnowledgeText,
+  checkKnowledgeTextWritePermission,
+} from "./knowledge-texts";
+import { syncKnowledgeTextBlocks } from "./knowledge-text-blocks";
+import { editKnowledgeTextContent } from "./knowledge-text-edit";
+import { createTeam, addTeamMember } from "../../lib/usermanagement/teams";
+import {
+  initTests,
+  TEST_ORGANISATION_1,
+  TEST_ORG1_USER_1, // tenant owner
+  TEST_ORG1_USER_2, // tenant member
+  TEST_ORG1_USER_3, // tenant member
+} from "../../test/init.test";
+
+const TENANT = TEST_ORGANISATION_1.id;
+const OWNER = TEST_ORG1_USER_1.id;
+const MEMBER = TEST_ORG1_USER_2.id;
+const OUTSIDER = TEST_ORG1_USER_3.id; // tenant member, but not in the team
+
+let teamId: string;
+
+const uniqueTitle = (name: string) => `${name} ${crypto.randomUUID()}`;
+
+describe("Knowledge Text Permissions", () => {
+  beforeAll(async () => {
+    await initTests();
+    const team = await createTeam({
+      name: `Perm Test Team ${crypto.randomUUID()}`,
+      tenantId: TENANT,
+    });
+    teamId = team.id;
+    // MEMBER is a plain team member (not team admin)
+    await addTeamMember(teamId, TENANT, MEMBER, "member");
+  });
+
+  describe("tenant-wide pages: every tenant member reads and writes", () => {
+    it("a plain tenant member can update a tenant-wide page", async () => {
+      const page = await createKnowledgeText({
+        title: uniqueTitle("Org Page"),
+        text: "org wide content",
+        tenantId: TENANT,
+        userId: OWNER,
+        tenantWide: true,
+      });
+
+      // MEMBER has tenant role "member" — per spec that is enough to write
+      const updated = await updateKnowledgeText(
+        page.id,
+        { text: "changed by plain member" },
+        { tenantId: TENANT, userId: MEMBER }
+      );
+      expect(updated.text).toBe("changed by plain member");
+
+      // block saves and string edits too
+      const blockResult = await syncKnowledgeTextBlocks(
+        page.id,
+        [{ type: "markdown", content: "block content by member" }],
+        { tenantId: TENANT, userId: MEMBER }
+      );
+      expect(blockResult.knowledgeText.text).toBe("block content by member");
+
+      const edit = await editKnowledgeTextContent(
+        page.id,
+        { oldString: "by member", newString: "by plain member" },
+        { tenantId: TENANT, userId: MEMBER }
+      );
+      expect(edit.replacements).toBe(1);
+    });
+
+    it("a plain tenant member can create and delete tenant-wide pages", async () => {
+      const page = await createKnowledgeText({
+        title: uniqueTitle("Member Created Org Page"),
+        text: "content",
+        tenantId: TENANT,
+        userId: MEMBER,
+        tenantWide: true,
+      });
+      expect(page.id).toBeDefined();
+
+      // another plain member may delete it (tenant-wide = everyone writes)
+      const result = await deleteKnowledgeText(page.id, {
+        tenantId: TENANT,
+        userId: OUTSIDER,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("team pages: every team member reads and writes", () => {
+    it("a plain team member can create and write team pages", async () => {
+      // MEMBER has team role "member" (not admin) — per spec that's enough
+      const page = await createKnowledgeText({
+        title: uniqueTitle("Team Page"),
+        text: "team content",
+        tenantId: TENANT,
+        userId: MEMBER,
+        teamId,
+      });
+      expect(page.teamId).toBe(teamId);
+
+      const updated = await updateKnowledgeText(
+        page.id,
+        { text: "updated by team member" },
+        { tenantId: TENANT, userId: MEMBER }
+      );
+      expect(updated.text).toBe("updated by team member");
+    });
+
+    it("a non-team-member can neither read nor write team pages", async () => {
+      const page = await createKnowledgeText({
+        title: uniqueTitle("Team Only Page"),
+        text: "internal",
+        tenantId: TENANT,
+        userId: MEMBER,
+        teamId,
+      });
+
+      // OUTSIDER is in the tenant but not in the team → page is invisible
+      await expect(
+        getKnowledgeTextById(page.id, { tenantId: TENANT, userId: OUTSIDER })
+      ).rejects.toThrow();
+      await expect(
+        updateKnowledgeText(
+          page.id,
+          { text: "hacked" },
+          { tenantId: TENANT, userId: OUTSIDER }
+        )
+      ).rejects.toThrow();
+      await expect(
+        syncKnowledgeTextBlocks(
+          page.id,
+          [{ type: "markdown", content: "hacked" }],
+          { tenantId: TENANT, userId: OUTSIDER }
+        )
+      ).rejects.toThrow();
+    });
+
+    it("a non-team-member cannot create pages inside the team", async () => {
+      await expect(
+        createKnowledgeText({
+          title: uniqueTitle("Sneaky Page"),
+          text: "should fail",
+          tenantId: TENANT,
+          userId: OUTSIDER,
+          teamId,
+        })
+      ).rejects.toThrow();
+    });
+
+    it("write check prefers team membership over the tenant-wide flag", async () => {
+      // page assigned to a team AND flagged tenant-wide: reads are
+      // team-scoped, so writes must be too
+      await expect(
+        checkKnowledgeTextWritePermission(
+          {
+            tenantId: TENANT,
+            tenantWide: true,
+            teamId,
+            userId: null,
+          },
+          { tenantId: TENANT, userId: OUTSIDER }
+        )
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("personal pages: the assigned user always reads and writes", () => {
+    it("the owner can always write, others cannot even see the page", async () => {
+      const page = await createKnowledgeText({
+        title: uniqueTitle("Private Page"),
+        text: "my notes",
+        tenantId: TENANT,
+        userId: MEMBER,
+      });
+
+      const updated = await updateKnowledgeText(
+        page.id,
+        { text: "my updated notes" },
+        { tenantId: TENANT, userId: MEMBER }
+      );
+      expect(updated.text).toBe("my updated notes");
+
+      await expect(
+        getKnowledgeTextById(page.id, { tenantId: TENANT, userId: OUTSIDER })
+      ).rejects.toThrow();
+      await expect(
+        deleteKnowledgeText(page.id, { tenantId: TENANT, userId: OUTSIDER })
+      ).rejects.toThrow();
+    });
+
+    it("the owner of a team page keeps write access (owner rule)", async () => {
+      const page = await createKnowledgeText({
+        title: uniqueTitle("Owner Team Page"),
+        text: "content",
+        tenantId: TENANT,
+        userId: MEMBER,
+        teamId,
+      });
+      // direct check: owner passes without any role lookup
+      await checkKnowledgeTextWritePermission(page, {
+        tenantId: TENANT,
+        userId: MEMBER,
+      });
+    });
+  });
+
+  describe("moving pages between containers", () => {
+    it("a non-team-member cannot move their page into the team", async () => {
+      const page = await createKnowledgeText({
+        title: uniqueTitle("Move Attempt"),
+        text: "content",
+        tenantId: TENANT,
+        userId: OUTSIDER,
+      });
+
+      await expect(
+        updateKnowledgeText(
+          page.id,
+          { teamId },
+          { tenantId: TENANT, userId: OUTSIDER }
+        )
+      ).rejects.toThrow();
+    });
+
+    it("a team member can move their page into the team", async () => {
+      const page = await createKnowledgeText({
+        title: uniqueTitle("Move Allowed"),
+        text: "content",
+        tenantId: TENANT,
+        userId: MEMBER,
+      });
+
+      const moved = await updateKnowledgeText(
+        page.id,
+        { teamId },
+        { tenantId: TENANT, userId: MEMBER }
+      );
+      expect(moved.teamId).toBe(teamId);
+    });
+  });
+});

--- a/src/lib/knowledge/knowledge-texts.ts
+++ b/src/lib/knowledge/knowledge-texts.ts
@@ -30,14 +30,61 @@ import {
 } from "./knowledge-text-links";
 
 /**
+ * Central write-permission rule for knowledgeText pages:
+ *
+ *   - the assigned user (owner) may always read and write
+ *   - team pages: every team member may read and write
+ *   - tenant-wide pages: every tenant member may read and write
+ *   - private pages of another user are off limits
+ *
+ * Mirrors the read rule in buildKnowledgeTextVisibilityConditions (team
+ * membership takes precedence over the tenant-wide flag). Contexts without
+ * a userId are internal/service calls and skip the check, matching all
+ * other knowledgeText operations.
+ */
+export const checkKnowledgeTextWritePermission = async (
+  page: {
+    tenantId: string;
+    tenantWide: boolean;
+    teamId: string | null;
+    userId: string | null;
+  },
+  context: { tenantId: string; userId?: string }
+): Promise<void> => {
+  if (!context.userId) return;
+  if (page.userId && page.userId === context.userId) return; // owner
+  if (page.teamId) {
+    await checkTeamMemberRole(page.teamId, context.userId, [
+      "member",
+      "admin",
+    ]);
+    return;
+  }
+  if (page.tenantWide) {
+    await checkTenantMemberRole(page.tenantId, context.userId, [
+      "member",
+      "admin",
+      "owner",
+    ]);
+    return;
+  }
+  throw new Error("Knowledge text not found or access denied");
+};
+
+/**
  * Create a new knowledgeText entry
  */
 export const createKnowledgeText = async (data: KnowledgeTextInsert) => {
-  // check permission
+  // creating a page inside a team / tenant-wide requires access to that
+  // container (ownership alone is not enough here)
   if (data.userId && data.teamId) {
-    await checkTeamMemberRole(data.teamId, data.userId, ["admin"]);
+    await checkTeamMemberRole(data.teamId, data.userId, ["member", "admin"]);
   } else if (data.userId && data.tenantWide) {
-    await checkTenantMemberRole(data.tenantId, data.userId, ["admin", "owner"]);
+    await checkTenantMemberRole(data.tenantId, data.userId, [
+      "member",
+      "admin",
+      "owner",
+    ]);
   }
 
   const e = await getDb()
@@ -251,15 +298,23 @@ export const updateKnowledgeText = async (
   // Get the current entry (including text) to create history
   const currentEntry = await getKnowledgeTextById(id, context);
 
-  // check permission
+  await checkKnowledgeTextWritePermission(currentEntry, context);
+
+  // moving a page into a team or making it tenant-wide additionally
+  // requires access to the TARGET container
   if (context.userId) {
-    if (currentEntry.tenantWide) {
+    if (data.teamId && data.teamId !== currentEntry.teamId) {
+      await checkTeamMemberRole(data.teamId, context.userId, [
+        "member",
+        "admin",
+      ]);
+    }
+    if (data.tenantWide === true && !currentEntry.tenantWide) {
       await checkTenantMemberRole(context.tenantId, context.userId, [
+        "member",
         "admin",
         "owner",
       ]);
-    } else if (currentEntry.teamId) {
-      await checkTeamMemberRole(currentEntry.teamId, context.userId, ["admin"]);
     }
   }
 
@@ -359,16 +414,7 @@ export const deleteKnowledgeText = async (
 ) => {
   const item = await getKnowledgeTextById(id, context);
 
-  if (context.userId) {
-    if (item.tenantWide) {
-      await checkTenantMemberRole(context.tenantId, context.userId, [
-        "admin",
-        "owner",
-      ]);
-    } else if (item.teamId) {
-      await checkTeamMemberRole(item.teamId, context.userId, ["admin"]);
-    }
-  }
+  await checkKnowledgeTextWritePermission(item, context);
 
   // Delete the entry (history and blocks are cascade deleted via FKs)
   await getDb()


### PR DESCRIPTION
## Summary

Write access to wiki pages now follows the sharing model instead of requiring admin roles — writes match what reads already allowed:

| Page assignment | Read (unchanged) | Write (before) | Write (now) |
|---|---|---|---|
| tenant-wide | every tenant member | tenant **admin/owner** only | **every tenant member** |
| team | every team member | team **admin** only | **every team member** |
| personal (userId) | owner | owner | owner — always |
| private page of someone else | invisible | — | invisible & unwritable |

### Implementation

- New exported helper `checkKnowledgeTextWritePermission` — the single write rule, used by `updateKnowledgeText`, `deleteKnowledgeText` and the block/content write paths (`PUT …/blocks`, `PATCH …/content` go through these). It mirrors the read-side `buildKnowledgeTextVisibilityConditions` (team membership takes precedence over the tenant-wide flag), so read and write rules cannot drift apart.
- The duplicated admin-only checks in `knowledge-texts.ts` and `knowledge-text-blocks.ts` are removed in favor of the helper.
- **Container checks preserved**: creating a page inside a team or moving a page into a team still requires membership in the *target* team; flipping a page to tenant-wide requires tenant membership. Ownership alone does not grant access to foreign containers.
- Contexts without a `userId` (internal/service calls) skip the check, as before.

No schema changes, no API changes — pure permission-logic alignment.

## Tests

New `knowledge-text-permissions.test.ts` (10 tests):
- plain tenant member updates / block-saves / string-edits / creates / deletes tenant-wide pages
- plain team member (role `member`, not admin) creates and writes team pages
- tenant member outside the team can neither read, write, nor create pages in the team
- owner rule: assigned user always writes; private pages stay invisible to others
- move checks: moving a page into a team requires target-team membership
- team assignment takes precedence over the tenant-wide flag for writes (matching reads)

Full knowledge regression suite re-run locally against PGlite: failure set identical to the unchanged baseline (only the known `MISTRAL_API_KEY`-dependent tests, which run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv

---
_Generated by [Claude Code](https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv)_