### PR TITLE
ci: run unit tests on pull requests, not only on merge to develop

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,17 @@ on:
     branches:
       - develop
 
+  pull_request:
+    branches:
+      - develop
+
   workflow_dispatch:
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR) so CI
+# does not pile up outdated runs.
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -32,8 +42,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: develop
 
       - name: Create .env file
         run: |


### PR DESCRIPTION
## Summary
The `Unit tests for framework` workflow previously only ran on `push` to `develop` (and manual dispatch), so the test suite executed **after** a PR was already merged. This makes it run on every PR **before** merge.

## Changes (`.github/workflows/unit-tests.yml`)
- **Add `pull_request` trigger** (targeting `develop`) so the suite runs on each PR.
- **Remove the hard-coded `ref: develop` on checkout** — otherwise a PR run would check out `develop` instead of the PR's own code, testing the wrong thing.
- **Add a `concurrency` group** with `cancel-in-progress` so rapid pushes to a PR cancel superseded runs instead of piling up.

## Note on activation
GitHub evaluates the `pull_request` trigger from the workflow file on the **base branch** (`develop`). PR CI therefore becomes active for other PRs once this change is merged into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WktU4cVhZxXtrTquuXHvCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WktU4cVhZxXtrTquuXHvCQ)_