### PR TITLE
feat(knowledge): enrich post-processor interface and wire it everywhere

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import { defineJob, startJobQueue } from "./lib/jobs";
 // Cron
 import scheduler from "./lib/cron";
 import { cleanupExpiredFiles } from "./lib/knowledge/knowledge-text-files";
+import { registerPostProcessor } from "./lib/knowledge/parsing/post-processors";
 // Store
 import { _GLOBAL_SERVER_CONFIG, setGlobalServerConfig } from "./store";
 
@@ -108,6 +109,15 @@ export const defineServer = (config: ServerSpecificConfig) => {
   initializeFullDbSchema(config.customDbSchema ?? {});
   initializeCollectionPermissions(config.customCollectionPermissions ?? {});
   createDatabaseClient(config.customDbSchema);
+
+  /**
+   * Register all custom knowledge post processors
+   */
+  if (config.customPostProcessors) {
+    config.customPostProcessors.forEach((processor) => {
+      registerPostProcessor(processor);
+    });
+  }
 
   /**
    * Register all custom cron jobs
@@ -486,3 +496,14 @@ export { log };
 export { smtpService };
 export const GLOBAL_SERVER_CONFIG = _GLOBAL_SERVER_CONFIG;
 export { connectionsService } from "./lib/connections";
+export {
+  registerPostProcessor,
+  getAllPostProcessors,
+  applyPostProcessors,
+} from "./lib/knowledge/parsing/post-processors";
+export type {
+  PostProcessor,
+  PostProcessorInput,
+  PostProcessorOutput,
+  ApplyPostProcessorsResult,
+} from "./lib/knowledge/parsing/post-processors";

--- a/src/lib/knowledge/add-knowledge.ts
+++ b/src/lib/knowledge/add-knowledge.ts
@@ -23,6 +23,7 @@ import {
   type KnowledgeEntryInsert,
 } from "../db/schema/knowledge";
 import { parseDocument, parseFile } from "./parsing";
+import { applyPostProcessors } from "./parsing/post-processors";
 import type { PageContent } from "./parsing/pdf/types";
 import { generateEmbedding } from "./embedding";
 
@@ -299,11 +300,44 @@ export const extractKnowledgeInOneStep = async (
       workspaceId: data.workspaceId,
     });
 
-    // 2. Extract knowledge
+    // 2. optional post processing (e.g. clean up a datasheet via an LLM)
+    let text = parsed.text;
+    let pages = parsed.pages;
+    let title = data.file.name ?? "Unknown";
+    if (data.usePostProcessors && data.usePostProcessors.length > 0) {
+      const processed = await applyPostProcessors(
+        {
+          text,
+          pages,
+          title,
+          source: {
+            type: "external",
+            fileName: data.file.name,
+            mimeType: data.file.type,
+            includesImages: parsed.includesImages,
+          },
+          context: {
+            tenantId: data.tenantId,
+            teamId: data.teamId,
+            workspaceId: data.workspaceId,
+          },
+          model: data.model,
+        },
+        data.usePostProcessors
+      );
+      text = processed.text;
+      pages = processed.pages;
+      if (processed.title) {
+        title = processed.title;
+      }
+    }
+
+    // 3. Extract knowledge
     const result = await extractKnowledgeFromText({
       tenantId: data.tenantId,
-      title: data.file.name ?? "Unknown",
-      text: parsed.text,
+      title,
+      text,
+      pages,
       filters: data.filters,
       teamId: data.teamId,
       workspaceId: data.workspaceId,
@@ -322,10 +356,34 @@ export const extractKnowledgeInOneStep = async (
   }
   // if the text is provided, extract knowledge from it
   else if (data.data) {
+    // optional post processing before extraction
+    let text = data.data.text;
+    let title = data.data.title;
+    if (data.usePostProcessors && data.usePostProcessors.length > 0) {
+      const processed = await applyPostProcessors(
+        {
+          text,
+          title,
+          source: { type: "text", includesImages: false },
+          context: {
+            tenantId: data.tenantId,
+            teamId: data.teamId,
+            workspaceId: data.workspaceId,
+          },
+          model: data.model,
+        },
+        data.usePostProcessors
+      );
+      text = processed.text;
+      if (processed.title) {
+        title = processed.title;
+      }
+    }
+
     return extractKnowledgeFromText({
       tenantId: data.tenantId,
-      title: data.data.title,
-      text: data.data.text,
+      title,
+      text,
       filters: data.filters,
       teamId: data.teamId,
       workspaceId: data.workspaceId,

--- a/src/lib/knowledge/knowledge-text-import.test.ts
+++ b/src/lib/knowledge/knowledge-text-import.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./knowledge-text-import";
 import { getKnowledgeTextBlocks } from "./knowledge-text-blocks";
 import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+import { registerPostProcessor } from "./parsing/post-processors";
 
 const ctx = { tenantId: TEST_ORGANISATION_1.id };
 
@@ -126,5 +127,99 @@ describe("Knowledge Text Import", () => {
       { ...ctx, parentId: parent.knowledgeText.id }
     );
     expect(child.knowledgeText.parentId).toBe(parent.knowledgeText.id);
+  });
+});
+
+describe("Knowledge Text Import with post processors", () => {
+  beforeAll(async () => {
+    await initTests();
+
+    // Rewrites the text to uppercase and records that it ran.
+    registerPostProcessor({
+      name: "it-upper",
+      label: "Upper",
+      description: "uppercases the text",
+      execute: async ({ text }) => ({
+        text: text.toUpperCase(),
+        meta: { upperRan: true },
+      }),
+    });
+
+    // Restructures the text into headed sections and suggests a title + meta,
+    // standing in for an LLM datasheet processor.
+    registerPostProcessor({
+      name: "it-structure",
+      label: "Structure",
+      description: "adds headings and extracts structured data",
+      execute: async ({ text }) => ({
+        text: `# Overview\n\n${text}\n\n## Specs\n\nvoltage: 5V`,
+        title: "Structured Datasheet",
+        meta: { voltage: "5V", processedBy: "it-structure" },
+      }),
+    });
+  });
+
+  it("applies the processed text to the stored page and its blocks", async () => {
+    const result = await importMarkdownAsKnowledgeText(
+      {
+        title: `PP Upper ${crypto.randomUUID()}`,
+        text: "# heading\n\nlower case body",
+      },
+      { ...ctx, usePostProcessors: ["it-upper"] }
+    );
+
+    expect(result.knowledgeText.text).toContain("LOWER CASE BODY");
+    expect(result.knowledgeText.text).not.toContain("lower case body");
+    // blocks are split from the *processed* text
+    expect(result.blocks[0]?.content).toContain("# HEADING");
+    expect((result.knowledgeText.meta as any).upperRan).toBe(true);
+  });
+
+  it("lets a processor override the title and merge structured meta", async () => {
+    const result = await importMarkdownAsKnowledgeText(
+      { title: `PP Title ${crypto.randomUUID()}`, text: "raw datasheet dump" },
+      { ...ctx, usePostProcessors: ["it-structure"] }
+    );
+
+    expect(result.knowledgeText.title).toBe("Structured Datasheet");
+    expect((result.knowledgeText.meta as any).voltage).toBe("5V");
+    expect((result.knowledgeText.meta as any).processedBy).toBe("it-structure");
+    // the restructured text produced two heading sections
+    expect(result.blocks.length).toBe(2);
+    expect(result.blocks[0]?.content).toContain("# Overview");
+    expect(result.blocks[1]?.content).toContain("## Specs");
+  });
+
+  it("runs multiple processors in the given order", async () => {
+    const result = await importMarkdownAsKnowledgeText(
+      { title: `PP Chain ${crypto.randomUUID()}`, text: "body" },
+      { ...ctx, usePostProcessors: ["it-structure", "it-upper"] }
+    );
+
+    // it-structure wraps first, then it-upper uppercases the whole thing
+    expect(result.knowledgeText.text).toContain("# OVERVIEW");
+    expect(result.knowledgeText.text).toContain("VOLTAGE: 5V");
+    // both processors' meta survives the merge
+    expect((result.knowledgeText.meta as any).upperRan).toBe(true);
+    expect((result.knowledgeText.meta as any).voltage).toBe("5V");
+  });
+
+  it("stores the raw text when no post processors are requested", async () => {
+    const result = await importMarkdownAsKnowledgeText(
+      { title: `PP None ${crypto.randomUUID()}`, text: "untouched body" },
+      ctx
+    );
+    expect(result.knowledgeText.text).toContain("untouched body");
+  });
+
+  it("applies post processors on the file import path too", async () => {
+    const file = new File(["quiet note"], `pp-${crypto.randomUUID()}.txt`, {
+      type: "text/plain",
+    });
+    const result = await importKnowledgeTextFromFile(file, {
+      ...ctx,
+      usePostProcessors: ["it-upper"],
+    });
+    expect(result.knowledgeText.text).toContain("QUIET NOTE");
   });
 });

--- a/src/lib/knowledge/knowledge-text-import.ts
+++ b/src/lib/knowledge/knowledge-text-import.ts
@@ -18,6 +18,7 @@ import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
 import { parseFile } from "./parsing";
 import { urlToMarkdown } from "./parsing/url";
+import { applyPostProcessors } from "./parsing/post-processors";
 import {
   createKnowledgeText,
   updateKnowledgeText,
@@ -47,6 +48,13 @@ export type ImportKnowledgeTextOptions = {
   splitIntoBlocks?: boolean;
   /** extra meta merged into the page meta */
   meta?: Record<string, unknown>;
+  /**
+   * Names of post processors to run on the parsed markdown before the page is
+   * created (e.g. clean up / restructure a datasheet via an LLM). Any
+   * structured `meta` they emit is merged into the page meta, and a returned
+   * title overrides the derived one.
+   */
+  usePostProcessors?: string[];
 };
 
 export type ImportKnowledgeTextResult = {
@@ -135,6 +143,35 @@ export const importMarkdownAsKnowledgeText = async (
     workspaceId: options.workspaceId,
   };
 
+  // Run post processors on the parsed markdown before storing (e.g. clean up
+  // / restructure a datasheet via an LLM). The cleaned text also feeds the
+  // block splitting below, so imported pages get well-structured blocks.
+  let text = data.text;
+  let title = data.title;
+  let processorMeta: Record<string, unknown> = {};
+  if (options.usePostProcessors && options.usePostProcessors.length > 0) {
+    const isUrl = /^https?:\/\//i.test(data.sourceUri ?? "");
+    const processed = await applyPostProcessors(
+      {
+        text,
+        title,
+        source: {
+          type: isUrl ? "url" : "file",
+          url: isUrl ? data.sourceUri : undefined,
+          fileName: isUrl ? undefined : data.sourceUri,
+          includesImages: false,
+        },
+        context,
+      },
+      options.usePostProcessors
+    );
+    text = processed.text;
+    if (processed.title) {
+      title = processed.title;
+    }
+    processorMeta = processed.meta;
+  }
+
   // create first WITHOUT the embedding flag so the page is embedded exactly
   // once, after its final content (blocks) is in place
   const page = await createKnowledgeText({
@@ -143,17 +180,18 @@ export const importMarkdownAsKnowledgeText = async (
     teamId: options.teamId,
     tenantWide: options.tenantWide ?? false,
     parentId: options.parentId,
-    title: data.title,
-    text: data.text,
+    title,
+    text,
     meta: {
       ...(options.meta ?? {}),
+      ...processorMeta,
       ...(data.sourceUri ? { sourceUri: data.sourceUri } : {}),
     },
   });
 
   let blocks: KnowledgeTextBlockSelect[] = [];
   if (options.splitIntoBlocks !== false) {
-    const sections = splitMarkdownIntoSections(data.text);
+    const sections = splitMarkdownIntoSections(text);
     const blockInputs: KnowledgeTextBlockInput[] = sections.map(
       (content) => ({ type: "markdown", content })
     );

--- a/src/lib/knowledge/parsing/index.ts
+++ b/src/lib/knowledge/parsing/index.ts
@@ -197,16 +197,36 @@ export const parseDocument = async (data: {
   log.debug(`File parsed. Content length: ${content.length}`);
 
   // Apply post processors if requested
+  let meta: Record<string, unknown> = {};
   if (data.usePostProcessors && data.usePostProcessors.length > 0) {
-    content = await applyPostProcessors(
-      content,
-      data.tenantId,
+    const processed = await applyPostProcessors(
+      {
+        text: content,
+        pages,
+        title,
+        source: {
+          type: data.sourceType,
+          url: data.sourceUrl,
+          includesImages: docIncludesImages,
+        },
+        context: {
+          tenantId: data.tenantId,
+          teamId: data.teamId,
+          workspaceId: data.workspaceId,
+        },
+        model: data.model,
+      },
       data.usePostProcessors
     );
-    // set pages to undefined since we don't have pages after post processing
-    pages = undefined;
-    // Optionally, also update pages if needed (not implemented here)
+    content = processed.text;
+    // The page mapping only survives if a processor returned an updated one;
+    // otherwise it is dropped (page-level chunk metadata is no longer valid).
+    pages = processed.pages;
+    if (processed.title) {
+      title = processed.title;
+    }
+    meta = processed.meta;
   }
 
-  return { content, pages, title, includesImages: docIncludesImages };
+  return { content, pages, title, includesImages: docIncludesImages, meta };
 };

--- a/src/lib/knowledge/parsing/post-processors.test.ts
+++ b/src/lib/knowledge/parsing/post-processors.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from "bun:test";
+import {
+  applyPostProcessors,
+  registerPostProcessor,
+  getAllPostProcessors,
+  type PostProcessor,
+  type PostProcessorInput,
+} from "./post-processors";
+
+/**
+ * The registry is a module-level global and rejects duplicate names, so every
+ * test registers processors under unique names.
+ */
+const baseInput = (
+  overrides: Partial<PostProcessorInput> = {}
+): PostProcessorInput => ({
+  text: "original",
+  source: { type: "text", includesImages: false },
+  context: { tenantId: "t1" },
+  ...overrides,
+});
+
+describe("applyPostProcessors", () => {
+  it("returns the input unchanged when no processors are requested", async () => {
+    const input = baseInput({
+      text: "hello",
+      title: "Title",
+      pages: [{ page: 1, text: "hello" }],
+    });
+
+    const noneUndefined = await applyPostProcessors(input, undefined);
+    const noneEmpty = await applyPostProcessors(input, []);
+
+    for (const result of [noneUndefined, noneEmpty]) {
+      expect(result.text).toBe("hello");
+      expect(result.title).toBe("Title");
+      expect(result.pages).toEqual([{ page: 1, text: "hello" }]);
+      expect(result.meta).toEqual({});
+    }
+  });
+
+  it("applies a single processor to the text", async () => {
+    registerPostProcessor({
+      name: "single-upper",
+      label: "Upper",
+      description: "uppercases",
+      execute: async ({ text }) => ({ text: text.toUpperCase() }),
+    });
+
+    const result = await applyPostProcessors(
+      baseInput({ text: "abc" }),
+      ["single-upper"]
+    );
+
+    expect(result.text).toBe("ABC");
+  });
+
+  it("runs processors in the given order, threading text through the chain", async () => {
+    const order: string[] = [];
+    registerPostProcessor({
+      name: "chain-a",
+      label: "a",
+      description: "append a",
+      execute: async ({ text }) => {
+        order.push("a");
+        return { text: text + "-a" };
+      },
+    });
+    registerPostProcessor({
+      name: "chain-b",
+      label: "b",
+      description: "append b",
+      execute: async ({ text }) => {
+        order.push("b");
+        return { text: text + "-b" };
+      },
+    });
+
+    const forward = await applyPostProcessors(baseInput({ text: "x" }), [
+      "chain-a",
+      "chain-b",
+    ]);
+    expect(forward.text).toBe("x-a-b");
+    expect(order).toEqual(["a", "b"]);
+
+    // The same processors in the opposite order produce a different result.
+    order.length = 0;
+    const reverse = await applyPostProcessors(baseInput({ text: "x" }), [
+      "chain-b",
+      "chain-a",
+    ]);
+    expect(reverse.text).toBe("x-b-a");
+    expect(order).toEqual(["b", "a"]);
+  });
+
+  it("each processor sees the previous processor's output as input", async () => {
+    const seen: string[] = [];
+    registerPostProcessor({
+      name: "observe-first",
+      label: "1",
+      description: "",
+      execute: async ({ text }) => {
+        seen.push(text);
+        return { text: text + "1" };
+      },
+    });
+    registerPostProcessor({
+      name: "observe-second",
+      label: "2",
+      description: "",
+      execute: async ({ text }) => {
+        seen.push(text);
+        return { text: text + "2" };
+      },
+    });
+
+    await applyPostProcessors(baseInput({ text: "start" }), [
+      "observe-first",
+      "observe-second",
+    ]);
+
+    expect(seen).toEqual(["start", "start1"]);
+  });
+
+  it("merges meta across processors (later processor wins on conflicts)", async () => {
+    registerPostProcessor({
+      name: "meta-a",
+      label: "a",
+      description: "",
+      execute: async ({ text }) => ({
+        text,
+        meta: { shared: "from-a", onlyA: 1 },
+      }),
+    });
+    registerPostProcessor({
+      name: "meta-b",
+      label: "b",
+      description: "",
+      execute: async ({ text }) => ({
+        text,
+        meta: { shared: "from-b", onlyB: 2 },
+      }),
+    });
+
+    const result = await applyPostProcessors(baseInput(), [
+      "meta-a",
+      "meta-b",
+    ]);
+
+    expect(result.meta).toEqual({ shared: "from-b", onlyA: 1, onlyB: 2 });
+  });
+
+  it("overrides the title only when a processor returns one", async () => {
+    registerPostProcessor({
+      name: "title-none",
+      label: "",
+      description: "",
+      execute: async ({ text }) => ({ text }),
+    });
+    registerPostProcessor({
+      name: "title-set",
+      label: "",
+      description: "",
+      execute: async ({ text }) => ({ text, title: "New Title" }),
+    });
+
+    const kept = await applyPostProcessors(
+      baseInput({ title: "Original" }),
+      ["title-none"]
+    );
+    expect(kept.title).toBe("Original");
+
+    const replaced = await applyPostProcessors(
+      baseInput({ title: "Original" }),
+      ["title-none", "title-set"]
+    );
+    expect(replaced.title).toBe("New Title");
+  });
+
+  it("keeps pages when a processor returns them", async () => {
+    registerPostProcessor({
+      name: "pages-keep",
+      label: "",
+      description: "",
+      execute: async ({ text, pages }) => ({ text, pages }),
+    });
+
+    const result = await applyPostProcessors(
+      baseInput({ pages: [{ page: 1, text: "p1" }] }),
+      ["pages-keep"]
+    );
+
+    expect(result.pages).toEqual([{ page: 1, text: "p1" }]);
+  });
+
+  it("drops pages when a processor rewrites text without returning pages", async () => {
+    registerPostProcessor({
+      name: "pages-drop",
+      label: "",
+      description: "",
+      execute: async ({ text }) => ({ text: text + "!" }),
+    });
+
+    const result = await applyPostProcessors(
+      baseInput({ pages: [{ page: 1, text: "p1" }] }),
+      ["pages-drop"]
+    );
+
+    expect(result.pages).toBeUndefined();
+  });
+
+  it("passes source, context and model through to the processor", async () => {
+    let received: PostProcessorInput | undefined;
+    registerPostProcessor({
+      name: "capture-input",
+      label: "",
+      description: "",
+      execute: async (input) => {
+        received = input;
+        return { text: input.text };
+      },
+    });
+
+    const input = baseInput({
+      source: {
+        type: "url",
+        url: "https://example.com",
+        includesImages: true,
+      },
+      context: { tenantId: "t9", userId: "u1", teamId: "team1" },
+      model: "gpt-x",
+    });
+    await applyPostProcessors(input, ["capture-input"]);
+
+    expect(received?.source).toEqual({
+      type: "url",
+      url: "https://example.com",
+      includesImages: true,
+    });
+    expect(received?.context).toEqual({
+      tenantId: "t9",
+      userId: "u1",
+      teamId: "team1",
+    });
+    expect(received?.model).toBe("gpt-x");
+  });
+
+  it("throws when a requested processor is not registered", async () => {
+    await expect(
+      applyPostProcessors(baseInput(), ["does-not-exist"])
+    ).rejects.toThrow("Post processor 'does-not-exist' is not registered.");
+  });
+});
+
+describe("registerPostProcessor", () => {
+  it("throws when registering the same name twice", () => {
+    const processor: PostProcessor = {
+      name: "duplicate-name",
+      label: "",
+      description: "",
+      execute: async ({ text }) => ({ text }),
+    };
+    registerPostProcessor(processor);
+    expect(() => registerPostProcessor(processor)).toThrow(
+      "Post processor with name 'duplicate-name' already registered."
+    );
+  });
+});
+
+describe("getAllPostProcessors", () => {
+  it("exposes metadata but not the execute function", async () => {
+    registerPostProcessor({
+      name: "listed-processor",
+      label: "Listed",
+      description: "a listed processor",
+      execute: async ({ text }) => ({ text }),
+    });
+
+    const listed = getAllPostProcessors().find(
+      (p) => p.name === "listed-processor"
+    );
+
+    expect(listed).toEqual({
+      name: "listed-processor",
+      label: "Listed",
+      description: "a listed processor",
+    });
+    expect((listed as Record<string, unknown>).execute).toBeUndefined();
+  });
+});

--- a/src/lib/knowledge/parsing/post-processors.ts
+++ b/src/lib/knowledge/parsing/post-processors.ts
@@ -1,12 +1,87 @@
+import type { PageContent } from "./pdf/types";
+
+/**
+ * Input handed to a post processor. Post processors run AFTER a document has
+ * been parsed to markdown (PDF/OCR, URL, uploaded file, plain text) and BEFORE
+ * it is stored — either as RAG knowledge entries or as knowledgeText wiki
+ * pages. They may rewrite the text (e.g. clean up a datasheet via an LLM),
+ * extract structured data, or suggest a better title.
+ */
+export type PostProcessorInput = {
+  /**
+   * The current document text (markdown). For multi-page documents this is
+   * the concatenation of all page texts.
+   */
+  text: string;
+  /**
+   * Per-page structure when the parser provided it (e.g. Mistral OCR gives
+   * one entry per page). A processor that rewrites the text should return an
+   * updated `pages` array if it wants the page/citation mapping to survive
+   * downstream (the RAG splitter stores `chunk.meta.page` from it). If a
+   * processor rewrites the text but returns no `pages`, the mapping is
+   * considered invalid and page-level metadata is dropped.
+   */
+  pages?: PageContent[];
+  /** Current document title (file name / page title), if known. */
+  title?: string;
+  /** Where the document came from and what it contains. */
+  source: {
+    /** e.g. "url", "text", "external", "db", "local", "file" */
+    type: string;
+    url?: string;
+    fileName?: string;
+    mimeType?: string;
+    includesImages: boolean;
+  };
+  /** Tenant scoping plus the optional acting user/team/workspace. */
+  context: {
+    tenantId: string;
+    userId?: string;
+    teamId?: string;
+    workspaceId?: string;
+  };
+  /** Preferred LLM model, if the caller configured one. */
+  model?: string;
+};
+
+/**
+ * Result returned by a post processor. Only `text` is required.
+ */
+export type PostProcessorOutput = {
+  /** The processed text (required). */
+  text: string;
+  /**
+   * Updated page structure. Omit to signal that the page mapping is no longer
+   * valid after this processor (downstream drops page-level metadata).
+   */
+  pages?: PageContent[];
+  /** Optional replacement title. */
+  title?: string;
+  /**
+   * Structured data extracted by the processor (e.g. datasheet fields).
+   * Merged across processors and persisted into `knowledgeText.meta` on the
+   * wiki import path.
+   */
+  meta?: Record<string, unknown>;
+};
+
 // PostProcessor type definition
 export type PostProcessor = {
   name: string;
   label: string;
   description: string;
-  execute: (input: {
-    text: string;
-    tenantId: string;
-  }) => Promise<{ text: string }>;
+  execute: (input: PostProcessorInput) => Promise<PostProcessorOutput>;
+};
+
+/**
+ * Aggregated result of running a chain of post processors.
+ */
+export type ApplyPostProcessorsResult = {
+  text: string;
+  pages?: PageContent[];
+  title?: string;
+  /** Merged `meta` of all processors (empty object if none produced any). */
+  meta: Record<string, unknown>;
 };
 
 // Registry for post processors
@@ -35,28 +110,44 @@ export function getAllPostProcessors(): Omit<PostProcessor, "execute">[] {
 }
 
 /**
- * Apply post processors by name in order to the text
+ * Apply post processors by name, in order, to a parsed document. Each
+ * processor receives the (possibly already modified) text/pages/title of the
+ * previous one; structured `meta` outputs are merged.
  */
 export async function applyPostProcessors(
-  text: string,
-  tenantId: string,
+  input: PostProcessorInput,
   processorNames?: string[]
-): Promise<string> {
+): Promise<ApplyPostProcessorsResult> {
+  let text = input.text;
+  let pages = input.pages;
+  let title = input.title;
+  const meta: Record<string, unknown> = {};
+
   if (!processorNames || processorNames.length === 0) {
-    return text;
+    return { text, pages, title, meta };
   }
 
-  let result = text;
   for (const name of processorNames) {
     const processor = postProcessorRegistry[name];
     if (!processor) {
       throw new Error(`Post processor '${name}' is not registered.`);
     }
-    const processed = await processor.execute({
-      text: result,
-      tenantId: tenantId,
+    const result = await processor.execute({
+      ...input,
+      text,
+      pages,
+      title,
     });
-    result = processed.text;
+    text = result.text;
+    // A processor that rewrites the text invalidates the previous page
+    // mapping unless it returns a fresh one. Adopt whatever it returned
+    // (possibly undefined → page-level metadata is dropped downstream).
+    pages = result.pages;
+    if (result.title !== undefined) title = result.title;
+    if (result.meta) {
+      Object.assign(meta, result.meta);
+    }
   }
-  return result;
+
+  return { text, pages, title, meta };
 }

--- a/src/routes/tenant/[tenantId]/knowledge/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/index.ts
@@ -715,16 +715,21 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
         const { tenantId } = c.req.valid("param");
         validateOrganisationId(data, tenantId);
 
-        const text = await applyPostProcessors(
-          data.text,
-          tenantId,
+        const processed = await applyPostProcessors(
+          {
+            text: data.text,
+            title: data.title,
+            source: { type: "text", includesImages: false },
+            context: { tenantId, userId: c.get("usersId") },
+          },
           data.usePostProcessors
         );
+        const text = processed.text;
 
         const r = await extractKnowledgeFromText({
           userId: c.get("usersId"),
           tenantId: data.tenantId,
-          title: data.title,
+          title: processed.title ?? data.title,
           text,
           filters: data.filters,
           teamId: data.teamId,
@@ -793,16 +798,21 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
           );
         }
 
-        const text = await applyPostProcessors(
-          parsed.markdown,
-          tenantId,
+        const processed = await applyPostProcessors(
+          {
+            text: parsed.markdown,
+            title: parsed.title,
+            source: { type: "url", url: data.url, includesImages: false },
+            context: { tenantId, userId: c.get("usersId") },
+          },
           data.usePostProcessors
         );
+        const text = processed.text;
 
         const r = await extractKnowledgeFromText({
           userId: c.get("usersId"),
           tenantId: data.tenantId,
-          title: parsed.title,
+          title: processed.title ?? parsed.title,
           text,
           filters: data.filters,
           teamId: data.teamId,

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -212,6 +212,7 @@ export default function defineRoutesForKnowledgeTexts(
               tenantWide: v.optional(v.string()),
               embeddingEnabled: v.optional(v.string()),
               splitIntoBlocks: v.optional(v.string()),
+              usePostProcessors: v.optional(v.string()),
             }),
           },
         },
@@ -248,6 +249,12 @@ export default function defineRoutesForKnowledgeTexts(
             form.get("embeddingEnabled")?.toString() === "true",
           splitIntoBlocks:
             form.get("splitIntoBlocks")?.toString() !== "false",
+          usePostProcessors: form
+            .get("usePostProcessors")
+            ?.toString()
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0),
         });
         return c.json(r);
       } catch (e) {
@@ -284,6 +291,7 @@ export default function defineRoutesForKnowledgeTexts(
         tenantWide: v.optional(v.boolean()),
         embeddingEnabled: v.optional(v.boolean()),
         splitIntoBlocks: v.optional(v.boolean()),
+        usePostProcessors: v.optional(v.array(v.string())),
       })
     ),
     validator("param", v.object({ tenantId: v.string() })),
@@ -303,6 +311,7 @@ export default function defineRoutesForKnowledgeTexts(
           tenantWide: body.tenantWide,
           embeddingEnabled: body.embeddingEnabled,
           splitIntoBlocks: body.splitIntoBlocks,
+          usePostProcessors: body.usePostProcessors,
         });
         return c.json(r);
       } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import type { JobHandlerRegister } from "./lib/jobs";
 import type { Task } from "./lib/cron";
 import type { SyncItem } from "./lib/types/sync";
 import type { ProcessedWhatsAppMessage } from "./lib/communication/whatsapp";
+import type { PostProcessor } from "./lib/knowledge/parsing/post-processors";
 
 export type { SyncItem };
 export type { JobHandlerRegister };
@@ -106,6 +107,14 @@ export interface ServerSpecificConfig {
   customPreRegisterCustomVerifications?: CustomPreRegisterVerification[];
   customPostRegisterActions?: CustomPostRegisterAction[];
   customPostConnectionActions?: CustomPostConnectionAction[];
+
+  // Knowledge post processors
+  /**
+   * Post processors registered at server start. They run after a document is
+   * parsed to markdown (PDF/OCR, URL, uploaded file, plain text) and before it
+   * is stored, and are selected per-import by `name` via `usePostProcessors`.
+   */
+  customPostProcessors?: PostProcessor[];
 
   // CRON
   customCronJobs?: Task[];


### PR DESCRIPTION
Follow-up to #48 (naming cleanup, already merged). This builds out the post-processing concept for PDF/URL/file/text imports so it is actually usable for cases like LLM-based datasheet cleanup.

## Step 1 — richer `PostProcessor` interface
- `execute()` now receives `text`, `pages`, `title`, `source` (`type`/`url`/`fileName`/`mimeType`/`includesImages`), `context` (`tenant`/`user`/`team`/`workspace`) and `model`, instead of just `{ text, tenantId }`.
- `execute()` may return `pages`, `title` and structured `meta` in addition to `text`.
- `applyPostProcessors()` takes a rich input object and returns an aggregated `{ text, pages, title, meta }` result, threading state across the processor chain (meta merged).
- **Page/citation info is preserved**: `parseDocument` no longer unconditionally drops `pages`. The mapping survives if a processor returns updated `pages`, and is only dropped when a rewrite invalidates it. The `from-text` / `from-url` routes can now also adopt a processor-suggested title.

## Step 2 — wire post-processing into the `knowledgeText` (wiki) import path
- `importMarkdownAsKnowledgeText` applies post processors before creating the page; the cleaned text also feeds the block splitting, a returned title overrides the derived one, and structured `meta` is merged into `knowledgeText.meta`.
- `usePostProcessors` plumbed through the `/texts/import` (comma-separated form value) and `/texts/import-url` (array) routes.

## Step 3 — fix the dead `usePostProcessors` parameter in `extractKnowledgeInOneStep`
- It was declared but ignored. Both the file and text branches now apply the processors, and the file branch also forwards parsed `pages` to the extractor (aligning it with the `parseDocument` path).

## Notes / follow-up
- On the RAG path the structured `meta` output is not yet persisted into `knowledgeEntry`, because its `metadata` field is string-typed. Full `meta` usage currently lives on the wiki path (jsonb). Persisting it for RAG entries would be a small schema follow-up.
- No concrete post processor is registered yet (registry is still empty at runtime) — the actual LLM datasheet processor is the next step.

## Verification
- `tsc --noEmit` is clean for all changed files (the only remaining errors are pre-existing, in `src/test/fetcher.test.ts`).
- Integration tests that touch the DB/embedding APIs could not be run in this environment (no Postgres/embedding backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdZ1T5vEpUyoCCDnkKvvr1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdZ1T5vEpUyoCCDnkKvvr1)_