### PR TITLE
Add file/URL import and external sync for knowledge text wiki pages

### DIFF
--- a/src/lib/knowledge/knowledge-text-import.test.ts
+++ b/src/lib/knowledge/knowledge-text-import.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import {
+  importKnowledgeTextFromFile,
+  importMarkdownAsKnowledgeText,
+  splitMarkdownIntoSections,
+} from "./knowledge-text-import";
+import { getKnowledgeTextBlocks } from "./knowledge-text-blocks";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+
+const ctx = { tenantId: TEST_ORGANISATION_1.id };
+
+describe("splitMarkdownIntoSections", () => {
+  it("splits at top-level headings", () => {
+    const sections = splitMarkdownIntoSections(
+      "# One\n\ntext one\n\n## Two\n\ntext two\n\n### Not split\n\nmore"
+    );
+    expect(sections.length).toBe(2);
+    expect(sections[0]).toBe("# One\n\ntext one");
+    expect(sections[1]).toContain("## Two");
+    expect(sections[1]).toContain("### Not split");
+  });
+
+  it("keeps headings inside code fences intact", () => {
+    const sections = splitMarkdownIntoSections(
+      "# Doc\n\n```md\n# not a heading\n```\n\n## Real\n\nend"
+    );
+    expect(sections.length).toBe(2);
+    expect(sections[0]).toContain("# not a heading");
+  });
+
+  it("returns a single section without headings", () => {
+    expect(splitMarkdownIntoSections("just text\nno headings")).toEqual([
+      "just text\nno headings",
+    ]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(splitMarkdownIntoSections("   \n  ")).toEqual([]);
+  });
+});
+
+describe("Knowledge Text Import", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("imports a markdown file split into blocks", async () => {
+    const file = new File(
+      ["# Handbook\n\nIntro text.\n\n## Chapter 1\n\nContent one."],
+      "handbook.md",
+      { type: "text/markdown" }
+    );
+
+    const result = await importKnowledgeTextFromFile(file, ctx);
+
+    expect(result.knowledgeText.title).toBe("handbook");
+    expect(result.knowledgeText.contentMode).toBe("blocks");
+    expect(result.blocks.length).toBe(2);
+    expect(result.blocks[0]?.content).toContain("# Handbook");
+    expect(result.blocks[1]?.content).toContain("## Chapter 1");
+    expect((result.knowledgeText.meta as any).sourceUri).toBe("handbook.md");
+    // text cache materialized from the blocks
+    expect(result.knowledgeText.text).toContain("Content one.");
+  });
+
+  it("imports a plain text file via the parsing pipeline", async () => {
+    const file = new File(["Simple note content."], "note.txt", {
+      type: "text/plain",
+    });
+    const result = await importKnowledgeTextFromFile(file, ctx);
+    expect(result.knowledgeText.title).toBe("note");
+    expect(result.knowledgeText.text).toBe("Simple note content.");
+  });
+
+  it("converts html files to markdown", async () => {
+    const file = new File(
+      ["<h1>Web Doc</h1><p>Hello <strong>world</strong></p>"],
+      "page.html",
+      { type: "text/html" }
+    );
+    const result = await importKnowledgeTextFromFile(file, ctx);
+    expect(result.knowledgeText.text).toContain("# Web Doc");
+    expect(result.knowledgeText.text).toContain("**world**");
+  });
+
+  it("respects title override and splitIntoBlocks=false", async () => {
+    const file = new File(["# A\n\n## B\n\ntext"], "raw.md", {
+      type: "text/markdown",
+    });
+    const result = await importKnowledgeTextFromFile(file, {
+      ...ctx,
+      title: "Custom Title",
+      splitIntoBlocks: false,
+    });
+
+    expect(result.knowledgeText.title).toBe("Custom Title");
+    expect(result.knowledgeText.contentMode).toBe("text");
+    expect(result.blocks).toEqual([]);
+    const blocks = await getKnowledgeTextBlocks(result.knowledgeText.id, ctx);
+    expect(blocks.length).toBe(0);
+  });
+
+  it("rejects files without extractable text", async () => {
+    const file = new File(["   "], "empty.md", { type: "text/markdown" });
+    await expect(importKnowledgeTextFromFile(file, ctx)).rejects.toThrow(
+      "no extractable text"
+    );
+  });
+
+  it("import with embeddingEnabled never fails without a provider", async () => {
+    const result = await importMarkdownAsKnowledgeText(
+      { title: `Embed Import ${crypto.randomUUID()}`, text: "# Doc\n\ncontent" },
+      { ...ctx, embeddingEnabled: true }
+    );
+    expect(result.knowledgeText.embeddingEnabled).toBe(true);
+    // without MISTRAL_API_KEY the sync is skipped gracefully
+  });
+
+  it("supports wiki hierarchy via parentId", async () => {
+    const parent = await importMarkdownAsKnowledgeText(
+      { title: `Import Parent ${crypto.randomUUID()}`, text: "parent" },
+      ctx
+    );
+    const child = await importMarkdownAsKnowledgeText(
+      { title: `Import Child ${crypto.randomUUID()}`, text: "child" },
+      { ...ctx, parentId: parent.knowledgeText.id }
+    );
+    expect(child.knowledgeText.parentId).toBe(parent.knowledgeText.id);
+  });
+});

--- a/src/lib/knowledge/knowledge-text-import.ts
+++ b/src/lib/knowledge/knowledge-text-import.ts
@@ -1,0 +1,226 @@
+/**
+ * Import external documents as knowledgeText wiki pages.
+ *
+ * Generalizes the ingestion that previously only existed for knowledge
+ * entries (upload-and-extract): files and URLs are parsed to markdown and
+ * become normal wiki pages — editable in the block editor, searchable,
+ * linkable, and (opt-in) mirrored into the RAG pipeline via the existing
+ * embedding sync.
+ *
+ *   - markdown / plain text / html files are converted directly
+ *   - everything else (PDF, …) goes through the existing `parseFile`
+ *     pipeline (external parser services)
+ *   - the markdown is split into one block per top-level heading so the
+ *     imported page is immediately block-editable (optional)
+ */
+
+import TurndownService from "turndown";
+import { gfm } from "turndown-plugin-gfm";
+import { parseFile } from "./parsing";
+import { urlToMarkdown } from "./parsing/url";
+import {
+  createKnowledgeText,
+  updateKnowledgeText,
+  getKnowledgeTextById,
+} from "./knowledge-texts";
+import {
+  syncKnowledgeTextBlocks,
+  type KnowledgeTextBlockInput,
+} from "./knowledge-text-blocks";
+import type {
+  KnowledgeTextSelect,
+  KnowledgeTextBlockSelect,
+} from "../db/schema/knowledge";
+
+export type ImportKnowledgeTextOptions = {
+  tenantId: string;
+  userId?: string;
+  teamId?: string;
+  workspaceId?: string;
+  tenantWide?: boolean;
+  parentId?: string;
+  /** override the derived title (file name / page title) */
+  title?: string;
+  /** mirror the page into the RAG pipeline after import */
+  embeddingEnabled?: boolean;
+  /** split the markdown at top-level headings into blocks (default true) */
+  splitIntoBlocks?: boolean;
+  /** extra meta merged into the page meta */
+  meta?: Record<string, unknown>;
+};
+
+export type ImportKnowledgeTextResult = {
+  knowledgeText: KnowledgeTextSelect;
+  blocks: KnowledgeTextBlockSelect[];
+};
+
+let turndown: TurndownService | null = null;
+const getTurndown = (): TurndownService => {
+  if (!turndown) {
+    turndown = new TurndownService({
+      headingStyle: "atx",
+      codeBlockStyle: "fenced",
+    });
+    turndown.use(gfm);
+  }
+  return turndown;
+};
+
+const stripExtension = (name: string): string =>
+  name.replace(/\.[^.]+$/, "");
+
+/**
+ * Split markdown into sections at top-level headings (# / ##), keeping code
+ * fences intact. Returns at least one section for non-empty input.
+ */
+export const splitMarkdownIntoSections = (markdown: string): string[] => {
+  const lines = markdown.split("\n");
+  const sections: string[] = [];
+  let current: string[] = [];
+  let inFence = false;
+
+  for (const line of lines) {
+    if (/^(```|~~~)/.test(line.trim())) {
+      inFence = !inFence;
+    }
+    if (
+      !inFence &&
+      /^#{1,2}\s/.test(line) &&
+      current.join("\n").trim().length > 0
+    ) {
+      sections.push(current.join("\n").trim());
+      current = [];
+    }
+    current.push(line);
+  }
+  const last = current.join("\n").trim();
+  if (last.length > 0) sections.push(last);
+  return sections;
+};
+
+/** Convert an uploaded file to markdown text */
+const fileToMarkdown = async (
+  file: File,
+  context: { tenantId: string; userId?: string; teamId?: string; workspaceId?: string }
+): Promise<string> => {
+  const name = file.name ?? "";
+  const mime = (file.type ?? "").trim().toLowerCase();
+
+  if (
+    mime.startsWith("text/markdown") ||
+    /\.(md|markdown)$/i.test(name)
+  ) {
+    return await file.text();
+  }
+  if (mime.startsWith("text/html") || /\.html?$/i.test(name)) {
+    return getTurndown().turndown(await file.text()).trim();
+  }
+  // PDF, plain text, … via the existing parsing pipeline
+  const parsed = await parseFile(file, context);
+  return parsed.text;
+};
+
+/**
+ * Create a wiki page from already-parsed markdown. Shared by the file,
+ * URL and sync ingestion paths.
+ */
+export const importMarkdownAsKnowledgeText = async (
+  data: { title: string; text: string; sourceUri?: string },
+  options: ImportKnowledgeTextOptions
+): Promise<ImportKnowledgeTextResult> => {
+  const context = {
+    tenantId: options.tenantId,
+    userId: options.userId,
+    teamId: options.teamId,
+    workspaceId: options.workspaceId,
+  };
+
+  // create first WITHOUT the embedding flag so the page is embedded exactly
+  // once, after its final content (blocks) is in place
+  const page = await createKnowledgeText({
+    tenantId: options.tenantId,
+    userId: options.userId,
+    teamId: options.teamId,
+    tenantWide: options.tenantWide ?? false,
+    parentId: options.parentId,
+    title: data.title,
+    text: data.text,
+    meta: {
+      ...(options.meta ?? {}),
+      ...(data.sourceUri ? { sourceUri: data.sourceUri } : {}),
+    },
+  });
+
+  let blocks: KnowledgeTextBlockSelect[] = [];
+  if (options.splitIntoBlocks !== false) {
+    const sections = splitMarkdownIntoSections(data.text);
+    const blockInputs: KnowledgeTextBlockInput[] = sections.map(
+      (content) => ({ type: "markdown", content })
+    );
+    const synced = await syncKnowledgeTextBlocks(
+      page.id,
+      blockInputs,
+      context
+    );
+    blocks = synced.blocks;
+  }
+
+  let finalPage = options.splitIntoBlocks !== false ? undefined : page;
+  if (options.embeddingEnabled) {
+    // one embedding sync over the final content
+    finalPage = await updateKnowledgeText(
+      page.id,
+      { embeddingEnabled: true },
+      context
+    );
+  }
+  if (!finalPage) {
+    finalPage = await getKnowledgeTextById(page.id, context);
+  }
+
+  return { knowledgeText: finalPage, blocks };
+};
+
+/**
+ * Import an uploaded file (markdown, html, plain text, PDF, …) as a wiki
+ * page. The title defaults to the file name without extension.
+ */
+export const importKnowledgeTextFromFile = async (
+  file: File,
+  options: ImportKnowledgeTextOptions
+): Promise<ImportKnowledgeTextResult> => {
+  const text = await fileToMarkdown(file, {
+    tenantId: options.tenantId,
+    userId: options.userId,
+    teamId: options.teamId,
+    workspaceId: options.workspaceId,
+  });
+  if (text.trim().length === 0) {
+    throw new Error("The file contains no extractable text");
+  }
+  const title =
+    options.title ??
+    (file.name ? stripExtension(file.name) : "Imported document");
+  return await importMarkdownAsKnowledgeText(
+    { title, text, sourceUri: file.name },
+    options
+  );
+};
+
+/**
+ * Import a web page as a wiki page (Readability + Turndown, SSRF-guarded).
+ * The title defaults to the extracted page title.
+ */
+export const importKnowledgeTextFromUrl = async (
+  url: string,
+  options: ImportKnowledgeTextOptions
+): Promise<ImportKnowledgeTextResult> => {
+  const result = await urlToMarkdown(url);
+  if (result.markdown.trim().length === 0) {
+    throw new Error("The page contains no extractable text");
+  }
+  return await importMarkdownAsKnowledgeText(
+    { title: options.title ?? result.title, text: result.markdown, sourceUri: url },
+    options
+  );
+};

--- a/src/lib/knowledge/knowledge-text-sync.test.ts
+++ b/src/lib/knowledge/knowledge-text-sync.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import {
+  upsertKnowledgeTextFromSource,
+  deleteOrphanedKnowledgeTexts,
+  findKnowledgeTextBySourceIdentifier,
+} from "./knowledge-text-sync";
+import {
+  createKnowledgeText,
+  getKnowledgeTextById,
+  getKnowledgeTextHistory,
+} from "./knowledge-texts";
+import {
+  syncKnowledgeTextBlocks,
+  getKnowledgeTextBlocks,
+} from "./knowledge-text-blocks";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+
+const ctx = { tenantId: TEST_ORGANISATION_1.id };
+
+// per-run scope so parallel/repeated runs don't interfere
+const SCOPE = { syncConfigId: crypto.randomUUID() };
+
+describe("Knowledge Text Sync", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("creates a page on first sync with the identifier in meta", async () => {
+    const result = await upsertKnowledgeTextFromSource({
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "https://example.com/doc-1",
+      title: "Synced Doc 1",
+      text: "external content v1",
+      matchScope: SCOPE,
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.changed).toBe(true);
+
+    const page = await getKnowledgeTextById(result.id, ctx);
+    expect(page.title).toBe("Synced Doc 1");
+    expect((page.meta as any).sourceIdentifier).toBe(
+      "https://example.com/doc-1"
+    );
+    expect((page.meta as any).syncConfigId).toBe(SCOPE.syncConfigId);
+  });
+
+  it("is a no-op when the content is unchanged", async () => {
+    const input = {
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "https://example.com/doc-2",
+      title: "Synced Doc 2",
+      text: "stable content",
+      matchScope: SCOPE,
+    };
+    const first = await upsertKnowledgeTextFromSource(input);
+    const historyBefore = (await getKnowledgeTextHistory(first.id, ctx)).length;
+
+    const second = await upsertKnowledgeTextFromSource(input);
+    expect(second.created).toBe(false);
+    expect(second.changed).toBe(false);
+    expect(second.id).toBe(first.id);
+
+    const historyAfter = (await getKnowledgeTextHistory(first.id, ctx)).length;
+    expect(historyAfter).toBe(historyBefore);
+  });
+
+  it("updates in place when the content changed, keeping the page id", async () => {
+    const base = {
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "https://example.com/doc-3",
+      title: "Synced Doc 3",
+      text: "version 1",
+      matchScope: SCOPE,
+    };
+    const first = await upsertKnowledgeTextFromSource(base);
+
+    const second = await upsertKnowledgeTextFromSource({
+      ...base,
+      title: "Synced Doc 3 (renamed)",
+      text: "version 2",
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.created).toBe(false);
+    expect(second.changed).toBe(true);
+
+    const page = await getKnowledgeTextById(first.id, ctx);
+    expect(page.title).toBe("Synced Doc 3 (renamed)");
+    expect(page.text).toBe("version 2");
+  });
+
+  it("replaces the blocks of a block-mode page on update", async () => {
+    const base = {
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "https://example.com/doc-4",
+      title: "Synced Doc 4",
+      text: "initial",
+      matchScope: SCOPE,
+    };
+    const first = await upsertKnowledgeTextFromSource(base);
+
+    // someone converted the synced page to block mode in the meantime
+    await syncKnowledgeTextBlocks(
+      first.id,
+      [
+        { type: "markdown", content: "locally edited A" },
+        { type: "markdown", content: "locally edited B" },
+      ],
+      ctx
+    );
+
+    await upsertKnowledgeTextFromSource({ ...base, text: "fresh from source" });
+
+    const blocks = await getKnowledgeTextBlocks(first.id, ctx);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0]?.content).toBe("fresh from source");
+    const page = await getKnowledgeTextById(first.id, ctx);
+    expect(page.text).toBe("fresh from source");
+  });
+
+  it("finds pages only within the matchScope", async () => {
+    const otherScope = { syncConfigId: crypto.randomUUID() };
+    await upsertKnowledgeTextFromSource({
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "shared-id",
+      title: "Scope A Page",
+      text: "a",
+      matchScope: SCOPE,
+    });
+    const inOtherScope = await findKnowledgeTextBySourceIdentifier(
+      ctx.tenantId,
+      "shared-id",
+      otherScope
+    );
+    expect(inOtherScope).toBeNull();
+
+    // same identifier in another scope creates a SEPARATE page
+    const result = await upsertKnowledgeTextFromSource({
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "shared-id",
+      title: "Scope B Page",
+      text: "b",
+      matchScope: otherScope,
+    });
+    expect(result.created).toBe(true);
+  });
+
+  it("deletes orphaned synced pages but never hand-written ones", async () => {
+    const scope = { syncConfigId: crypto.randomUUID() };
+    const keep = await upsertKnowledgeTextFromSource({
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "keep-me",
+      title: "Keep Page",
+      text: "keep",
+      matchScope: scope,
+    });
+    const orphan = await upsertKnowledgeTextFromSource({
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "remove-me",
+      title: "Orphan Page",
+      text: "orphan",
+      matchScope: scope,
+    });
+    // a hand-written page (no sourceIdentifier) with the same scope-ish meta
+    const manual = await createKnowledgeText({
+      tenantId: ctx.tenantId,
+      title: `Manual Page ${crypto.randomUUID()}`,
+      text: "hand-written",
+      meta: { syncConfigId: scope.syncConfigId },
+    });
+
+    const cleanup = await deleteOrphanedKnowledgeTexts({
+      tenantId: ctx.tenantId,
+      activeSourceIdentifiers: ["keep-me"],
+      matchScope: scope,
+    });
+
+    expect(cleanup.deleted).toBe(1);
+    await expect(getKnowledgeTextById(orphan.id, ctx)).rejects.toThrow();
+    // kept + manual pages survive
+    const keptPage = await getKnowledgeTextById(keep.id, ctx);
+    expect(keptPage.title).toBe("Keep Page");
+    const manualPage = await getKnowledgeTextById(manual.id, ctx);
+    expect(manualPage.text).toBe("hand-written");
+  });
+
+  it("does not touch synced pages outside the matchScope during cleanup", async () => {
+    const scopeA = { syncConfigId: crypto.randomUUID() };
+    const scopeB = { syncConfigId: crypto.randomUUID() };
+    const pageB = await upsertKnowledgeTextFromSource({
+      tenantId: ctx.tenantId,
+      sourceIdentifier: "other-scope-page",
+      title: "Other Scope Page",
+      text: "b",
+      matchScope: scopeB,
+    });
+
+    // cleanup in scope A with an empty keep-set must not delete scope B pages
+    await deleteOrphanedKnowledgeTexts({
+      tenantId: ctx.tenantId,
+      activeSourceIdentifiers: [],
+      matchScope: scopeA,
+    });
+
+    const survived = await getKnowledgeTextById(pageB.id, ctx);
+    expect(survived.title).toBe("Other Scope Page");
+  });
+});

--- a/src/lib/knowledge/knowledge-text-sync.ts
+++ b/src/lib/knowledge/knowledge-text-sync.ts
@@ -1,0 +1,209 @@
+/**
+ * Sync-style ingestion for knowledgeText wiki pages.
+ *
+ * Mirrors the proven knowledge-entry sync model (see upsert-knowledge.ts)
+ * on the wiki level: external sources (crawls, file mirrors, API imports)
+ * re-ingest the same logical documents repeatedly, identified by a stable
+ * `sourceIdentifier` stored in the page meta.
+ *
+ *   - `upsertKnowledgeTextFromSource` — insert if unknown, update in place
+ *     if the content changed, no-op if unchanged. The page keeps its id
+ *     across updates, so wikilinks, backlinks, history and the embedding
+ *     mirror stay intact.
+ *
+ *   - `deleteOrphanedKnowledgeTexts` — at the end of a sync run, delete
+ *     every synced page (inside the given scope) whose identifier is no
+ *     longer in the active keep-set. Pages WITHOUT a sourceIdentifier are
+ *     never touched — regular wiki pages are not part of any sync.
+ */
+
+import { and, eq, sql, isNotNull } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { knowledgeText } from "../db/schema/knowledge";
+import {
+  createKnowledgeText,
+  updateKnowledgeText,
+  deleteKnowledgeText,
+} from "./knowledge-texts";
+import { syncKnowledgeTextBlocks } from "./knowledge-text-blocks";
+
+/** JSON key in `knowledge_text.meta` identifying the external source
+ *  (same key the knowledge-entry sync uses) */
+export const TEXT_SOURCE_IDENTIFIER_META_KEY = "sourceIdentifier";
+
+type MatchScope = Record<string, string>;
+
+const metaEquals = (key: string, value: string) =>
+  sql`jsonb_extract_path_text(${knowledgeText.meta}, ${key}) = ${value}`;
+
+export type UpsertKnowledgeTextFromSourceInput = {
+  tenantId: string;
+  /** stable external identifier (URL, GUID, file path, …) */
+  sourceIdentifier: string;
+  title: string;
+  text: string;
+  userId?: string;
+  teamId?: string;
+  workspaceId?: string;
+  tenantWide?: boolean;
+  parentId?: string;
+  embeddingEnabled?: boolean;
+  /**
+   * Additional meta key/value constraints used to find the existing page
+   * and (on insert) stored on the new page — scope by sync config so two
+   * syncs in the same tenant cannot collide on the same identifier.
+   */
+  matchScope?: MatchScope;
+  /** extra meta merged into the page meta on insert */
+  meta?: Record<string, unknown>;
+};
+
+export type UpsertKnowledgeTextFromSourceResult = {
+  id: string;
+  created: boolean;
+  /** false when the content was identical and nothing was written */
+  changed: boolean;
+};
+
+/** Find a synced page by its stable source identifier (+ optional scope) */
+export const findKnowledgeTextBySourceIdentifier = async (
+  tenantId: string,
+  sourceIdentifier: string,
+  matchScope?: MatchScope
+) => {
+  const filters = [
+    eq(knowledgeText.tenantId, tenantId),
+    metaEquals(TEXT_SOURCE_IDENTIFIER_META_KEY, sourceIdentifier),
+    ...Object.entries(matchScope ?? {}).map(([key, value]) =>
+      metaEquals(key, value)
+    ),
+  ];
+  const rows = await getDb()
+    .select()
+    .from(knowledgeText)
+    .where(and(...filters))
+    .limit(1);
+  return rows[0] ?? null;
+};
+
+/**
+ * Insert-or-update a wiki page identified by a stable `sourceIdentifier`.
+ */
+export const upsertKnowledgeTextFromSource = async (
+  data: UpsertKnowledgeTextFromSourceInput
+): Promise<UpsertKnowledgeTextFromSourceResult> => {
+  const context = {
+    tenantId: data.tenantId,
+    userId: data.userId,
+    teamId: data.teamId,
+    workspaceId: data.workspaceId,
+    includeHidden: true,
+  };
+
+  const existing = await findKnowledgeTextBySourceIdentifier(
+    data.tenantId,
+    data.sourceIdentifier,
+    data.matchScope
+  );
+
+  // ----- insert -----------------------------------------------------------
+  if (!existing) {
+    const page = await createKnowledgeText({
+      tenantId: data.tenantId,
+      userId: data.userId,
+      teamId: data.teamId,
+      tenantWide: data.tenantWide ?? false,
+      parentId: data.parentId,
+      title: data.title,
+      text: data.text,
+      embeddingEnabled: data.embeddingEnabled ?? false,
+      meta: {
+        ...(data.meta ?? {}),
+        ...(data.matchScope ?? {}),
+        [TEXT_SOURCE_IDENTIFIER_META_KEY]: data.sourceIdentifier,
+      },
+    });
+    return { id: page.id, created: true, changed: true };
+  }
+
+  // ----- unchanged --------------------------------------------------------
+  if (existing.title === data.title && existing.text === data.text) {
+    return { id: existing.id, created: false, changed: false };
+  }
+
+  // ----- update in place --------------------------------------------------
+  if (existing.contentMode === "blocks") {
+    // the page mirrors an external source: replace its blocks with the new
+    // content (single markdown block); block sync refreshes text cache,
+    // links and the embedding mirror
+    await syncKnowledgeTextBlocks(
+      existing.id,
+      data.text.trim().length > 0
+        ? [{ type: "markdown", content: data.text }]
+        : [],
+      context,
+      // sync runs are batch jobs — always leave a restore point
+      { historyCoalesceMinutes: 0 }
+    );
+    if (existing.title !== data.title) {
+      await updateKnowledgeText(existing.id, { title: data.title }, context);
+    }
+  } else {
+    await updateKnowledgeText(
+      existing.id,
+      { title: data.title, text: data.text },
+      context
+    );
+  }
+
+  return { id: existing.id, created: false, changed: true };
+};
+
+/**
+ * Delete synced pages whose `sourceIdentifier` is not in the active
+ * keep-set. Only pages that HAVE a sourceIdentifier (inside the optional
+ * matchScope) are candidates — hand-written wiki pages are never deleted.
+ * Deletion goes through deleteKnowledgeText, so blocks, history, links and
+ * the mirrored knowledge entry are cleaned up as well.
+ */
+export const deleteOrphanedKnowledgeTexts = async (opts: {
+  tenantId: string;
+  /** identifiers still present in the source (pages to keep) */
+  activeSourceIdentifiers: string[];
+  matchScope?: MatchScope;
+}): Promise<{ deleted: number }> => {
+  const filters = [
+    eq(knowledgeText.tenantId, opts.tenantId),
+    isNotNull(
+      sql`jsonb_extract_path_text(${knowledgeText.meta}, ${TEXT_SOURCE_IDENTIFIER_META_KEY})`
+    ),
+    ...Object.entries(opts.matchScope ?? {}).map(([key, value]) =>
+      metaEquals(key, value)
+    ),
+  ];
+
+  const candidates = await getDb()
+    .select({
+      id: knowledgeText.id,
+      meta: knowledgeText.meta,
+    })
+    .from(knowledgeText)
+    .where(and(...filters));
+
+  const keep = new Set(opts.activeSourceIdentifiers);
+  const orphans = candidates.filter((row) => {
+    const identifier = (row.meta as Record<string, unknown>)?.[
+      TEXT_SOURCE_IDENTIFIER_META_KEY
+    ];
+    return typeof identifier === "string" && !keep.has(identifier);
+  });
+
+  for (const orphan of orphans) {
+    await deleteKnowledgeText(orphan.id, {
+      tenantId: opts.tenantId,
+      includeHidden: true,
+    });
+  }
+
+  return { deleted: orphans.length };
+};

--- a/src/routes/tenant/[tenantId]/knowledge/texts/import-api.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/import-api.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { testFetcher } from "../../../../../test/fetcher.test";
+import defineRoutes from ".";
+import { initTests, TEST_ORGANISATION_1 } from "../../../../../test/init.test";
+import { Hono } from "hono";
+import type { SFContextVariables } from "../../../../../types";
+import {
+  createDatabaseClient,
+  waitForDbConnection,
+} from "../../../../../lib/db/db-connection";
+
+let app = new Hono<{ Variables: SFContextVariables }>();
+let TEST_USER_1_TOKEN: string;
+
+const SCOPE_ID = crypto.randomUUID();
+
+beforeAll(async () => {
+  await createDatabaseClient();
+  await waitForDbConnection();
+
+  defineRoutes(app, "/api");
+  const { user1Token } = await initTests();
+  TEST_USER_1_TOKEN = user1Token;
+});
+
+describe("Knowledge Text Import & Sync API", () => {
+  test("POST import uploads a markdown file and creates a block page", async () => {
+    const form = new FormData();
+    form.append(
+      "file",
+      new File(
+        ["# Imported Doc\n\nIntro.\n\n## Section\n\nDetails."],
+        "imported-doc.md",
+        { type: "text/markdown" }
+      )
+    );
+
+    const response = await testFetcher.postFormData(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/import`,
+      TEST_USER_1_TOKEN,
+      form
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.knowledgeText.title).toBe("imported-doc");
+    expect(response.jsonResponse.knowledgeText.contentMode).toBe("blocks");
+    expect(response.jsonResponse.blocks.length).toBe(2);
+  });
+
+  test("POST import honors title and splitIntoBlocks fields", async () => {
+    const form = new FormData();
+    form.append(
+      "file",
+      new File(["# One\n\n## Two"], "x.md", { type: "text/markdown" })
+    );
+    form.append("title", "My Custom Title");
+    form.append("splitIntoBlocks", "false");
+
+    const response = await testFetcher.postFormData(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/import`,
+      TEST_USER_1_TOKEN,
+      form
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.knowledgeText.title).toBe("My Custom Title");
+    expect(response.jsonResponse.knowledgeText.contentMode).toBe("text");
+  });
+
+  test("POST import without a file returns 400", async () => {
+    const form = new FormData();
+    form.append("title", "no file");
+
+    const response = await testFetcher.postFormData(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/import`,
+      TEST_USER_1_TOKEN,
+      form
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("POST import-url rejects an invalid url", async () => {
+    const response = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/import-url`,
+      TEST_USER_1_TOKEN,
+      { url: "not-a-url" }
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("POST sync upserts items and reports per-item results", async () => {
+    const response = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/sync`,
+      TEST_USER_1_TOKEN,
+      {
+        items: [
+          {
+            sourceIdentifier: "api-doc-1",
+            title: "API Synced Doc 1",
+            text: "content 1",
+          },
+          {
+            sourceIdentifier: "api-doc-2",
+            title: "API Synced Doc 2",
+            text: "content 2",
+          },
+        ],
+        matchScope: { syncConfigId: SCOPE_ID },
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.results.length).toBe(2);
+    expect(response.jsonResponse.results[0].created).toBe(true);
+    expect(response.jsonResponse.orphansDeleted).toBe(0);
+  });
+
+  test("POST sync again: unchanged items are no-ops, orphans get cleaned", async () => {
+    const response = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/sync`,
+      TEST_USER_1_TOKEN,
+      {
+        items: [
+          {
+            sourceIdentifier: "api-doc-1",
+            title: "API Synced Doc 1",
+            text: "content 1",
+          },
+          // api-doc-2 vanished from the source
+        ],
+        matchScope: { syncConfigId: SCOPE_ID },
+        deleteOrphans: true,
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.results[0].created).toBe(false);
+    expect(response.jsonResponse.results[0].changed).toBe(false);
+    expect(response.jsonResponse.orphansDeleted).toBe(1);
+  });
+
+  test("POST sync validates the payload", async () => {
+    const response = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/sync`,
+      TEST_USER_1_TOKEN,
+      { items: [{ sourceIdentifier: "", title: "", text: "x" }] }
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -31,6 +31,14 @@ import {
   getRelatedKnowledgeTexts,
 } from "../../../../../lib/knowledge/knowledge-text-links";
 import {
+  importKnowledgeTextFromFile,
+  importKnowledgeTextFromUrl,
+} from "../../../../../lib/knowledge/knowledge-text-import";
+import {
+  upsertKnowledgeTextFromSource,
+  deleteOrphanedKnowledgeTexts,
+} from "../../../../../lib/knowledge/knowledge-text-sync";
+import {
   authAndSetUsersInfo,
   checkUserPermission,
 } from "../../../../../lib/utils/hono-middlewares";
@@ -173,6 +181,209 @@ export default function defineRoutesForKnowledgeTexts(
           includeHidden,
         });
         return c.json(r);
+      } catch (e) {
+        throw new HTTPException(400, { message: e + "" });
+      }
+    }
+  );
+
+  /**
+   * Import an uploaded file (markdown, html, txt, PDF, …) as a wiki page.
+   * NOTE: registered before GET/POST /texts/:id-style routes on purpose —
+   * hono matches in registration order.
+   */
+  app.post(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/import",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Import a file (markdown, html, txt, PDF, ...) as a knowledge text wiki page",
+      requestBody: {
+        content: {
+          "multipart/form-data": {
+            schema: v.object({
+              file: v.any(),
+              title: v.optional(v.string()),
+              parentId: v.optional(v.string()),
+              teamId: v.optional(v.string()),
+              tenantWide: v.optional(v.string()),
+              embeddingEnabled: v.optional(v.string()),
+              splitIntoBlocks: v.optional(v.string()),
+            }),
+          },
+        },
+      },
+      responses: {
+        200: {
+          description:
+            "Successful response with the created page and its blocks",
+        },
+      },
+    }),
+    validateScope("knowledge:write"),
+    validator("param", v.object({ tenantId: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { tenantId } = c.req.valid("param");
+        const userId = c.get("usersId");
+        const form = await c.req.formData();
+
+        const file = form.get("file");
+        if (!(file instanceof File)) {
+          throw new Error("Missing 'file' form field");
+        }
+
+        const r = await importKnowledgeTextFromFile(file, {
+          tenantId,
+          userId,
+          title: form.get("title")?.toString() || undefined,
+          parentId: form.get("parentId")?.toString() || undefined,
+          teamId: form.get("teamId")?.toString() || undefined,
+          tenantWide: form.get("tenantWide")?.toString() === "true",
+          embeddingEnabled:
+            form.get("embeddingEnabled")?.toString() === "true",
+          splitIntoBlocks:
+            form.get("splitIntoBlocks")?.toString() !== "false",
+        });
+        return c.json(r);
+      } catch (e) {
+        throw new HTTPException(400, { message: e + "" });
+      }
+    }
+  );
+
+  /**
+   * Import a web page as a wiki page (Readability + Turndown, SSRF-guarded)
+   */
+  app.post(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/import-url",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary: "Import a web page as a knowledge text wiki page",
+      responses: {
+        200: {
+          description:
+            "Successful response with the created page and its blocks",
+        },
+      },
+    }),
+    validateScope("knowledge:write"),
+    validator(
+      "json",
+      v.object({
+        url: v.pipe(v.string(), v.url()),
+        title: v.optional(v.string()),
+        parentId: v.optional(v.string()),
+        teamId: v.optional(v.string()),
+        tenantWide: v.optional(v.boolean()),
+        embeddingEnabled: v.optional(v.boolean()),
+        splitIntoBlocks: v.optional(v.boolean()),
+      })
+    ),
+    validator("param", v.object({ tenantId: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { tenantId } = c.req.valid("param");
+        const userId = c.get("usersId");
+        const body = c.req.valid("json");
+
+        const r = await importKnowledgeTextFromUrl(body.url, {
+          tenantId,
+          userId,
+          title: body.title,
+          parentId: body.parentId,
+          teamId: body.teamId,
+          tenantWide: body.tenantWide,
+          embeddingEnabled: body.embeddingEnabled,
+          splitIntoBlocks: body.splitIntoBlocks,
+        });
+        return c.json(r);
+      } catch (e) {
+        throw new HTTPException(400, { message: e + "" });
+      }
+    }
+  );
+
+  /**
+   * Batch-sync pages from an external source. Each item is upserted by its
+   * stable sourceIdentifier; optionally deletes synced pages that vanished
+   * from the source (never touches hand-written pages).
+   */
+  app.post(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/sync",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Batch-sync wiki pages from an external source (upsert by sourceIdentifier, optional orphan cleanup)",
+      responses: {
+        200: {
+          description:
+            "Per-item results (id, created, changed) and the orphan-cleanup count",
+        },
+      },
+    }),
+    validateScope("knowledge:write"),
+    validator(
+      "json",
+      v.object({
+        items: v.pipe(
+          v.array(
+            v.object({
+              sourceIdentifier: v.pipe(v.string(), v.minLength(1)),
+              title: v.pipe(v.string(), v.minLength(1)),
+              text: v.string(),
+              parentId: v.optional(v.string()),
+              teamId: v.optional(v.string()),
+              tenantWide: v.optional(v.boolean()),
+              embeddingEnabled: v.optional(v.boolean()),
+              meta: v.optional(v.record(v.string(), v.unknown())),
+            })
+          ),
+          v.maxLength(200)
+        ),
+        matchScope: v.optional(v.record(v.string(), v.string())),
+        deleteOrphans: v.optional(v.boolean()),
+      })
+    ),
+    validator("param", v.object({ tenantId: v.string() })),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { tenantId } = c.req.valid("param");
+        const userId = c.get("usersId");
+        const { items, matchScope, deleteOrphans } = c.req.valid("json");
+
+        const results = [];
+        for (const item of items) {
+          results.push(
+            await upsertKnowledgeTextFromSource({
+              ...item,
+              tenantId,
+              userId,
+              matchScope,
+            })
+          );
+        }
+
+        let orphansDeleted = 0;
+        if (deleteOrphans) {
+          const cleanup = await deleteOrphanedKnowledgeTexts({
+            tenantId,
+            activeSourceIdentifiers: items.map((i) => i.sourceIdentifier),
+            matchScope,
+          });
+          orphansDeleted = cleanup.deleted;
+        }
+
+        return c.json({ results, orphansDeleted });
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
       }


### PR DESCRIPTION
## Summary

Generalizes the ingestion that previously only existed for knowledge entries (upload-and-extract, entry sync) onto the wiki level. External documents become **normal wiki pages** — block-editable, full-text/hybrid searchable, wikilink-able, and (opt-in) mirrored into the RAG pipeline through the existing embedding sync. First step towards making knowledge entries a purely derived index.

### File import

```
POST …/knowledge/texts/import          (multipart/form-data)
  file, title?, parentId?, teamId?, tenantWide?, embeddingEnabled?, splitIntoBlocks?
```

- markdown / plain text / html files are converted directly (html via Turndown); **PDF and other formats go through the existing `parseFile` pipeline** (external parser services) — nothing was duplicated
- the markdown is split into **one block per top-level heading** (`#`/`##`, code-fence aware), so imported documents are immediately block-editable; `splitIntoBlocks=false` keeps a plain text page
- title defaults to the file name; the source file name/URL is stored in `meta.sourceUri`
- with `embeddingEnabled=true`, the page is embedded **exactly once** after its final content is in place

### URL import

```
POST …/knowledge/texts/import-url      { "url": "https://…", …same options }
```

Uses the existing SSRF-guarded Readability + Turndown parser; title defaults to the extracted page title.

### External sync (mirrors the proven knowledge-entry sync model)

```
POST …/knowledge/texts/sync
  { items: [{ sourceIdentifier, title, text, … }], matchScope?, deleteOrphans? }
```

- `upsertKnowledgeTextFromSource`: insert / update-in-place / no-op, keyed by a stable `sourceIdentifier` in the page meta. The page **keeps its id across updates**, so wikilinks, backlinks, history and the embedding mirror stay intact. `matchScope` (e.g. `{ syncConfigId }`) prevents two sync configs from colliding on the same identifier.
- Pages converted to block mode in the meantime are updated through the normal block sync (content replaced, restore point in history).
- `deleteOrphanedKnowledgeTexts`: removes synced pages that vanished from the source. **Pages without a `sourceIdentifier` — hand-written wiki pages — are never touched**, even inside the scope.
- Unchanged items write nothing (no history noise, no embedding calls).

## Tests

- `knowledge-text-import.test.ts` — 11 tests: heading split (incl. code fences), markdown/txt/html imports, title override, splitIntoBlocks=false, empty files, embedding flag without provider, parentId hierarchy
- `knowledge-text-sync.test.ts` — 7 tests: create/unchanged/update-in-place, block-mode replacement, matchScope separation, orphan cleanup sparing hand-written and out-of-scope pages
- `import-api.test.ts` — 7 HTTP-level tests incl. multipart upload, validation errors, sync round-trip with orphan cleanup
- Full knowledge regression suite re-run locally against PGlite: failure set identical to the unchanged baseline (only the known `MISTRAL_API_KEY`-dependent tests, which run in CI)

No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv

---
_Generated by [Claude Code](https://claude.ai/code/session_019F3ershDydSrg3wGaNXdZv)_