### PR TITLE
Add smart, markdown-aware document chunking strategy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -522,3 +522,13 @@ export type {
   PostProcessorResolver,
   ApplyPostProcessorsResult,
 } from "./lib/knowledge/parsing/post-processors";
+export {
+  splitDocumentIntoChunks,
+} from "./lib/knowledge/chunking";
+export type { ChunkingStrategy } from "./lib/knowledge/chunking";
+export {
+  splitTextIntoSectionsOrChunks,
+} from "./lib/knowledge/splitter";
+export {
+  smartSplitTextIntoSectionsOrChunks,
+} from "./lib/knowledge/smart-splitter";

--- a/src/lib/knowledge/add-knowledge.ts
+++ b/src/lib/knowledge/add-knowledge.ts
@@ -14,7 +14,7 @@
 import { getDb } from "../db/db-connection";
 import log from "../log";
 import type { FileSourceType } from "../storage";
-import { splitTextIntoSectionsOrChunks } from "./splitter";
+import { splitDocumentIntoChunks } from "./chunking";
 import type { ChunkWithEmbedding } from "../types/chunks";
 import {
   knowledgeChunks,
@@ -99,7 +99,7 @@ export const extractKnowledgeFromText = async (data: {
   }
 
   // Split the content into chunks - now handles both text and pages
-  const chunks = splitTextIntoSectionsOrChunks(data.pages || fullText);
+  const chunks = splitDocumentIntoChunks(data.pages || fullText);
 
   // Generate embeddings for all chunks
   const allEmbeddings: ChunkWithEmbedding[] = await Promise.all(

--- a/src/lib/knowledge/chunking.test.ts
+++ b/src/lib/knowledge/chunking.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { splitDocumentIntoChunks } from "./chunking";
+import { splitTextIntoSectionsOrChunks } from "./splitter";
+import { smartSplitTextIntoSectionsOrChunks } from "./smart-splitter";
+import { _GLOBAL_SERVER_CONFIG } from "../../store";
+
+// An oversized markdown table is the clearest behavioural difference between
+// the two strategies: "smart" repeats the header in every part, "simple" does
+// not.
+const buildOversizedTable = (): string => {
+  const lines = ["| Code | Meaning |", "|------|---------|"];
+  for (let i = 0; i < 300; i++) {
+    lines.push(`| E${i} | Error description number ${i} with some extra text |`);
+  }
+  return lines.join("\n");
+};
+
+describe("splitDocumentIntoChunks", () => {
+  const originalStrategy = _GLOBAL_SERVER_CONFIG.chunkingStrategy;
+
+  afterEach(() => {
+    _GLOBAL_SERVER_CONFIG.chunkingStrategy = originalStrategy;
+  });
+
+  it("defaults to the simple strategy", () => {
+    const table = buildOversizedTable();
+    expect(splitDocumentIntoChunks(table)).toEqual(
+      splitTextIntoSectionsOrChunks(table)
+    );
+    // Simple splitter does NOT repeat the header on every part.
+    const chunks = splitDocumentIntoChunks(table);
+    expect(chunks.every((c) => c.text.includes("| Code | Meaning |"))).toBe(
+      false
+    );
+  });
+
+  it("uses the smart strategy when passed explicitly", () => {
+    const table = buildOversizedTable();
+    const chunks = splitDocumentIntoChunks(table, "smart");
+
+    expect(chunks).toEqual(smartSplitTextIntoSectionsOrChunks(table));
+    expect(chunks.every((c) => c.text.includes("| Code | Meaning |"))).toBe(
+      true
+    );
+  });
+
+  it("honours the global config when no strategy is passed", () => {
+    const table = buildOversizedTable();
+
+    _GLOBAL_SERVER_CONFIG.chunkingStrategy = "smart";
+    expect(splitDocumentIntoChunks(table)).toEqual(
+      smartSplitTextIntoSectionsOrChunks(table)
+    );
+
+    _GLOBAL_SERVER_CONFIG.chunkingStrategy = "simple";
+    expect(splitDocumentIntoChunks(table)).toEqual(
+      splitTextIntoSectionsOrChunks(table)
+    );
+  });
+
+  it("an explicit strategy overrides the global config", () => {
+    const table = buildOversizedTable();
+
+    _GLOBAL_SERVER_CONFIG.chunkingStrategy = "simple";
+    expect(splitDocumentIntoChunks(table, "smart")).toEqual(
+      smartSplitTextIntoSectionsOrChunks(table)
+    );
+  });
+});

--- a/src/lib/knowledge/chunking.ts
+++ b/src/lib/knowledge/chunking.ts
@@ -1,0 +1,29 @@
+import type { Chunk } from "../types/chunks";
+import type { PageContent } from "./parsing/pdf/types";
+import { splitTextIntoSectionsOrChunks } from "./splitter";
+import { smartSplitTextIntoSectionsOrChunks } from "./smart-splitter";
+import { _GLOBAL_SERVER_CONFIG } from "../../store";
+
+/**
+ * Chunking strategy selectable per app via `defineServer({ chunkingStrategy })`.
+ *   - "simple": the original word/character splitter (default).
+ *   - "smart":  markdown/table-aware splitter (keeps tables atomic, repeats
+ *               table headers on oversized tables, paragraph/heading-aware text).
+ */
+export type ChunkingStrategy = "simple" | "smart";
+
+/**
+ * Split a parsed document (markdown string or `PageContent[]`) into chunks
+ * using the configured strategy. Pass `strategy` to override the global config
+ * (mainly for tests); otherwise the app-wide `chunkingStrategy` is used, which
+ * defaults to "simple".
+ */
+export const splitDocumentIntoChunks = (
+  input: string | PageContent[],
+  strategy?: ChunkingStrategy
+): Chunk[] => {
+  const active = strategy ?? _GLOBAL_SERVER_CONFIG.chunkingStrategy ?? "simple";
+  return active === "smart"
+    ? smartSplitTextIntoSectionsOrChunks(input)
+    : splitTextIntoSectionsOrChunks(input);
+};

--- a/src/lib/knowledge/smart-splitter.test.ts
+++ b/src/lib/knowledge/smart-splitter.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "bun:test";
+import { smartSplitTextIntoSectionsOrChunks } from "./smart-splitter";
+
+// Mirror of the constants in `splitter.ts` (kept in sync intentionally).
+const MAX_CHARS_PER_CHUNK = 6000;
+const MAX_WORDS_PER_CHUNK = 500;
+
+const buildMarkdownTable = (rows: number): string => {
+  const lines = ["| Code | Meaning |", "|------|---------|"];
+  for (let i = 0; i < rows; i++) {
+    lines.push(`| E${i} | Error description number ${i} with some extra text |`);
+  }
+  return lines.join("\n");
+};
+
+describe("smartSplitTextIntoSectionsOrChunks", () => {
+  it("keeps a short text as a single chunk", () => {
+    const text = "This is a short text";
+    const chunks = smartSplitTextIntoSectionsOrChunks(text);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.text).toBe(text);
+    expect(chunks[0]!.order).toBe(0);
+    expect(chunks[0]!.header).toBeUndefined();
+  });
+
+  it("keeps a small markdown table atomic (one chunk)", () => {
+    const table = buildMarkdownTable(5); // well under the char cap
+    expect(table.length).toBeLessThan(MAX_CHARS_PER_CHUNK);
+
+    const chunks = smartSplitTextIntoSectionsOrChunks(table);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.text).toBe(table);
+  });
+
+  it("splits an oversized table and repeats the header row in every part", () => {
+    const table = buildMarkdownTable(300); // > char cap
+    expect(table.length).toBeGreaterThan(MAX_CHARS_PER_CHUNK);
+
+    const chunks = smartSplitTextIntoSectionsOrChunks(table);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      // Every part is self-contained: it repeats the header + separator.
+      expect(chunk.text).toContain("| Code | Meaning |");
+      expect(chunk.text).toContain("|------|---------|");
+      expect(chunk.text.length).toBeLessThanOrEqual(MAX_CHARS_PER_CHUNK);
+    }
+    // order is contiguous starting at 0.
+    chunks.forEach((c, idx) => expect(c.order).toBe(idx));
+  });
+
+  it("keeps a short heading directly before a table together with it", () => {
+    const input =
+      "## Error codes\n\n| Code | Meaning |\n|---|---|\n| E1 | foo |\n| E2 | bar |";
+    const chunks = smartSplitTextIntoSectionsOrChunks(input);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.text).toContain("Error codes");
+    expect(chunks[0]!.text).toContain("| E1 | foo |");
+    expect(chunks[0]!.header).toBe("Error codes");
+  });
+
+  it("chunks free text at heading boundaries and records the header", () => {
+    const input =
+      "# First\n\nSome text under first.\n\n# Second\n\nSome text under second.";
+    const chunks = smartSplitTextIntoSectionsOrChunks(input);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]!.header).toBe("First");
+    expect(chunks[0]!.text).toContain("Some text under first.");
+    expect(chunks[1]!.header).toBe("Second");
+    expect(chunks[1]!.text).toContain("Some text under second.");
+  });
+
+  it("bundles multiple short paragraphs up to the word budget", () => {
+    // Ten short paragraphs, no headings → should collapse into a single chunk.
+    const paras = Array.from({ length: 10 }, (_, i) => `Paragraph number ${i}.`);
+    const chunks = smartSplitTextIntoSectionsOrChunks(paras.join("\n\n"));
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.text.split(/\s+/).length).toBeLessThanOrEqual(
+      MAX_WORDS_PER_CHUNK
+    );
+  });
+
+  it("hard-splits an oversized single paragraph and enforces the char cap", () => {
+    const huge = "lorem ".repeat(20_000); // ~120k chars, one paragraph
+    const chunks = smartSplitTextIntoSectionsOrChunks(huge);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(MAX_CHARS_PER_CHUNK);
+    }
+    chunks.forEach((c, idx) => expect(c.order).toBe(idx));
+  });
+
+  it("preserves whitespace-collapsed content on a round trip", () => {
+    const text = "abc ".repeat(5_000);
+    const chunks = smartSplitTextIntoSectionsOrChunks(text);
+
+    const reassembled = chunks
+      .slice()
+      .sort((a, b) => a.order - b.order)
+      .map((c) => c.text)
+      .join("");
+    const stripped = (s: string) => s.replace(/\s+/g, "");
+    expect(stripped(reassembled)).toBe(stripped(text));
+  });
+
+  it("processes PageContent[] and preserves the page number in meta", () => {
+    const hugePageText = "lorem ".repeat(20_000);
+    const chunks = smartSplitTextIntoSectionsOrChunks([
+      { page: 1, text: "Short intro page" },
+      { page: 2, text: hugePageText },
+      { page: 3, text: "Short outro page" },
+    ]);
+
+    expect(chunks.length).toBeGreaterThan(2);
+    for (const chunk of chunks) {
+      expect(chunk.text.length).toBeLessThanOrEqual(MAX_CHARS_PER_CHUNK);
+    }
+    chunks.forEach((c, idx) => expect(c.order).toBe(idx));
+    expect(chunks.some((c) => c.meta?.page === 1)).toBe(true);
+    expect(chunks.some((c) => c.meta?.page === 2)).toBe(true);
+    expect(chunks.some((c) => c.meta?.page === 3)).toBe(true);
+  });
+
+  it("returns no chunks for empty input", () => {
+    expect(smartSplitTextIntoSectionsOrChunks("")).toEqual([]);
+  });
+});

--- a/src/lib/knowledge/smart-splitter.ts
+++ b/src/lib/knowledge/smart-splitter.ts
@@ -1,0 +1,298 @@
+import type { Chunk } from "../types/chunks";
+import type { PageContent } from "./parsing/pdf/types";
+import {
+  MAX_WORDS_PER_CHUNK,
+  MAX_CHARS_PER_CHUNK,
+  countWords,
+  enforceCharLimit,
+  hardSplitText,
+} from "./splitter";
+
+/**
+ * Smart, markdown-aware chunking (ported from the knowledge-engine prototype's
+ * `chunking.py`, adapted to this framework's word/character budget so it stays
+ * pure TypeScript — no tokenizer dependency).
+ *
+ * What it does better than the simple splitter:
+ *   - Markdown tables stay ATOMIC (header + rows in one chunk) as long as they
+ *     fit the hard character cap. The simple splitter can break a table mid-way.
+ *   - A table that exceeds the cap is split into sub-tables that each REPEAT the
+ *     table header (and any single-cell "section" row), so every piece stays
+ *     self-contained and rankable during retrieval.
+ *   - A short heading / caption directly before a table is kept together with
+ *     that table so the table keeps its context.
+ *   - Free text is chunked at paragraph and heading boundaries: paragraphs are
+ *     bundled up to the word budget, a heading always starts a new chunk, and a
+ *     single oversized paragraph falls back to `hardSplitText`.
+ *
+ * The public interface mirrors `splitTextIntoSectionsOrChunks`: pass a markdown
+ * string or an array of `PageContent` (from the PDF parsers). For pages, each
+ * page is chunked independently and the page number is stored in `chunk.meta`.
+ *
+ * NOTE: only markdown pipe tables are treated specially. HTML `<table>` markup
+ * (rare here — the URL reader emits GFM markdown tables) flows through the text
+ * path and is protected only by the character cap.
+ */
+
+// A markdown table line starts and ends (trimmed) with a pipe.
+const isTableLine = (line: string): boolean => {
+  const s = line.trim();
+  return s.startsWith("|") && s.endsWith("|") && s.length >= 2;
+};
+
+const isHeading = (text: string): boolean => /^#{1,6}\s/.test(text.trimStart());
+
+// Extract the last markdown heading found in a block (without the leading #s),
+// used to populate `chunk.header`.
+const lastHeadingIn = (text: string): string | undefined => {
+  let found: string | undefined;
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (/^#{1,6}\s+/.test(trimmed)) {
+      found = trimmed.replace(/^#{1,6}\s+/, "").trim();
+    }
+  }
+  return found;
+};
+
+type Segment = { isTable: boolean; text: string };
+
+/**
+ * Split markdown into consecutive table / non-table segments. Runs of pipe
+ * lines form a table segment, everything else forms text segments.
+ */
+const segmentMarkdown = (content: string): Segment[] => {
+  const segments: Segment[] = [];
+  let buf: string[] = [];
+  let bufIsTable = false;
+
+  const flush = () => {
+    if (buf.length === 0) return;
+    const text = buf.join("\n").trim();
+    if (text) segments.push({ isTable: bufIsTable, text });
+    buf = [];
+  };
+
+  for (const line of content.split("\n")) {
+    const isTbl = isTableLine(line);
+    if (buf.length > 0 && isTbl !== bufIsTable) {
+      flush();
+    }
+    bufIsTable = isTbl;
+    buf.push(line);
+  }
+  flush();
+  return segments;
+};
+
+/**
+ * Bundle a free-text block into chunks at paragraph / heading boundaries.
+ * Returns chunk texts paired with the heading in effect for each.
+ */
+const splitTextBlock = (
+  text: string,
+  initialHeader: string | undefined
+): { pieces: { text: string; header: string | undefined }[]; endHeader: string | undefined } => {
+  const paragraphs = text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  const pieces: { text: string; header: string | undefined }[] = [];
+  let currentHeader = initialHeader;
+  let cur: string[] = [];
+  let curWords = 0;
+
+  const flush = () => {
+    if (cur.length === 0) return;
+    const joined = cur.join("\n\n").trim();
+    if (joined) pieces.push({ text: joined, header: currentHeader });
+    cur = [];
+    curWords = 0;
+  };
+
+  for (const para of paragraphs) {
+    const pWords = countWords(para);
+
+    // A heading starts a new section — flush the previous bundle first, then
+    // adopt the heading as the current header.
+    if (isHeading(para) && cur.length > 0) {
+      flush();
+    }
+    if (isHeading(para)) {
+      const h = lastHeadingIn(para);
+      if (h !== undefined) currentHeader = h;
+    }
+
+    // A single paragraph over the budget is emitted on its own and hard-split.
+    if (pWords > MAX_WORDS_PER_CHUNK || para.length > MAX_CHARS_PER_CHUNK) {
+      flush();
+      for (const sub of hardSplitText(para)) {
+        pieces.push({ text: sub, header: currentHeader });
+      }
+      continue;
+    }
+
+    // Would this paragraph overflow the current bundle? Flush first.
+    if (cur.length > 0 && curWords + pWords > MAX_WORDS_PER_CHUNK) {
+      flush();
+    }
+    cur.push(para);
+    curWords += pWords;
+  }
+  flush();
+  return { pieces, endHeader: currentHeader };
+};
+
+// A single-cell row (e.g. "| Torque specs |  |") that carries context for the
+// rows below it in workshop-style tables.
+const isSectionRow = (line: string): boolean => {
+  const cells = line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((c) => c.replace(/[ *]/g, "").trim());
+  return cells.filter((c) => c.length > 0).length === 1;
+};
+
+/**
+ * Split an oversized markdown table into sub-tables. The prefix (optional
+ * merged heading + the header row + separator row) is repeated in every part so
+ * each part is self-contained; the current single-cell "section" row is carried
+ * into the following part as context.
+ */
+const splitTableBlock = (text: string): string[] => {
+  const lines = text.split("\n");
+  const firstTbl = lines.findIndex((l) => isTableLine(l));
+  if (firstTbl === -1) return [text];
+
+  let headerEnd = firstTbl + 1;
+  // The separator row (|---|:--:|) belongs to the header.
+  if (headerEnd < lines.length && /^[\s|:\-]+$/.test(lines[headerEnd] ?? " ")) {
+    headerEnd += 1;
+  }
+  const prefix = lines.slice(0, headerEnd).join("\n");
+  const body = lines.slice(headerEnd).filter((l) => l.trim().length > 0);
+  if (body.length === 0) return [text];
+
+  const prefixWords = countWords(prefix);
+  const prefixChars = prefix.length;
+  const wordBudget = Math.max(
+    MAX_WORDS_PER_CHUNK - prefixWords,
+    Math.floor(MAX_WORDS_PER_CHUNK / 4)
+  );
+  const charBudget = Math.max(
+    MAX_CHARS_PER_CHUNK - prefixChars,
+    Math.floor(MAX_CHARS_PER_CHUNK / 4)
+  );
+
+  const parts: string[] = [];
+  let cur: string[] = [];
+  let curWords = 0;
+  let curChars = 0;
+  let currentSection: string | null = null;
+
+  const flush = () => {
+    if (cur.length === 0) return;
+    parts.push(prefix + "\n" + cur.join("\n"));
+  };
+
+  for (const line of body) {
+    const lineWords = countWords(line);
+    const lineChars = line.length + 1;
+    if (
+      cur.length > 0 &&
+      (curWords + lineWords > wordBudget || curChars + lineChars > charBudget)
+    ) {
+      flush();
+      // The next part inherits the current section row as context.
+      cur = currentSection ? [currentSection] : [];
+      curWords = currentSection ? countWords(currentSection) : 0;
+      curChars = currentSection ? currentSection.length + 1 : 0;
+    }
+    if (isSectionRow(line)) {
+      currentSection = line;
+    }
+    cur.push(line);
+    curWords += lineWords;
+    curChars += lineChars;
+  }
+  flush();
+  return parts.length > 0 ? parts : [text];
+};
+
+/**
+ * Chunk a single markdown string. Order is assigned later by `enforceCharLimit`,
+ * so the returned chunks carry `order: 0` as a placeholder.
+ */
+const smartChunkString = (text: string): Chunk[] => {
+  const segments = segmentMarkdown(text);
+
+  // Merge a short text segment (heading / caption) into the following table so
+  // the table keeps its context.
+  const headingLimit = Math.max(1, Math.floor(MAX_WORDS_PER_CHUNK / 4));
+  const merged: Segment[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]!;
+    const next = segments[i + 1];
+    if (
+      !seg.isTable &&
+      next &&
+      next.isTable &&
+      countWords(seg.text) <= headingLimit
+    ) {
+      merged.push({ isTable: true, text: seg.text + "\n\n" + next.text });
+      i += 1; // consumed the table too
+    } else {
+      merged.push(seg);
+    }
+  }
+
+  const chunks: Chunk[] = [];
+  let runningHeader: string | undefined;
+
+  for (const seg of merged) {
+    if (seg.isTable) {
+      const heading = lastHeadingIn(seg.text);
+      if (heading !== undefined) runningHeader = heading;
+      // Keep the table atomic while it fits the hard cap; otherwise split it
+      // into header-repeating sub-tables.
+      const parts =
+        seg.text.length <= MAX_CHARS_PER_CHUNK
+          ? [seg.text]
+          : splitTableBlock(seg.text);
+      for (const part of parts) {
+        chunks.push({ text: part, header: runningHeader, order: 0 });
+      }
+    } else {
+      const { pieces, endHeader } = splitTextBlock(seg.text, runningHeader);
+      for (const piece of pieces) {
+        chunks.push({ text: piece.text, header: piece.header, order: 0 });
+      }
+      runningHeader = endHeader;
+    }
+  }
+  return chunks;
+};
+
+/**
+ * Smart, markdown/table-aware variant of `splitTextIntoSectionsOrChunks`.
+ * Accepts a markdown string or an array of `PageContent`.
+ */
+export const smartSplitTextIntoSectionsOrChunks = (
+  input: string | PageContent[]
+): Chunk[] => {
+  if (Array.isArray(input)) {
+    const all: Chunk[] = [];
+    input.forEach((p) => {
+      const forPage = smartChunkString(p.text);
+      forPage.forEach((c) => (c.meta = { page: p.page }));
+      all.push(...forPage);
+    });
+    // `enforceCharLimit` re-numbers order sequentially and acts as a final
+    // safety net against any piece still over the character cap.
+    return enforceCharLimit(all);
+  }
+  return enforceCharLimit(smartChunkString(input));
+};

--- a/src/lib/knowledge/splitter.ts
+++ b/src/lib/knowledge/splitter.ts
@@ -1,7 +1,7 @@
 import type { Chunk } from "../types/chunks";
 import type { PageContent } from "./parsing/pdf/types";
 
-const MAX_WORDS_PER_CHUNK = 500;
+export const MAX_WORDS_PER_CHUNK = 500;
 
 /**
  * Hard upper bound on a single chunk's character length.
@@ -15,10 +15,10 @@ const MAX_WORDS_PER_CHUNK = 500;
  * below the 8192 token ceiling to leave headroom for these worst-case
  * inputs.
  */
-const MAX_CHARS_PER_CHUNK = 6000;
+export const MAX_CHARS_PER_CHUNK = 6000;
 
 // Counts words in a given text (consecutive sequences separated by whitespace).
-const countWords = (text: string): number => {
+export const countWords = (text: string): number => {
   return text.trim() === "" ? 0 : text.trim().split(/\s+/).length;
 };
 
@@ -108,7 +108,7 @@ export const hardSplitText = (text: string): string[] => {
  * preserving the original `header` and `meta`. Sequential `order` values
  * are assigned across the resulting list.
  */
-const enforceCharLimit = (chunks: Chunk[]): Chunk[] => {
+export const enforceCharLimit = (chunks: Chunk[]): Chunk[] => {
   const result: Chunk[] = [];
   let order = 0;
   for (const chunk of chunks) {

--- a/src/lib/knowledge/update-knowledge.ts
+++ b/src/lib/knowledge/update-knowledge.ts
@@ -3,7 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { knowledgeEntry, knowledgeChunks } from "../db/schema/knowledge";
 import { isUserPartOfTeam } from "../usermanagement/teams";
 import { validateKnowledgeAccess } from "./permissions";
-import { splitTextIntoSectionsOrChunks } from "./splitter";
+import { splitDocumentIntoChunks } from "./chunking";
 import { generateEmbedding } from "./embedding";
 import type { ChunkWithEmbedding } from "../types/chunks";
 import type { KnowledgeChunksInsert } from "../db/schema/knowledge";
@@ -126,7 +126,7 @@ export const updateKnowledgeEntryText = async (
   log.debug(`Deleted existing chunks for knowledge entry: ${id}`);
 
   // Split the new text into chunks
-  const chunks = splitTextIntoSectionsOrChunks(text);
+  const chunks = splitDocumentIntoChunks(text);
 
   // Generate embeddings for all chunks
   const allEmbeddings: ChunkWithEmbedding[] = await Promise.all(

--- a/src/lib/knowledge/upsert-knowledge.ts
+++ b/src/lib/knowledge/upsert-knowledge.ts
@@ -40,7 +40,7 @@ import {
 import type { ChunkWithEmbedding } from "../types/chunks";
 import type { PageContent } from "./parsing/pdf/types";
 import type { FileSourceType } from "../storage";
-import { splitTextIntoSectionsOrChunks } from "./splitter";
+import { splitDocumentIntoChunks } from "./chunking";
 import { generateEmbedding } from "./embedding";
 import { extractKnowledgeFromText } from "./add-knowledge";
 import log from "../log";
@@ -98,7 +98,7 @@ const generateChunksAndEmbeddings = async (
   pages: PageContent[] | undefined,
   context: { tenantId: string; userId?: string }
 ): Promise<ChunkWithEmbedding[]> => {
-  const chunks = splitTextIntoSectionsOrChunks(pages || text);
+  const chunks = splitDocumentIntoChunks(pages || text);
 
   return await Promise.all(
     chunks.map(async (chunk) => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -50,6 +50,9 @@ export const _GLOBAL_SERVER_CONFIG = {
   whatsAppIncomingWebhookHandler: undefined as
     | WhatsAppIncomingWebhookHandler
     | undefined,
+  // Chunking strategy for splitting parsed documents into knowledge chunks.
+  // "simple" (default) = word/character splitter; "smart" = markdown/table-aware.
+  chunkingStrategy: <"simple" | "smart">"simple",
   // OAuth2 / OIDC Authorization Server (opt-in, default off)
   oauth2: {
     enabled: false,
@@ -100,6 +103,8 @@ export const setGlobalServerConfig = (config: ServerSpecificConfig) => {
 
   _GLOBAL_SERVER_CONFIG.useLicenseSystem = config.useLicenseSystem ?? false;
   _GLOBAL_SERVER_CONFIG.publicKey = config.publicKey ?? "";
+
+  _GLOBAL_SERVER_CONFIG.chunkingStrategy = config.chunkingStrategy ?? "simple";
 
   // Email Templates
   if (config.emailTemplates?.verifyEmail) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,17 @@ export interface ServerSpecificConfig {
    */
   customPostProcessorResolvers?: PostProcessorResolver[];
 
+  /**
+   * Chunking strategy used when a parsed document is split into knowledge
+   * chunks before embedding.
+   *   - "simple": word/character splitter (default).
+   *   - "smart":  markdown/table-aware splitter that keeps tables atomic,
+   *               repeats the header on oversized tables and chunks free text
+   *               at paragraph/heading boundaries.
+   * Default: "simple".
+   */
+  chunkingStrategy?: "simple" | "smart";
+
   // CRON
   customCronJobs?: Task[];
   /**


### PR DESCRIPTION
## Summary
Introduces a new "smart" chunking strategy for splitting parsed documents into knowledge chunks. This strategy is markdown and table-aware, providing better handling of structured content compared to the existing simple word/character splitter.

## Key Changes

- **New `smart-splitter.ts` module**: Implements markdown-aware chunking that:
  - Keeps markdown pipe tables atomic (header + rows in one chunk) as long as they fit the character cap
  - Splits oversized tables into sub-tables that repeat the header row, making each part self-contained and rankable
  - Merges short headings/captions directly before tables to preserve context
  - Chunks free text at paragraph and heading boundaries, bundling paragraphs up to the word budget
  - Falls back to hard splitting for single oversized paragraphs

- **New `chunking.ts` module**: Provides a unified interface (`splitDocumentIntoChunks`) that:
  - Supports both "simple" (default) and "smart" chunking strategies
  - Allows per-call strategy override via optional parameter
  - Respects global `chunkingStrategy` config from `_GLOBAL_SERVER_CONFIG`

- **Configuration support**: Added `chunkingStrategy` option to `ServerSpecificConfig` in `types.ts`, allowing apps to select their preferred chunking strategy via `defineServer()`

- **Exports**: Exposed chunking functions and types in `index.ts` for public API access

- **Integration**: Updated knowledge management modules (`add-knowledge.ts`, `update-knowledge.ts`, `upsert-knowledge.ts`) to use the new unified `splitDocumentIntoChunks` interface

- **Tests**: Added comprehensive test suites for both the smart splitter and the chunking strategy selection logic

## Notable Implementation Details

- The smart splitter segments markdown into table/non-table blocks, then processes each segment appropriately
- Table splitting preserves the header and separator rows in every sub-table for context
- Single-cell "section" rows in tables are carried forward as context when splitting
- Short text segments (headings/captions) are merged with following tables if they're under 25% of the word budget
- The implementation is pure TypeScript with no external tokenizer dependency
- All chunks are re-ordered sequentially and validated against character limits via `enforceCharLimit`

https://claude.ai/code/session_012jp2mMHbogBty1B3hEEjx7