### PR TITLE
Add one-click invitation acceptance via signed email tokens

### DIFF
--- a/src/lib/usermanagement/invitations-accept-link.test.ts
+++ b/src/lib/usermanagement/invitations-accept-link.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import {
+  initTests,
+  TEST_ORGANISATION_1,
+  TEST_ORG3_USER_1,
+} from "../../test/init.test";
+import { getDb } from "../db/db-connection";
+import { tenantInvitations, tenantMembers } from "../db/schema/users";
+import {
+  createInvitationToken,
+  verifyInvitationToken,
+  createTenantInvitation,
+  acceptInvitationByToken,
+} from "./invitations";
+
+/**
+ * Tests for the "one click = accepted" invitation link flow
+ * (accept-invitation via a signed token in the invitation email).
+ */
+describe("Accept invitation via emailed link", () => {
+  beforeAll(async () => {
+    await initTests();
+
+    // TEST_ORG3_USER_1 is not a member of ORGANISATION_1 – make sure any prior
+    // membership / invitation from earlier runs is cleared.
+    await getDb()
+      .delete(tenantMembers)
+      .where(
+        and(
+          eq(tenantMembers.tenantId, TEST_ORGANISATION_1.id),
+          eq(tenantMembers.userId, TEST_ORG3_USER_1.id)
+        )
+      );
+    await getDb()
+      .delete(tenantInvitations)
+      .where(eq(tenantInvitations.tenantId, TEST_ORGANISATION_1.id));
+  });
+
+  test("token round-trips (sign -> verify)", () => {
+    const token = createInvitationToken("some-invitation-id");
+    expect(verifyInvitationToken(token).invitationId).toBe("some-invitation-id");
+  });
+
+  test("verify rejects a garbage token", () => {
+    expect(() => verifyInvitationToken("not-a-real-token")).toThrow();
+  });
+
+  test("existing user: link accepts the membership immediately", async () => {
+    const invitation = await createTenantInvitation(
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        email: TEST_ORG3_USER_1.email,
+        role: "admin",
+        status: "pending",
+      },
+      false
+    );
+
+    const token = createInvitationToken(invitation.id);
+    const result = await acceptInvitationByToken(token);
+
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") return;
+    expect(result.userId).toBe(TEST_ORG3_USER_1.id);
+    expect(result.tenantId).toBe(TEST_ORGANISATION_1.id);
+
+    // Membership must now exist with the invited role.
+    const members = await getDb()
+      .select()
+      .from(tenantMembers)
+      .where(
+        and(
+          eq(tenantMembers.tenantId, TEST_ORGANISATION_1.id),
+          eq(tenantMembers.userId, TEST_ORG3_USER_1.id)
+        )
+      );
+    expect(members.length).toBe(1);
+    expect(members[0].role).toBe("admin");
+
+    // Invitation must be marked accepted.
+    const [inv] = await getDb()
+      .select()
+      .from(tenantInvitations)
+      .where(eq(tenantInvitations.id, invitation.id));
+    expect(inv.status).toBe("accepted");
+  });
+
+  test("clicking the link twice is idempotent (no error)", async () => {
+    const invitation = await createTenantInvitation(
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        email: TEST_ORG3_USER_1.email,
+        role: "member",
+        status: "pending",
+      },
+      false
+    );
+
+    const token = createInvitationToken(invitation.id);
+    // First click accepts, second click must not throw.
+    const first = await acceptInvitationByToken(token);
+    const second = await acceptInvitationByToken(token);
+
+    expect(first.status).toBe("accepted");
+    expect(second.status).toBe("accepted");
+
+    // Still exactly one membership row.
+    const members = await getDb()
+      .select()
+      .from(tenantMembers)
+      .where(
+        and(
+          eq(tenantMembers.tenantId, TEST_ORGANISATION_1.id),
+          eq(tenantMembers.userId, TEST_ORG3_USER_1.id)
+        )
+      );
+    expect(members.length).toBe(1);
+  });
+
+  test("unknown email: link routes the invitee to registration", async () => {
+    const invitation = await createTenantInvitation(
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        email: "brand-new-invitee@symbiosika.com",
+        role: "member",
+        status: "pending",
+      },
+      false
+    );
+
+    const token = createInvitationToken(invitation.id);
+    const result = await acceptInvitationByToken(token);
+
+    expect(result.status).toBe("needs_registration");
+    if (result.status !== "needs_registration") return;
+    expect(result.email).toBe("brand-new-invitee@symbiosika.com");
+    expect(result.tenantId).toBe(TEST_ORGANISATION_1.id);
+
+    // No membership should have been created for a non-existent user.
+    // (The registration flow will accept it once the account exists.)
+    const [inv] = await getDb()
+      .select()
+      .from(tenantInvitations)
+      .where(eq(tenantInvitations.id, invitation.id));
+    expect(inv.status).toBe("pending");
+  });
+
+  test("token for a deleted invitation throws", async () => {
+    const token = createInvitationToken(
+      "00000000-0000-0000-0000-000000000999"
+    );
+    await expect(acceptInvitationByToken(token)).rejects.toThrow();
+  });
+});

--- a/src/lib/usermanagement/invitations.ts
+++ b/src/lib/usermanagement/invitations.ts
@@ -4,6 +4,7 @@
  */
 
 import { eq, and } from "drizzle-orm";
+import jwt from "jsonwebtoken";
 import {
   invitationCodes,
   tenantInvitations,
@@ -116,11 +117,16 @@ export const acceptTenantInvitation = async (
       .set({ status: "accepted" })
       .where(eq(tenantInvitations.id, invitationId));
 
-    await trx.insert(tenantMembers).values({
-      userId,
-      tenantId: invitation.tenantId,
-      role: invitation.role,
-    });
+    // Stay idempotent: re-accepting an invitation for a tenant the user is
+    // already a member of must not fail on the primary-key conflict.
+    await trx
+      .insert(tenantMembers)
+      .values({
+        userId,
+        tenantId: invitation.tenantId,
+        role: invitation.role,
+      })
+      .onConflictDoNothing();
 
     await trx
       .update(users)
@@ -132,6 +138,149 @@ export const acceptTenantInvitation = async (
   });
 
   await setUsersLastTenant(userId, invitation.tenantId);
+};
+
+/**
+ * Secure, self-contained token that encodes a single tenant invitation.
+ *
+ * The token is a short-lived JWT signed with the server's JWT key (the same
+ * symmetric key used for login sessions). It carries only the invitation id
+ * plus a dedicated `purpose` claim, so it can never be mistaken for a login /
+ * session token. Because the invitation email is delivered to the invitee's
+ * mailbox, possession of the token proves control of that address – the same
+ * trust model as a magic login link.
+ */
+const INVITATION_TOKEN_PURPOSE = "tenant_invitation";
+// 7 days – matches the "valid for 7 days" copy in the invitation emails.
+const INVITATION_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 7;
+
+const getInvitationTokenKey = () => process.env.JWT_PRIVATE_KEY || "";
+
+/**
+ * Create a signed acceptance token for an invitation id.
+ */
+export const createInvitationToken = (invitationId: string): string => {
+  return jwt.sign(
+    { invitationId, purpose: INVITATION_TOKEN_PURPOSE },
+    getInvitationTokenKey(),
+    { expiresIn: INVITATION_TOKEN_TTL_SECONDS }
+  );
+};
+
+/**
+ * Verify an acceptance token and extract its invitation id. Throws when the
+ * token is invalid, expired, or not an invitation token.
+ */
+export const verifyInvitationToken = (
+  token: string
+): { invitationId: string } => {
+  const decoded = jwt.verify(token, getInvitationTokenKey()) as
+    | { invitationId?: string; purpose?: string }
+    | string;
+  if (
+    !decoded ||
+    typeof decoded === "string" ||
+    decoded.purpose !== INVITATION_TOKEN_PURPOSE ||
+    !decoded.invitationId
+  ) {
+    throw new Error("Invalid invitation token");
+  }
+  return { invitationId: decoded.invitationId };
+};
+
+export type AcceptInvitationByTokenResult =
+  | {
+      status: "accepted";
+      userId: string;
+      tenantId: string;
+      email: string;
+    }
+  | {
+      status: "needs_registration";
+      tenantId: string;
+      email: string;
+    };
+
+/**
+ * Accept a tenant invitation directly from the token embedded in the
+ * invitation email – the "one click = accepted" flow.
+ *
+ * - Existing users: the invitation is accepted immediately and the caller is
+ *   handed the userId so it can establish a login session.
+ * - Not-yet-registered emails: a membership cannot exist before an account
+ *   does, so the caller is told to route the user through registration. The
+ *   registration flow (`LocalAuth.register`) auto-accepts every pending
+ *   invitation for the email, so membership is confirmed the moment the
+ *   account is created.
+ *
+ * The function is idempotent: clicking the link a second time (or a mail
+ * scanner pre-opening it) does not error once the invitation is accepted.
+ */
+export const acceptInvitationByToken = async (
+  token: string
+): Promise<AcceptInvitationByTokenResult> => {
+  const { invitationId } = verifyInvitationToken(token);
+
+  const [invitation] = await getDb()
+    .select()
+    .from(tenantInvitations)
+    .where(eq(tenantInvitations.id, invitationId));
+
+  if (!invitation) {
+    throw new Error("Invitation not found");
+  }
+
+  // Look up the invited user by the invitation email.
+  const [user] = await getDb()
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .where(eq(users.email, invitation.email));
+
+  // No account yet -> the user must register first. Registration will pick up
+  // and accept this (still pending) invitation automatically.
+  if (!user) {
+    return {
+      status: "needs_registration",
+      tenantId: invitation.tenantId,
+      email: invitation.email,
+    };
+  }
+
+  if (invitation.status === "pending") {
+    // Normal case: accept the still-pending invitation.
+    await acceptTenantInvitation(invitation.id, user.id, invitation.tenantId);
+  } else {
+    // Already accepted (or previously declined) -> keep the result idempotent
+    // by ensuring the membership exists and the invitation is marked accepted.
+    await getDb().transaction(async (trx) => {
+      await trx
+        .update(tenantInvitations)
+        .set({ status: "accepted" })
+        .where(eq(tenantInvitations.id, invitation.id));
+
+      await trx
+        .insert(tenantMembers)
+        .values({
+          userId: user.id,
+          tenantId: invitation.tenantId,
+          role: invitation.role,
+        })
+        .onConflictDoNothing();
+
+      await trx
+        .update(users)
+        .set({ emailVerified: true, lastTenantId: invitation.tenantId })
+        .where(eq(users.id, user.id));
+    });
+    await setUsersLastTenant(user.id, invitation.tenantId);
+  }
+
+  return {
+    status: "accepted",
+    userId: user.id,
+    tenantId: invitation.tenantId,
+    email: invitation.email,
+  };
 };
 
 /**
@@ -176,11 +325,17 @@ export const acceptAllPendingInvitationsForTenantMember = async (
         .set({ status: "accepted" })
         .where(eq(tenantInvitations.id, invitation.id));
 
-      await trx.insert(tenantMembers).values({
-        userId,
-        tenantId: invitation.tenantId,
-        role: "member",
-      });
+      // Honor the role from the invitation (an admin invite must not be
+      // silently downgraded to "member") and stay idempotent if the user is
+      // already a member of the tenant.
+      await trx
+        .insert(tenantMembers)
+        .values({
+          userId,
+          tenantId: invitation.tenantId,
+          role: invitation.role,
+        })
+        .onConflictDoNothing();
     }
   });
 
@@ -281,6 +436,13 @@ export const createTenantInvitation = async (
     // check if user exists
     const user = await getUserByEmail(dataWithStatus.email).catch(() => {});
 
+    // Single "one click = accept" link for both new and existing users. It
+    // points at the public accept-invitation endpoint, which accepts the
+    // membership on click and either logs an existing user straight in or
+    // forwards a new user to registration (which then auto-accepts).
+    const acceptToken = createInvitationToken(result.id);
+    const acceptLink = `${_GLOBAL_SERVER_CONFIG.baseUrl}${_GLOBAL_SERVER_CONFIG.basePath}/user/accept-invitation?token=${encodeURIComponent(acceptToken)}`;
+
     // when the user is existing send only invite to tenant
     if (user) {
       const { html, subject } =
@@ -289,7 +451,7 @@ export const createTenantInvitation = async (
             appName: _GLOBAL_SERVER_CONFIG.appName,
             baseUrl: _GLOBAL_SERVER_CONFIG.baseUrl,
             logoUrl: _GLOBAL_SERVER_CONFIG.logoUrl,
-            link: `${_GLOBAL_SERVER_CONFIG.baseUrl || "http://localhost:3000"}/static/app/#/shared/tenants`,
+            link: acceptLink,
             user: {
               firstname: user.firstname,
               surname: user.surname,
@@ -315,7 +477,7 @@ export const createTenantInvitation = async (
           appName: _GLOBAL_SERVER_CONFIG.appName,
           baseUrl: _GLOBAL_SERVER_CONFIG.baseUrl,
           logoUrl: _GLOBAL_SERVER_CONFIG.logoUrl,
-          link: `${_GLOBAL_SERVER_CONFIG.baseUrl}${_GLOBAL_SERVER_CONFIG.loginUrl}?register=true&email=${encodeURIComponent(dataWithStatus.email)}&hideInvitationCode=true`,
+          link: acceptLink,
           tenant: {
             id: dataWithStatus.tenantId,
             name: tenantRes.name,

--- a/src/routes/user/public.ts
+++ b/src/routes/user/public.ts
@@ -398,10 +398,13 @@ export function definePublicUserRoutes(
         }
 
         // Existing user -> log them in and drop them into the app as a
-        // confirmed member.
+        // confirmed member. The landing page defaults to "/" and can be
+        // overridden per app via `invitationAcceptRedirectUrl` in the config.
         const session = await createJwtSessionForUserId(result.userId);
         setAuthCookies(c, session.token);
-        return c.redirect(`${baseUrl}/static/app/#/shared/tenants`);
+        return c.redirect(
+          `${baseUrl}${_GLOBAL_SERVER_CONFIG.invitationAcceptRedirectUrl}`
+        );
       } catch (err) {
         log.error("Error accepting invitation via link: " + err);
         // Do not leak details – forward to the login page with a hint so the

--- a/src/routes/user/public.ts
+++ b/src/routes/user/public.ts
@@ -14,7 +14,10 @@ import * as v from "valibot";
 import { usersRestrictedSelectSchema } from "../../lib/db/db-schema";
 import { RESPONSES } from "../../lib/responses";
 import { verifyPasswordResetToken } from "../../lib/auth/magic-link";
-import { checkIfInvitationCodeIsNeededToRegister } from "../../lib/usermanagement/invitations";
+import {
+  checkIfInvitationCodeIsNeededToRegister,
+  acceptInvitationByToken,
+} from "../../lib/usermanagement/invitations";
 import { verifyApiTokenAndGetJwt } from "../../lib/auth/token-auth";
 import { OAuthAuth } from "../../lib/auth/oauth2";
 import {
@@ -347,6 +350,65 @@ export function definePublicUserRoutes(
         return c.json(r);
       } catch (err) {
         throw new HTTPException(401, { message: "Invalid token: " + err });
+      }
+    }
+  );
+
+  /**
+   * Accept a tenant invitation from the link in the invitation email.
+   *
+   * This is the "one click = accepted" entry point and works for both new and
+   * existing users:
+   * - Existing users: the membership is confirmed immediately, a login session
+   *   is established (auth cookies set) and the user is redirected into the app.
+   * - Users without an account yet: they are redirected to the registration
+   *   page with their email pre-filled; `LocalAuth.register` then auto-accepts
+   *   the pending invitation once the account is created.
+   *
+   * Public by design: the caller is authenticated by possession of the signed,
+   * expiring token that was mailed to the invitee's address (same trust model
+   * as a magic login link).
+   */
+  app.get(
+    API_BASE_PATH + "/user/accept-invitation",
+    describeRoute({
+      tags: ["user"],
+      summary: "Accept a tenant invitation via the emailed link",
+      responses: {
+        302: {
+          description: "Redirect into the app or to the registration page",
+        },
+      },
+    }),
+    validator("query", v.object({ token: v.string() })),
+    async (c) => {
+      const { token } = c.req.valid("query");
+      const baseUrl = _GLOBAL_SERVER_CONFIG.baseUrl;
+      try {
+        const result = await acceptInvitationByToken(token);
+
+        if (result.status === "needs_registration") {
+          // No account yet -> send the user to registration with the email
+          // pre-filled. Registration auto-accepts the pending invitation.
+          const url =
+            `${baseUrl}${_GLOBAL_SERVER_CONFIG.loginUrl}` +
+            `?register=true&email=${encodeURIComponent(result.email)}` +
+            `&hideInvitationCode=true`;
+          return c.redirect(url);
+        }
+
+        // Existing user -> log them in and drop them into the app as a
+        // confirmed member.
+        const session = await createJwtSessionForUserId(result.userId);
+        setAuthCookies(c, session.token);
+        return c.redirect(`${baseUrl}/static/app/#/shared/tenants`);
+      } catch (err) {
+        log.error("Error accepting invitation via link: " + err);
+        // Do not leak details – forward to the login page with a hint so the
+        // SPA can show a friendly "invalid or expired invitation" message.
+        return c.redirect(
+          `${baseUrl}${_GLOBAL_SERVER_CONFIG.loginUrl}?invitationError=invalid`
+        );
       }
     }
   );

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -31,6 +31,9 @@ export const _GLOBAL_SERVER_CONFIG = {
   verifyEmailUrl: "/verify-email.html",
   resetPasswordUrl: "/reset-password.html",
   oauthCallbackUrl: "/oauth-callback.html",
+  // Landing page (relative to baseUrl) an existing user is redirected to after
+  // accepting a tenant invitation via the emailed link. Override per app.
+  invitationAcceptRedirectUrl: "/",
   jwtExpiresAfter: 60 * 60 * 24 * 30, // 30 days
   useConsoleLogger: true,
   useLicenseSystem: false,
@@ -163,6 +166,10 @@ export const setGlobalServerConfig = (config: ServerSpecificConfig) => {
   }
   if (config.oauthCallbackUrl) {
     _GLOBAL_SERVER_CONFIG.oauthCallbackUrl = config.oauthCallbackUrl;
+  }
+  if (config.invitationAcceptRedirectUrl) {
+    _GLOBAL_SERVER_CONFIG.invitationAcceptRedirectUrl =
+      config.invitationAcceptRedirectUrl;
   }
 
   // WhatsApp

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,9 @@ export interface ServerSpecificConfig {
   verifyEmailUrl?: string;
   resetPasswordUrl?: string;
   oauthCallbackUrl?: string;
+  // Where an existing user is redirected after accepting a tenant invitation
+  // via the emailed link (relative to baseUrl). Defaults to "/".
+  invitationAcceptRedirectUrl?: string;
 
   authType?: "local" | "auth0" | "hanko";
   jwtExpiresAfter?: number;


### PR DESCRIPTION
## Summary
Implement a streamlined tenant invitation flow where users can accept invitations directly from a link in the invitation email, without needing to manually enter invitation codes. The solution uses signed JWT tokens embedded in the email link to securely authenticate the acceptance action.

## Key Changes

- **JWT-based invitation tokens**: Added `createInvitationToken()` and `verifyInvitationToken()` functions that create short-lived (7-day) signed tokens containing only the invitation ID and a dedicated `purpose` claim to prevent token confusion with login sessions.

- **New `acceptInvitationByToken()` function**: Implements the core one-click acceptance logic that handles both existing and new users:
  - For existing users: immediately accepts the invitation, establishes a login session, and redirects into the app
  - For new users: redirects to registration with email pre-filled; the registration flow auto-accepts pending invitations once the account is created
  - Fully idempotent: clicking the link multiple times (or mail scanners pre-opening it) does not cause errors

- **New public API endpoint** (`GET /user/accept-invitation`): Accepts a `token` query parameter and handles the redirect logic for both user types, with proper error handling that doesn't leak sensitive details.

- **Updated invitation email links**: Changed from generic tenant page links (for existing users) and registration links (for new users) to a unified `accept-invitation` endpoint with the signed token, simplifying the UX.

- **Idempotency improvements**: Added `.onConflictDoNothing()` to tenant member insertions in `acceptTenantInvitation()` and `acceptAllPendingInvitationsForTenantMember()` to gracefully handle re-acceptance scenarios.

- **Role preservation**: Fixed `acceptAllPendingInvitationsForTenantMember()` to respect the role from the invitation rather than silently downgrading admin invites to "member".

- **Comprehensive test coverage**: Added `invitations-accept-link.test.ts` with tests covering token round-tripping, garbage token rejection, existing user acceptance, idempotency, new user routing, and error cases.

## Implementation Details

- Tokens use the same `JWT_PRIVATE_KEY` as login sessions but are distinguished by a dedicated `purpose` claim, preventing accidental misuse.
- The trust model mirrors magic login links: possession of the token proves control of the invitee's email address.
- The solution maintains backward compatibility with existing invitation code flows while providing a superior UX for email-based invitations.

https://claude.ai/code/session_01BY3S176ceJ9qugZQjBnudS