### PR TITLE
fix(oauth2): support claude.ai MCP connector flow (DCR scopes + RFC 8707 resource)

### DIFF
--- a/docs/framework/16_OAuth2_OIDC_Provider.md
+++ b/docs/framework/16_OAuth2_OIDC_Provider.md
@@ -14,7 +14,7 @@
 | Thema | Entscheidung |
 |---|---|
 | Protokoll | OAuth 2.1 **+ OIDC** (id_token, /userinfo, JWKS, openid-configuration) |
-| Client-Registrierung | **Nur Admin-erzeugt pro Tenant** — kein Dynamic Client Registration |
+| Client-Registrierung | **Admin-erzeugt pro Tenant** *oder* **Dynamic Client Registration** (RFC 7591, `POST /oauth/register`, immer `public`+PKCE). DCR ohne `scope` erhält die `dcrDefaultScopes` (leer = alle unterstützten Scopes). |
 | Login im Authorize-Flow | **Email-Code (OTP) ist fester Default.** Passwort und Passkey sind manuelle Alternativen, die der Nutzer selbst auf der Login-Seite wählt. **Kein** `login/methods`-/Methoden-Probing-Endpunkt — vermeidet User-Enumeration. Code wird im selben Fenster eingegeben (kein Magic-Link). |
 | Tenant | Nutzer in mehreren Tenants → **Auswahl im Authorize-Flow**; Token an Tenant gebunden |
 | Consent | **Persistenz** (gemerkte Zustimmung pro User+Client+Scopes, Re-Consent nur bei neuen Scopes) |
@@ -44,7 +44,8 @@
 - `POST /oauth/login/start` `{email}` → OTP per Mail (Hash, TTL 10m, max 5 Versuche)
 - `POST /oauth/login/verify` `{email,code}` → Session-Cookie
 - `POST /oauth/consent` — Erlauben/Ablehnen (+ persistente Zustimmung)
-- `POST /oauth/token` — `authorization_code` (+PKCE S256) & `refresh_token` (Rotation+Reuse-Detection); bei `openid`-Scope zusätzlich **id_token**
+- `POST /oauth/token` — `authorization_code` (+PKCE S256) & `refresh_token` (Rotation+Reuse-Detection); bei `openid`-Scope zusätzlich **id_token**. Ein `resource`-Parameter (RFC 8707, von MCP-Clients gesendet) wird zur Token-Audience (`aud`); ohne ihn bleibt `aud` = Issuer. Ungültige Werte → `invalid_target`.
+- `POST /oauth/register` — Dynamic Client Registration (RFC 7591); immer `public` + PKCE. Ohne `scope` werden die `dcrDefaultScopes` vergeben (leer = alle unterstützten Scopes).
 - `POST /oauth/revoke` (RFC 7009)
 - `GET /oauth/userinfo` — Bearer Access-Token → OIDC-Claims
 

--- a/src/lib/oauth2/index.ts
+++ b/src/lib/oauth2/index.ts
@@ -63,6 +63,41 @@ const isScopeAllowed = (scope: string, client: OAuthClientRow): boolean =>
   (OIDC_SCOPES as readonly string[]).includes(scope) ||
   (client.scopes as string[]).includes(scope);
 
+/** Scopes granted to RFC 7591 clients that register without `scope`. */
+const dcrDefaultScopes = (): string[] => {
+  const configured = oauthCfg().dcrDefaultScopes;
+  if (configured && configured.length > 0) {
+    return configured;
+  }
+  return [...OIDC_SCOPES, ...availableScopes.all];
+};
+
+/**
+ * RFC 8707 resource indicator: must be an absolute URI without a fragment.
+ * Returns the resource or undefined (absent), throws on a malformed value.
+ */
+const parseResourceParam = (value: unknown): string | undefined => {
+  if (typeof value !== "string" || value === "") {
+    return undefined;
+  }
+  let u: URL;
+  try {
+    u = new URL(value);
+  } catch {
+    throw new InvalidTargetError(value);
+  }
+  if (u.hash) {
+    throw new InvalidTargetError(value);
+  }
+  return value;
+};
+
+class InvalidTargetError extends Error {
+  constructor(resource: string) {
+    super(`Invalid resource indicator: ${resource}`);
+  }
+}
+
 const appendParams = (
   uri: string,
   params: Record<string, string | undefined | null>
@@ -176,7 +211,10 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
     }
 
     // From here redirect_uri is trusted → recoverable errors go via redirect.
-    const redirErr = (error: string) => {
+    const redirErr = (error: string, detail = "") => {
+      console.error(
+        `[oauth2] authorize rejected (client=${client.clientId}, error=${error})${detail ? ": " + detail : ""}`
+      );
       if (wantsJson(c)) return c.json({ step: "error", error }, 400);
       return c.redirect(appendParams(redirectUri, { error, state: q.state }));
     };
@@ -188,7 +226,10 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
 
     const requested = parseScopes(q.scope);
     if (requested.some((s) => !isScopeAllowed(s, client)))
-      return redirErr("invalid_scope");
+      return redirErr(
+        "invalid_scope",
+        `requested="${q.scope ?? ""}" allowed="${(client.scopes as string[]).join(" ")}"`
+      );
 
     const userId = await currentUserId(c);
     if (!userId) {
@@ -208,7 +249,7 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
     } else if (memberships.length === 1) {
       tenantId = memberships[0]!.id;
     } else if (memberships.length === 0) {
-      return redirErr("access_denied");
+      return redirErr("access_denied", `user ${userId} has no tenant membership`);
     } else {
       if (wantsJson(c))
         return c.json({ step: "tenant", tenants: memberships });
@@ -370,6 +411,10 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
     const grantType = body.grant_type;
 
     try {
+      // RFC 8707: bind the access token's audience to the requested resource
+      // (MCP clients like claude.ai send their MCP server URL here).
+      const resource = parseResourceParam(body.resource);
+
       if (grantType === "authorization_code") {
         const payload = await consumeAuthCode(
           body.code ?? "",
@@ -392,6 +437,7 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
             tenantId: payload.tenantId,
             scopes: payload.scopes,
             nonce: payload.nonce,
+            resource,
           })
         );
       }
@@ -409,6 +455,7 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
             scopes: rotated.scopes,
             nonce: null,
             existingRefreshToken: rotated.refreshToken,
+            resource,
           })
         );
       }
@@ -416,7 +463,11 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
       return c.json({ error: "unsupported_grant_type" }, 400);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return c.json({ error: "invalid_grant", error_description: message }, 400);
+      const error = err instanceof InvalidTargetError ? "invalid_target" : "invalid_grant";
+      console.error(
+        `[oauth2] token request failed (client=${clientId ?? "?"}, grant=${grantType ?? "?"}): ${message}`
+      );
+      return c.json({ error, error_description: message }, 400);
     }
   });
 
@@ -451,11 +502,17 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
       );
     }
     try {
+      // RFC 7591: `scope` is optional — fall back to the default scope set so
+      // dynamically registered clients can actually request the scopes the
+      // resource server advertises.
+      const requestedScopes = parseScopes(body.scope);
+      const scopes =
+        requestedScopes.length > 0 ? requestedScopes : dcrDefaultScopes();
       const result = await createOAuthClient({
         tenantId: null,
         clientName: body.client_name || "Dynamic Client",
         redirectUris: body.redirect_uris,
-        scopes: body.scope ? body.scope.split(/\s+/).filter(Boolean) : [],
+        scopes,
         clientType: "public",
         clientId: body.client_id || undefined,
       });
@@ -468,7 +525,7 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
           grant_types: body.grant_types ?? ["authorization_code", "refresh_token"],
           response_types: body.response_types ?? ["code"],
           token_endpoint_auth_method: "none",
-          scope: body.scope ?? "",
+          scope: scopes.join(" "),
           client_id_issued_at: Math.floor(Date.now() / 1000),
           registration_client_uri: `${issuer}/oauth/register/${result.clientId}`,
         },
@@ -618,6 +675,8 @@ const buildTokenResponse = async (args: {
   scopes: string[];
   nonce: string | null;
   existingRefreshToken?: string;
+  /** RFC 8707 resource indicator — becomes the access token audience. */
+  resource?: string;
 }) => {
   const user = await loadOidcUser(args.userId);
   const { token: accessToken, expiresIn } = generateAccessToken({
@@ -626,6 +685,7 @@ const buildTokenResponse = async (args: {
     tenantId: args.tenantId,
     clientId: args.clientId,
     scopes: args.scopes,
+    resource: args.resource,
   });
 
   const refreshToken =

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -61,6 +61,7 @@ export const _GLOBAL_SERVER_CONFIG = {
     emailLoginCodeTtl: 60 * 10, // 10 minutes
     emailLoginCodeMaxAttempts: 5,
     introspectionSecret: "",
+    dcrDefaultScopes: [] as string[], // empty = all supported scopes
     views: defaultOAuthViews,
   },
 };
@@ -173,6 +174,7 @@ export const setGlobalServerConfig = (config: ServerSpecificConfig) => {
     emailLoginCodeTtl: o.emailLoginCodeTtl ?? 60 * 10,
     emailLoginCodeMaxAttempts: o.emailLoginCodeMaxAttempts ?? 5,
     introspectionSecret: o.introspectionSecret ?? "",
+    dcrDefaultScopes: o.dcrDefaultScopes ?? [],
     views: { ...defaultOAuthViews, ...(o.views ?? {}) },
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,12 @@ export interface ServerSpecificConfig {
     emailLoginCodeMaxAttempts?: number; // default 5
     // Shared secret for RFC 7662 token introspection (resource servers send this as Bearer).
     introspectionSecret?: string;
+    // Scopes assigned to dynamically registered clients (RFC 7591) that omit
+    // `scope` in their registration request. Empty/unset = all supported
+    // scopes. MCP clients like claude.ai register without `scope` and then
+    // request the scopes advertised by the resource server, so an empty
+    // client allow-list would fail every authorize request with invalid_scope.
+    dcrDefaultScopes?: string[];
     // Override the default login/consent/tenant-select HTML (like emailTemplates).
     views?: Partial<import("./lib/oauth2/views").OAuthViews>;
   };


### PR DESCRIPTION
## Problem

Connecting the MCP server as a custom connector in claude.ai failed after a seemingly successful login/consent:

> „Dein Konto wurde autorisiert, aber `<AppName>` hat beim Verbinden einen Fehler zurückgegeben."

claude.ai's "auto" connector mode runs: DCR **without** a `scope` field → authorize with the scopes advertised by the resource server → token exchange with a `resource` (RFC 8707) indicator → MCP calls with the bearer token. Three defects in the framework's OAuth2 authorization server broke this:

1. **`invalid_scope` for every DCR client (main bug).** `POST /oauth/register` created clients with an **empty** scope allow-list when the request omitted `scope`. Every subsequent authorize request (e.g. `knowledge:read knowledge:write`) was then rejected with `invalid_scope`, so the auto flow could never complete.
2. **RFC 8707 `resource` ignored.** The token audience (`aud`) was always the issuer, so a resource server that binds the audience to its own MCP URL rejected the token with `401` after authorization succeeded.
3. **No diagnostics.** Authorize rejections and token failures weren't logged, making this error class undiagnosable from server logs.

This PR is **Part A** of the fix (the framework itself). The per-app resource-server changes (Part B) are handled separately in each consuming app.

## Changes

- **DCR default scopes (RFC 7591):** clients that register without `scope` now receive the configurable `dcrDefaultScopes` (empty/unset = all supported scopes) instead of an empty allow-list. The registration response echoes the scopes actually granted.
- **RFC 8707 `resource` → audience:** the token endpoint validates the `resource` parameter (absolute URI, no fragment) and binds it to the access token `aud`. Without it, `aud` stays the issuer (unchanged legacy behaviour). Malformed values return `invalid_target`.
- **Diagnostics:** authorize rejections now log the requested vs. allowed scopes (and the reason for `access_denied`); token failures log client + grant + message.
- **Config:** new `oauth2.dcrDefaultScopes?: string[]` in `ServerSpecificConfig`, threaded through the global server config (default `[]`).
- **Docs:** `docs/framework/16_OAuth2_OIDC_Provider.md` — corrected the outdated "no Dynamic Client Registration" note, documented the DCR default-scope behaviour and the `resource` → audience binding.

Files: `src/lib/oauth2/index.ts`, `src/store/index.ts`, `src/types.ts`, `docs/framework/16_OAuth2_OIDC_Provider.md`. (The `resource` plumbing in `src/lib/oauth2/tokens.ts` was already present; this PR wires it through the token endpoint.)

## Verification

- **Existing OAuth2/OIDC smoke test** (`.scripts/oauth-flow.ts`, in-process against a real DB): **16/16 pass** — no regression.
- **New end-to-end simulation of the claude.ai connector flow** (DCR without `scope` → authorize → consent → token with `resource` → audience binding): **10/10 pass**, including:
  - DCR without `scope` → `201` with the configured default scopes echoed
  - authorize accepts the advertised scopes (no `invalid_scope`) → consent → code
  - token `aud` = the requested `resource` (RFC 8707); refresh preserves it
  - no `resource` → `aud` defaults to the issuer
  - malformed `resource` → `400 invalid_target`
- `tsc` introduces no new type errors (pre-existing unrelated test-file errors only).

## Rollout note

The fix applies to **new** registrations only. Existing claude.ai connectors registered before this change have empty scope lists in `base_oauth_clients`; after deploy, reconnect the connector in claude.ai (or backfill the client's scopes via the tenant OAuth-apps management API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkAisH44XVw72TpKievHJ2)_