### PR TITLE
Route PDF downloads to dedicated parser, reject other binary formats

### DIFF
--- a/src/lib/knowledge/knowledge-text-import.ts
+++ b/src/lib/knowledge/knowledge-text-import.ts
@@ -253,7 +253,14 @@ export const importKnowledgeTextFromUrl = async (
   url: string,
   options: ImportKnowledgeTextOptions
 ): Promise<ImportKnowledgeTextResult> => {
-  const result = await urlToMarkdown(url);
+  const result = await urlToMarkdown(url, {
+    parseContext: {
+      tenantId: options.tenantId,
+      userId: options.userId,
+      teamId: options.teamId,
+      workspaceId: options.workspaceId,
+    },
+  });
   if (result.markdown.trim().length === 0) {
     throw new Error("The page contains no extractable text");
   }

--- a/src/lib/knowledge/parsing/index.ts
+++ b/src/lib/knowledge/parsing/index.ts
@@ -169,7 +169,14 @@ export const parseDocument = async (data: {
     docIncludesImages = includesImages;
   } else if (data.sourceType === "url" && data.sourceUrl) {
     log.debug(`Fetch and parse content from URL: ${data.sourceUrl}`);
-    const result = await urlToMarkdown(data.sourceUrl);
+    const result = await urlToMarkdown(data.sourceUrl, {
+      parseContext: {
+        tenantId: data.tenantId,
+        teamId: data.teamId,
+        workspaceId: data.workspaceId,
+      },
+      pdfModel: data.model,
+    });
     content = result.markdown;
     title = result.title || data.sourceUrl;
     log.debug(

--- a/src/lib/knowledge/parsing/url.test.ts
+++ b/src/lib/knowledge/parsing/url.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { urlToMarkdown } from "./url";
+
+// A local test server serves the fixtures; allow the SSRF guard to reach it.
+let savedOptOut: string | undefined;
+let server: ReturnType<typeof Bun.serve>;
+let baseUrl: string;
+
+beforeAll(() => {
+  savedOptOut = process.env.SSRF_ALLOW_PRIVATE_TARGETS;
+  process.env.SSRF_ALLOW_PRIVATE_TARGETS = "true";
+
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+
+      if (pathname === "/doc.pdf") {
+        // Minimal PDF bytes: "%PDF-" magic + a little padding.
+        const bytes = new TextEncoder().encode("%PDF-1.4\n%noise\n");
+        return new Response(bytes, {
+          headers: {
+            "content-type": "application/pdf",
+            "content-disposition": 'attachment; filename="doc.pdf"',
+          },
+        });
+      }
+
+      if (pathname === "/image.png") {
+        const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic
+        return new Response(bytes, {
+          headers: { "content-type": "image/png" },
+        });
+      }
+
+      if (pathname === "/page.html") {
+        return new Response(
+          `<!doctype html><html><head><title>Hello Page</title></head>` +
+            `<body><article><h1>Heading</h1><p>Some readable paragraph of text ` +
+            `that is long enough for Readability to keep it around as content.</p>` +
+            `</article></body></html>`,
+          { headers: { "content-type": "text/html; charset=utf-8" } }
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  });
+  baseUrl = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  server?.stop(true);
+  if (savedOptOut !== undefined) {
+    process.env.SSRF_ALLOW_PRIVATE_TARGETS = savedOptOut;
+  } else {
+    delete process.env.SSRF_ALLOW_PRIVATE_TARGETS;
+  }
+});
+
+describe("urlToMarkdown", () => {
+  it("routes PDF downloads to the PDF parser (no Readability tagName crash)", async () => {
+    // With a parseContext the PDF path is taken. There is no PDF parser service
+    // configured in tests, so it fails with a clear PDF-parser message — crucially
+    // NOT the Readability `tagName` crash and NOT silent binary garbage.
+    let err: unknown;
+    try {
+      await urlToMarkdown(`${baseUrl}/doc.pdf`, {
+        parseContext: { tenantId: "test-tenant" },
+        pdfModel: "does-not-exist",
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).not.toContain("tagName");
+    expect(msg).toContain("PDF parser service");
+  });
+
+  it("rejects a PDF URL when no parseContext is provided", async () => {
+    await expect(urlToMarkdown(`${baseUrl}/doc.pdf`)).rejects.toThrow(
+      /no parseContext/i
+    );
+  });
+
+  it("rejects unsupported binary content types instead of crashing", async () => {
+    let err: unknown;
+    try {
+      await urlToMarkdown(`${baseUrl}/image.png`);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).not.toContain("tagName");
+    expect(msg).toContain("Unsupported content type");
+  });
+
+  it("converts a normal HTML page to markdown (regression)", async () => {
+    const result = await urlToMarkdown(`${baseUrl}/page.html`);
+    expect(result.title).toBe("Hello Page");
+    expect(result.markdown).toContain("Heading");
+    expect(result.markdown).toContain("readable paragraph");
+  });
+});

--- a/src/lib/knowledge/parsing/url.ts
+++ b/src/lib/knowledge/parsing/url.ts
@@ -1,14 +1,23 @@
 /**
- * Fetch an HTML document from a URL and convert it to clean markdown.
+ * Fetch a document from a URL and convert it to clean markdown.
  *
- * Pipeline:
- *   1. fetch() → HTML string (with a polite User-Agent)
+ * Pipeline (HTML path):
+ *   1. fetch() → raw bytes + content-type (with a polite User-Agent)
  *   2. linkedom → DOM
  *   3. Mozilla Readability → article (title, excerpt, byline, content HTML)
  *   4. Turndown + GFM (tables, strikethrough, task lists) → markdown
  *
  * If Readability cannot extract anything (e.g. SPA with empty <body>),
  * the entire body innerHTML is converted as fallback.
+ *
+ * Not every import URL is an HTML page. Many are file downloads (e.g. WP
+ * Download Manager `?wpdmdl=…`) that respond with `Content-Type:
+ * application/pdf`. Feeding raw PDF bytes through Readability either crashes
+ * (the mis-parsed byte soup has no <body>, so Readability walks the parent
+ * chain up to `null.tagName`) or stores megabytes of binary noise as "text".
+ * We therefore branch on the content type first: PDFs go to the dedicated PDF
+ * parser, other binary formats are rejected with a clear error, and only
+ * textual responses reach the HTML pipeline.
  */
 
 import { parseHTML } from "linkedom";
@@ -17,6 +26,7 @@ import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
 import log from "../../log";
 import { fetchWithSsrfGuard } from "../../utils/url-guard";
+import { parsePdfFileAsMardown } from "./pdf";
 
 const DEFAULT_USER_AGENT =
   "Mozilla/5.0 (compatible; SymbiosikaKnowledgeBot/1.0; +https://symbiosika.de)";
@@ -25,6 +35,18 @@ const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 export type UrlToMarkdownOptions = {
   userAgent?: string;
   timeoutMs?: number;
+  /**
+   * Required to import PDF downloads: the PDF parser needs a tenant context.
+   * Without it, PDF URLs are rejected with a clear error instead of crashing.
+   */
+  parseContext?: {
+    tenantId: string;
+    userId?: string;
+    teamId?: string;
+    workspaceId?: string;
+  };
+  /** Override the PDF parser service/model (falls back to PDF_PARSER_SERVICE). */
+  pdfModel?: string;
 };
 
 export type UrlToMarkdownResult = {
@@ -34,6 +56,12 @@ export type UrlToMarkdownResult = {
   byline: string | null;
   siteName: string | null;
   markdown: string;
+};
+
+type FetchedResource = {
+  contentType: string;
+  disposition: string;
+  bytes: Uint8Array;
 };
 
 /**
@@ -48,15 +76,20 @@ const injectBaseHref = (html: string, url: string): string => {
     return html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`);
   }
   if (/<html[^>]*>/i.test(html)) {
-    return html.replace(
-      /<html([^>]*)>/i,
-      `<html$1><head>${baseTag}</head>`
-    );
+    return html.replace(/<html([^>]*)>/i, `<html$1><head>${baseTag}</head>`);
   }
   return `<head>${baseTag}</head>${html}`;
 };
 
-const fetchHtml = async (url: string, opts?: UrlToMarkdownOptions) => {
+/**
+ * Fetch the resource at `url`, returning the raw bytes together with the
+ * content-type and content-disposition headers. We read `arrayBuffer()` (not
+ * `text()`) so binary payloads such as PDFs stay intact.
+ */
+const fetchHtml = async (
+  url: string,
+  opts?: UrlToMarkdownOptions
+): Promise<FetchedResource> => {
   const controller = new AbortController();
   const timeout = setTimeout(
     () => controller.abort(),
@@ -82,30 +115,129 @@ const fetchHtml = async (url: string, opts?: UrlToMarkdownOptions) => {
     }
 
     const contentType = response.headers.get("content-type") ?? "";
-    if (
-      !contentType.includes("text/html") &&
-      !contentType.includes("application/xhtml") &&
-      !contentType.includes("application/xml")
-    ) {
-      log.debug(
-        `URL ${url} returned non-HTML content-type "${contentType}". Trying to parse anyway.`
-      );
-    }
+    const disposition = response.headers.get("content-disposition") ?? "";
+    const bytes = new Uint8Array(await response.arrayBuffer());
 
-    return await response.text();
+    return { contentType, disposition, bytes };
   } finally {
     clearTimeout(timeout);
   }
 };
 
+/** PDF magic bytes: "%PDF-" == 25 50 44 46 2d */
+const hasPdfMagic = (bytes: Uint8Array): boolean =>
+  bytes.length >= 5 &&
+  bytes[0] === 0x25 &&
+  bytes[1] === 0x50 &&
+  bytes[2] === 0x44 &&
+  bytes[3] === 0x46 &&
+  bytes[4] === 0x2d;
+
+/** Detect PDFs by content-type, filename in content-disposition, or magic bytes. */
+const isPdf = (
+  contentType: string,
+  disposition: string,
+  bytes: Uint8Array
+): boolean =>
+  contentType.toLowerCase().includes("application/pdf") ||
+  /filename[^;=\n]*=\s*["']?[^"';\n]*\.pdf/i.test(disposition) ||
+  hasPdfMagic(bytes);
+
 /**
- * Convert the HTML page at `url` into clean markdown using Readability + Turndown.
+ * A response is safe to run through the HTML pipeline if it is HTML/XHTML/XML
+ * or plain text (or the server sent no content-type at all).
+ */
+const isTextual = (contentType: string): boolean => {
+  const ct = contentType.toLowerCase();
+  return (
+    ct === "" ||
+    ct.includes("text/html") ||
+    ct.includes("application/xhtml") ||
+    ct.includes("xml") ||
+    ct.includes("text/plain")
+  );
+};
+
+/** Extract the charset from a content-type header (defaults handled by caller). */
+const charsetFrom = (contentType: string): string | null => {
+  const m = /charset=([^;]+)/i.exec(contentType);
+  return m ? m[1].trim().replace(/^["']|["']$/g, "") : null;
+};
+
+/** Derive a filename (ending in .pdf) from content-disposition or the URL. */
+const filenameFrom = (disposition: string, url: string): string => {
+  const dispMatch =
+    /filename\*=(?:UTF-8'')?["']?([^"';\n]+)/i.exec(disposition) ??
+    /filename\s*=\s*["']?([^"';\n]+)/i.exec(disposition);
+  let name = dispMatch?.[1]?.trim();
+
+  if (!name) {
+    try {
+      const pathname = new URL(url).pathname;
+      const last = pathname.split("/").filter(Boolean).pop();
+      if (last) name = decodeURIComponent(last);
+    } catch {
+      // ignore malformed URL; fall through to default
+    }
+  }
+
+  if (!name) name = "download";
+  if (!/\.pdf$/i.test(name)) name = `${name}.pdf`;
+  return name;
+};
+
+/** Human-friendly title from a filename (strip .pdf, keep the base name). */
+const titleFrom = (name: string): string =>
+  name.replace(/\.pdf$/i, "").trim() || name;
+
+/**
+ * Convert the document at `url` into clean markdown.
+ * HTML pages use Readability + Turndown; PDF downloads use the PDF parser.
  */
 export const urlToMarkdown = async (
   url: string,
   opts?: UrlToMarkdownOptions
 ): Promise<UrlToMarkdownResult> => {
-  const html = await fetchHtml(url, opts);
+  const { contentType, disposition, bytes } = await fetchHtml(url, opts);
+
+  // PDF downloads: route to the dedicated PDF parser instead of Readability.
+  if (isPdf(contentType, disposition, bytes)) {
+    if (!opts?.parseContext) {
+      throw new Error(
+        `Cannot import PDF ${url}: no parseContext (tenantId) provided.`
+      );
+    }
+    const name = filenameFrom(disposition, url);
+    const file = new File([bytes as BlobPart], name, {
+      type: "application/pdf",
+    });
+    const parsed = await parsePdfFileAsMardown(file, opts.parseContext, {
+      model: opts.pdfModel,
+    });
+    const markdown = (parsed.pages?.map((p) => p.text).join("\n\n") ?? "").trim();
+    if (!markdown) {
+      throw new Error(`PDF at ${url} produced no extractable text.`);
+    }
+    return {
+      url,
+      title: titleFrom(name),
+      excerpt: null,
+      byline: null,
+      siteName: null,
+      markdown,
+    };
+  }
+
+  // Reject other binary formats rather than feeding them to Readability.
+  if (!isTextual(contentType)) {
+    throw new Error(
+      `Unsupported content type "${contentType}" for URL import ${url}.`
+    );
+  }
+
+  const html = new TextDecoder(charsetFrom(contentType) ?? "utf-8").decode(
+    bytes
+  );
 
   // Inject <base href> so Readability can resolve relative links/images.
   const htmlWithBase = injectBaseHref(html, url);
@@ -113,7 +245,12 @@ export const urlToMarkdown = async (
 
   // Readability mutates the document; clone first so we still have a fallback body.
   const docClone = document.cloneNode(true) as unknown as typeof document;
-  const article = new Readability(docClone as any).parse();
+  let article: ReturnType<Readability["parse"]> = null;
+  try {
+    article = new Readability(docClone as any).parse();
+  } catch (e) {
+    log.debug(`Readability failed for ${url}, using body fallback: ${e}`);
+  }
 
   const td = new TurndownService({
     headingStyle: "atx",
@@ -130,9 +267,7 @@ export const urlToMarkdown = async (
   const markdown = td.turndown(sourceHtml).trim();
 
   const title =
-    (article?.title && article.title.trim()) ||
-    document.title?.trim() ||
-    url;
+    (article?.title && article.title.trim()) || document.title?.trim() || url;
 
   return {
     url,

--- a/src/routes/tenant/[tenantId]/knowledge/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/index.ts
@@ -790,7 +790,9 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
           throw new Error("URL must start with http:// or https://");
         }
 
-        const parsed = await urlToMarkdown(data.url);
+        const parsed = await urlToMarkdown(data.url, {
+          parseContext: { tenantId },
+        });
 
         if (!parsed.markdown || parsed.markdown.trim().length === 0) {
           throw new Error(


### PR DESCRIPTION
## Summary
This PR adds intelligent content-type detection to the URL-to-markdown pipeline, routing PDF downloads to a dedicated PDF parser instead of attempting to parse them as HTML. This prevents crashes and binary garbage when importing file downloads, while maintaining support for HTML and plain text content.

## Key Changes

- **Content-type branching**: The `fetchHtml` function now returns raw bytes along with content-type and content-disposition headers, enabling downstream logic to route based on content type rather than blindly parsing everything as HTML.

- **PDF detection**: Implemented multi-method PDF detection via:
  - Content-Type header (`application/pdf`)
  - Filename in Content-Disposition header (`.pdf` extension)
  - PDF magic bytes (`%PDF-` signature)

- **PDF routing**: PDF downloads are now routed to `parsePdfFileAsMardown()` instead of Readability, with proper error handling when `parseContext` (tenantId) is missing.

- **Binary format rejection**: Non-textual content types (images, archives, etc.) are now rejected with a clear error message instead of being fed to Readability, which would either crash or produce garbage.

- **Charset handling**: Added proper charset detection from Content-Type headers with UTF-8 fallback for text decoding.

- **Readability error handling**: Wrapped Readability parsing in try-catch to gracefully fall back to body innerHTML if parsing fails.

- **API updates**: Updated all callers (`importKnowledgeTextFromUrl`, `parseDocument`, knowledge route handler) to pass `parseContext` with tenant/user/team/workspace IDs to support PDF parsing.

- **Test coverage**: Added comprehensive test suite covering PDF routing, missing parseContext errors, unsupported binary types, and HTML regression.

## Notable Implementation Details

- The `FetchedResource` type encapsulates the fetched bytes, content-type, and disposition headers for clean separation of concerns.
- Helper functions (`isPdf`, `isTextual`, `charsetFrom`, `filenameFrom`, `titleFrom`) keep the main logic readable and testable.
- PDF filename derivation falls back gracefully: Content-Disposition → URL pathname → generic "download" name.
- The change is backward compatible; existing HTML imports continue to work unchanged.

https://claude.ai/code/session_01AqoB3jWeqn88cr223D4Nkd