### PR TITLE
Make email sends non-blocking for login flows

### DIFF
--- a/src/lib/auth/email-otp.ts
+++ b/src/lib/auth/email-otp.ts
@@ -109,7 +109,11 @@ export const sendEmailLoginCode = async (
     code,
   });
 
-  await smtpService.sendMail({
+  // The login code is already persisted above, so the SMTP dispatch is
+  // decoupled from the request: the POST handler returns immediately instead
+  // of blocking on the SMTP round-trip (which can retry for up to ~30 minutes
+  // on failure). The user still enters the code they receive by email.
+  smtpService.sendMailInBackground({
     sender: process.env.SMTP_FROM,
     recipients: [normalized],
     subject,

--- a/src/lib/auth/magic-link.ts
+++ b/src/lib/auth/magic-link.ts
@@ -199,7 +199,11 @@ export const sendMagicLink = async (
     link: magicLink,
   });
 
-  await smtpService.sendMail({
+  // The magic-link token is already persisted at this point, so the actual
+  // SMTP dispatch is decoupled from the request: the caller (e.g. the login
+  // POST handler) returns immediately instead of blocking on the SMTP
+  // round-trip (which can retry for up to ~30 minutes on failure).
+  smtpService.sendMailInBackground({
     sender: process.env.SMTP_FROM,
     recipients: [email],
     subject,

--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -230,6 +230,33 @@ class SMTPService {
     return false;
   }
 
+  /**
+   * Dispatch an email without blocking the caller ("fire and forget").
+   *
+   * Login-related mails (magic link, email login code) are triggered from
+   * within a request handler, but the HTTP response must not wait for the SMTP
+   * round-trip. In the failure path {@link sendMail} retries up to 3 times with
+   * a 15-minute pause between attempts (~30 minutes total), which would hang the
+   * POST for the entire duration. This wrapper hands the send off to the
+   * background and logs the outcome instead of surfacing it to the request.
+   *
+   * The caller is expected to have already completed any state that must be
+   * durable (e.g. persisting the login code) before invoking this.
+   */
+  sendMailInBackground(options: EmailOptions): void {
+    void this.sendMail(options)
+      .then((sent) => {
+        if (!sent) {
+          log.error(
+            `Background email send failed for subject "${options.subject}"`
+          );
+        }
+      })
+      .catch((err) => {
+        log.error(`Unexpected error sending background email: ${err}`);
+      });
+  }
+
   async sendTestMail(recipient: string): Promise<boolean> {
     const testEmailOptions: EmailOptions = {
       recipients: [recipient],


### PR DESCRIPTION
## Summary
Decouples email sending from login request handlers to prevent HTTP responses from blocking on SMTP round-trips, which can take up to ~30 minutes on retry.

## Changes
- **New method `sendMailInBackground()`** in `SMTPService`: Dispatches emails asynchronously without blocking the caller. Errors are logged instead of surfaced to the request handler.
- **Updated `sendEmailLoginCode()`**: Changed from `await smtpService.sendMail()` to `smtpService.sendMailInBackground()` since the login code is already persisted before sending.
- **Updated `sendMagicLink()`**: Changed from `await smtpService.sendMail()` to `smtpService.sendMailInBackground()` since the magic-link token is already persisted before sending.

## Implementation Details
- The login code and magic-link token are persisted to durable storage before the email is sent, so the email dispatch can be safely decoupled from the request lifecycle.
- `sendMailInBackground()` uses fire-and-forget pattern with `.then()` and `.catch()` handlers to log outcomes without throwing errors back to the caller.
- This prevents login POST handlers from hanging for up to ~30 minutes when SMTP retries are exhausted, while still ensuring users receive their authentication codes/links.

https://claude.ai/code/session_01WktU4cVhZxXtrTquuXHvCQ