### PR TITLE
feat(knowledge): paginate text history and add single-version endpoint

### DIFF
--- a/src/lib/knowledge/knowledge-texts.test.ts
+++ b/src/lib/knowledge/knowledge-texts.test.ts
@@ -4,6 +4,7 @@ import {
   getKnowledgeText,
   getKnowledgeTextById,
   getKnowledgeTextHistory,
+  getKnowledgeTextHistoryVersion,
   updateKnowledgeText,
   deleteKnowledgeText,
 } from "./knowledge-texts";
@@ -614,5 +615,122 @@ describe("Knowledge Texts Test", () => {
 
     expect(updated.createdBy).toBe(TEST_ORG1_USER_1.id);
     expect(updated.updatedBy).toBe(TEST_ORG1_USER_2.id);
+  });
+
+  it("should paginate history with limit and page", async () => {
+    const created = await createKnowledgeText({
+      text: "v1",
+      title: "Pagination History",
+      tenantId: TEST_ORGANISATION_1.id,
+    });
+    // 3 updates => 3 history entries (newest first)
+    await updateKnowledgeText(
+      created.id,
+      { text: "v2" },
+      { tenantId: created.tenantId }
+    );
+    await updateKnowledgeText(
+      created.id,
+      { text: "v3" },
+      { tenantId: created.tenantId }
+    );
+    await updateKnowledgeText(
+      created.id,
+      { text: "v4" },
+      { tenantId: created.tenantId }
+    );
+
+    const all = await getKnowledgeTextHistory(created.id, {
+      tenantId: TEST_ORGANISATION_1.id,
+    });
+    expect(all.length).toBe(3);
+    // newest first: the snapshot of the most recent pre-update state is "v3"
+    expect(all[0]?.text).toBe("v3");
+
+    const firstPage = await getKnowledgeTextHistory(
+      created.id,
+      { tenantId: TEST_ORGANISATION_1.id },
+      { limit: 2, page: 1 }
+    );
+    expect(firstPage.length).toBe(2);
+    expect(firstPage.map((h) => h.text)).toEqual(["v3", "v2"]);
+
+    const secondPage = await getKnowledgeTextHistory(
+      created.id,
+      { tenantId: TEST_ORGANISATION_1.id },
+      { limit: 2, page: 2 }
+    );
+    expect(secondPage.length).toBe(1);
+    expect(secondPage[0]?.text).toBe("v1");
+  });
+
+  it("should get a single history version by id with full content", async () => {
+    const created = await createKnowledgeText({
+      text: "original content",
+      title: "Single Version",
+      tenantId: TEST_ORGANISATION_1.id,
+    });
+    await updateKnowledgeText(
+      created.id,
+      { text: "new content" },
+      { tenantId: created.tenantId }
+    );
+
+    const history = await getKnowledgeTextHistory(created.id, {
+      tenantId: TEST_ORGANISATION_1.id,
+    });
+    const versionId = history[0]!.id;
+
+    const version = await getKnowledgeTextHistoryVersion(
+      created.id,
+      versionId,
+      { tenantId: TEST_ORGANISATION_1.id }
+    );
+    expect(version.id).toBe(versionId);
+    expect(version.text).toBe("original content");
+    expect(version.knowledgeTextId).toBe(created.id);
+  });
+
+  it("should reject an unknown history version id", async () => {
+    const created = await createKnowledgeText({
+      text: "x",
+      title: "Unknown Version",
+      tenantId: TEST_ORGANISATION_1.id,
+    });
+    await expect(
+      getKnowledgeTextHistoryVersion(
+        created.id,
+        "00000000-0000-0000-0000-0000000000ff",
+        { tenantId: TEST_ORGANISATION_1.id }
+      )
+    ).rejects.toThrow();
+  });
+
+  it("should not return a history version belonging to another page", async () => {
+    const pageA = await createKnowledgeText({
+      text: "a1",
+      title: "Page A",
+      tenantId: TEST_ORGANISATION_1.id,
+    });
+    await updateKnowledgeText(
+      pageA.id,
+      { text: "a2" },
+      { tenantId: pageA.tenantId }
+    );
+    const pageB = await createKnowledgeText({
+      text: "b1",
+      title: "Page B",
+      tenantId: TEST_ORGANISATION_1.id,
+    });
+
+    const historyA = await getKnowledgeTextHistory(pageA.id, {
+      tenantId: TEST_ORGANISATION_1.id,
+    });
+    // asking for pageA's version through pageB must not resolve
+    await expect(
+      getKnowledgeTextHistoryVersion(pageB.id, historyA[0]!.id, {
+        tenantId: TEST_ORGANISATION_1.id,
+      })
+    ).rejects.toThrow();
   });
 });

--- a/src/lib/knowledge/knowledge-texts.ts
+++ b/src/lib/knowledge/knowledge-texts.ts
@@ -307,8 +307,12 @@ export const getKnowledgeTextById = async (
 };
 
 /**
- * Get complete version history for a knowledge text entry WITHOUT text content
- * Returns all versions chronologically (oldest to newest) with metadata only
+ * Get the version history for a knowledge text entry (newest first).
+ * Each entry is a full snapshot of a previous version, including its text,
+ * blocks and change authorship (createdBy / updatedBy / versionUpdatedAt).
+ *
+ * Optional pagination mirrors getKnowledgeText: pass `limit` (page size) and
+ * `page` (1-based); `page` only takes effect together with `limit`.
  */
 export const getKnowledgeTextHistory = async (
   id: string,
@@ -318,19 +322,64 @@ export const getKnowledgeTextHistory = async (
     teamId?: string;
     workspaceId?: string;
     includeHidden?: boolean;
-  }
+  },
+  options?: { limit?: number; page?: number }
 ) => {
-  // First get the entry to check permissions
-  const entry = await getKnowledgeTextById(id, context);
+  // First get the entry to check permissions (throws if not visible)
+  await getKnowledgeTextById(id, context);
 
-  // Get all history entries for this knowledge text
-  const historyEntries = await getDb()
+  const query = getDb()
     .select()
     .from(knowledgeTextHistory)
     .where(eq(knowledgeTextHistory.knowledgeTextId, id))
-    .orderBy(desc(knowledgeTextHistory.createdAt)); // Newest first
+    .orderBy(desc(knowledgeTextHistory.createdAt)) // Newest first
+    .$dynamic();
 
-  return historyEntries;
+  if (options?.limit) {
+    query.limit(options.limit);
+  }
+  if (options?.page && options?.limit) {
+    query.offset((options.page - 1) * options.limit);
+  }
+
+  return await query;
+};
+
+/**
+ * Get a single history version of a knowledge text entry by its history id,
+ * with full content. Access is checked against the parent page, and the
+ * version must belong to that page (and the caller's tenant).
+ */
+export const getKnowledgeTextHistoryVersion = async (
+  id: string,
+  historyId: string,
+  context: {
+    tenantId: string;
+    userId?: string;
+    teamId?: string;
+    workspaceId?: string;
+    includeHidden?: boolean;
+  }
+) => {
+  // Permission check against the parent page (throws if not visible)
+  await getKnowledgeTextById(id, context);
+
+  const result = await getDb()
+    .select()
+    .from(knowledgeTextHistory)
+    .where(
+      and(
+        eq(knowledgeTextHistory.id, historyId),
+        eq(knowledgeTextHistory.knowledgeTextId, id),
+        eq(knowledgeTextHistory.tenantId, context.tenantId)
+      )
+    );
+
+  if (!result[0]) {
+    throw new Error("Knowledge text history version not found");
+  }
+
+  return result[0];
 };
 
 /**

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.test.ts
@@ -405,6 +405,105 @@ describe("Knowledge API Endpoints", () => {
     );
   });
 
+  test("GET history endpoint should paginate with limit and page", async () => {
+    const v1Response = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts`,
+      TEST_USER_1_TOKEN,
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        text: "P1",
+        title: "History Pagination",
+      }
+    );
+    const entryId = v1Response.jsonResponse.id;
+
+    for (const text of ["P2", "P3", "P4"]) {
+      await testFetcher.put(
+        app,
+        `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}`,
+        TEST_USER_1_TOKEN,
+        { tenantId: TEST_ORGANISATION_1.id, text }
+      );
+    }
+
+    // 3 updates => 3 history entries; first page of 2
+    const page1 = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}/history?limit=2&page=1`,
+      TEST_USER_1_TOKEN
+    );
+    expect(page1.status).toBe(200);
+    expect(page1.jsonResponse.length).toBe(2);
+    expect(page1.jsonResponse.map((h: any) => h.text)).toEqual(["P3", "P2"]);
+
+    const page2 = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}/history?limit=2&page=2`,
+      TEST_USER_1_TOKEN
+    );
+    expect(page2.status).toBe(200);
+    expect(page2.jsonResponse.length).toBe(1);
+    expect(page2.jsonResponse[0].text).toBe("P1");
+
+    await testFetcher.delete(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}`,
+      TEST_USER_1_TOKEN
+    );
+  });
+
+  test("GET single history version by id returns full content", async () => {
+    const v1Response = await testFetcher.post(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts`,
+      TEST_USER_1_TOKEN,
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        text: "SV original",
+        title: "Single Version Route",
+      }
+    );
+    const entryId = v1Response.jsonResponse.id;
+
+    await testFetcher.put(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}`,
+      TEST_USER_1_TOKEN,
+      { tenantId: TEST_ORGANISATION_1.id, text: "SV updated" }
+    );
+
+    const historyResponse = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}/history`,
+      TEST_USER_1_TOKEN
+    );
+    const versionId = historyResponse.jsonResponse[0].id;
+
+    const versionResponse = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}/history/${versionId}`,
+      TEST_USER_1_TOKEN
+    );
+    expect(versionResponse.status).toBe(200);
+    expect(versionResponse.jsonResponse.id).toBe(versionId);
+    expect(versionResponse.jsonResponse.text).toBe("SV original");
+
+    // unknown version id => 404
+    const missing = await testFetcher.get(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}/history/00000000-0000-0000-0000-0000000000ff`,
+      TEST_USER_1_TOKEN
+    );
+    expect(missing.status).toBe(404);
+
+    await testFetcher.delete(
+      app,
+      `/api/tenant/${TEST_ORGANISATION_1.id}/knowledge/texts/${entryId}`,
+      TEST_USER_1_TOKEN
+    );
+  });
+
   test("Parent-child hierarchy should persist when parent is updated", async () => {
     // Create parent entry
     const parentResponse = await testFetcher.post(

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -11,6 +11,7 @@ import {
   getKnowledgeText,
   getKnowledgeTextById,
   getKnowledgeTextHistory,
+  getKnowledgeTextHistoryVersion,
   updateKnowledgeText,
   deleteKnowledgeText,
 } from "../../../../../lib/knowledge/knowledge-texts";
@@ -539,7 +540,9 @@ export default function defineRoutesForKnowledgeTexts(
   );
 
   /**
-   * Get complete version history for a knowledge text entry WITHOUT text content
+   * Get the version history for a knowledge text entry (newest first).
+   * Each entry is a full snapshot of a previous version, including its
+   * change authorship. Supports limit/page pagination.
    */
   app.get(
     API_BASE_PATH + "/tenant/:tenantId/knowledge/texts/:id/history",
@@ -548,11 +551,11 @@ export default function defineRoutesForKnowledgeTexts(
     describeRoute({
       tags: ["knowledge"],
       summary:
-        "Get complete version history for a knowledge text entry WITHOUT text content",
+        "Get the version history for a knowledge text entry (newest first, paginated with limit/page)",
       responses: {
         200: {
           description:
-            "Successful response with all versions chronologically (metadata only)",
+            "Successful response with version snapshots (newest first), including change authorship",
           content: {
             "application/json": {
               schema: resolver(v.array(knowledgeEntrySchema)),
@@ -568,19 +571,97 @@ export default function defineRoutesForKnowledgeTexts(
         teamId: v.optional(v.string()),
         workspaceId: v.optional(v.string()),
         includeHidden: v.optional(v.string()),
+        limit: v.optional(v.string()),
+        page: v.optional(v.string()),
       })
     ),
     validator("param", v.object({ tenantId: v.string(), id: v.string() })),
     isTenantMember,
     async (c) => {
       try {
-        const { teamId, workspaceId, includeHidden: includeHiddenStr } =
-          c.req.valid("query");
+        const {
+          teamId,
+          workspaceId,
+          includeHidden: includeHiddenStr,
+          limit: limitStr,
+          page: pageStr,
+        } = c.req.valid("query");
         const { tenantId, id } = c.req.valid("param");
         const userId = c.get("usersId");
         const includeHidden = includeHiddenStr === "true";
+        const limit = limitStr ? parseInt(limitStr) : undefined;
+        const page = pageStr ? parseInt(pageStr) : undefined;
 
-        const r = await getKnowledgeTextHistory(id, {
+        const r = await getKnowledgeTextHistory(
+          id,
+          {
+            tenantId,
+            userId,
+            teamId,
+            workspaceId,
+            includeHidden,
+          },
+          { limit, page }
+        );
+        return c.json(r);
+      } catch (e) {
+        throw new HTTPException(400, { message: e + "" });
+      }
+    }
+  );
+
+  /**
+   * Get a single history version of a knowledge text entry by history id,
+   * with full content (text + block snapshot).
+   */
+  app.get(
+    API_BASE_PATH +
+      "/tenant/:tenantId/knowledge/texts/:id/history/:historyId",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Get a single history version of a knowledge text entry by history id (full content)",
+      responses: {
+        200: {
+          description:
+            "Successful response with the requested version snapshot",
+          content: {
+            "application/json": {
+              schema: resolver(knowledgeEntrySchema),
+            },
+          },
+        },
+      },
+    }),
+    validateScope("knowledge:read"),
+    validator(
+      "query",
+      v.object({
+        teamId: v.optional(v.string()),
+        workspaceId: v.optional(v.string()),
+        includeHidden: v.optional(v.string()),
+      })
+    ),
+    validator(
+      "param",
+      v.object({
+        tenantId: v.string(),
+        id: v.string(),
+        historyId: v.string(),
+      })
+    ),
+    isTenantMember,
+    async (c) => {
+      try {
+        const { teamId, workspaceId, includeHidden: includeHiddenStr } =
+          c.req.valid("query");
+        const { tenantId, id, historyId } = c.req.valid("param");
+        const userId = c.get("usersId");
+        const includeHidden = includeHiddenStr === "true";
+
+        const r = await getKnowledgeTextHistoryVersion(id, historyId, {
           tenantId,
           userId,
           teamId,
@@ -589,7 +670,14 @@ export default function defineRoutesForKnowledgeTexts(
         });
         return c.json(r);
       } catch (e) {
-        throw new HTTPException(400, { message: e + "" });
+        const errorMsg = e + "";
+        if (
+          errorMsg.includes("not found") ||
+          errorMsg.includes("access denied")
+        ) {
+          throw new HTTPException(404, { message: errorMsg });
+        }
+        throw new HTTPException(400, { message: errorMsg });
       }
     }
   );


### PR DESCRIPTION
## Was

Follow-up zu #60 (bereits gemergt). Erweitert den Zugriff auf die Änderungshistorie von `knowledgeText`-Einträgen um Pagination und den Abruf einer einzelnen Version.

## Änderungen

- **Pagination am History-Endpunkt** – nach demselben Muster wie die Listen-Route `getKnowledgeText`:
  - `GET /tenant/:tenantId/knowledge/texts/:id/history?limit=&page=`
  - `limit` = Seitengröße, `page` = 1-basiert; `page` wirkt nur zusammen mit `limit`.
  - Ohne Parameter unverändert: komplette History, neueste zuerst.
- **Einzelne Version per ID**:
  - `GET /tenant/:tenantId/knowledge/texts/:id/history/:historyId`
  - Liefert einen History-Snapshot mit vollem Inhalt (`text` + Block-Snapshot + `createdBy`/`updatedBy`/`versionUpdatedAt`).
  - Rechteprüfung gegen die Eltern-Seite; die Version muss zu dieser Seite **und** dem Tenant gehören → sonst `404`.
- Korrigiert die irreführende Beschreibung „WITHOUT text content" an Route und Funktion (der Endpunkt liefert vollen Inhalt).

## Nicht enthalten (bewusst)

Kein Filter nach `updatedBy`/Zeitraum und keine tenant-weite Audit-Abfrage.

## Tests

- Neue Lib-Tests: Pagination über mehrere Versionen, Einzelversion, unbekannte ID, fremde Seite.
- Neue Route-Tests: Pagination via `?limit=&page=`, Einzelversion inkl. `404`.
- Lokal gegen PGlite verifiziert: 90 Tests grün (relevante Knowledge-Suiten), `tsc --noEmit` ohne neue Fehler.
- **Keine Schema-Änderung → keine neue Migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1THW52VQN1HoAEbcaZRKU)_