### PR TITLE
Move document ingestion to background jobs (async knowledge routes)

### DIFF
--- a/docs/framework/6_BuildIn_AI_Knowledge.md
+++ b/docs/framework/6_BuildIn_AI_Knowledge.md
@@ -35,7 +35,35 @@ The symbiosika-framework provides a built-in, organization-wide knowledge base t
 - **Update/Delete a group:**  
   `PUT`/`DELETE /api/v1/tenant/:tenantId/knowledge/groups/:id`
 
-### Add Knowledge
+### Add Knowledge (asynchronous — returns a Job)
+
+> **Breaking change:** Reading/ingesting documents (PDF and others) now runs
+> on the [background job system](./10_Using_Long_Running_Jobs.md) instead of
+> blocking the request. Every ingestion endpoint below **returns the created
+> Job immediately** — not the finished knowledge entry. Parsing a large PDF
+> plus embedding every chunk can take minutes, so the request no longer waits.
+>
+> A UI polls the job and decides what to do with the result:
+>
+> - `GET /api/v1/tenant/:tenantId/jobs/:jobId` → full job incl. `result`
+> - `GET /api/v1/tenant/:tenantId/jobs/:jobId/status` → `{ status, progress }`
+>
+> Statuses are `pending` → `running` → `completed` | `failed`. When
+> `completed`, the handler's output is on `job.result`:
+> `{ id, ok }` for RAG knowledge entries, `{ knowledgeText, blocks }` for
+> imported wiki pages. On `failed`, `job.error.message` explains why (e.g. a
+> missing source or an unreadable file). All jobs use the type
+> `knowledge:ingest`.
+>
+> Uploaded files are stashed in DB storage, processed by the job, and the
+> temporary file is deleted once the job has run.
+>
+> The framework registers the built-in ingestion handler and starts the job
+> queue automatically. If a separate worker process drains the queue, set
+> `disableJobQueue: true` in the server config on the web instance.
+
+The following endpoints all respond with a Job (`202`-style semantics, HTTP
+`200` + the job body):
 
 - **Add knowledge from text:**  
   `POST /api/v1/tenant/:tenantId/knowledge/from-text`
@@ -48,9 +76,12 @@ The symbiosika-framework provides a built-in, organization-wide knowledge base t
     "knowledgeGroupId": "string (optional)"
   }
   ```
-- **Add knowledge from a file/document:**  
+- **Add knowledge from a file/document (PDF, txt, …):**  
   `POST /api/v1/tenant/:tenantId/knowledge/upload-and-extract`  
   (multipart/form-data, file upload + optional metadata like group, filters, etc.)
+
+- **Extract knowledge from an existing stored source (db/local/url/text):**  
+  `POST /api/v1/tenant/:tenantId/knowledge/extract-knowledge`
 
 - **Add knowledge from a URL:**  
   `POST /api/v1/tenant/:tenantId/knowledge/from-url`
@@ -62,6 +93,19 @@ The symbiosika-framework provides a built-in, organization-wide knowledge base t
     "knowledgeGroupId": "string (optional)"
   }
   ```
+
+- **Import a file / URL as an editable wiki page:**  
+  `POST /api/v1/tenant/:tenantId/knowledge/texts/import` (multipart file) and  
+  `POST /api/v1/tenant/:tenantId/knowledge/texts/import-url` also return a Job.
+
+Typical client flow:
+
+```text
+POST .../knowledge/upload-and-extract        → { id: "<jobId>", type: "knowledge:ingest", status: "pending", ... }
+GET  .../jobs/<jobId>/status  (poll)          → { status: "running" }
+GET  .../jobs/<jobId>/status  (poll)          → { status: "completed" }
+GET  .../jobs/<jobId>                         → { ..., result: { id: "<knowledgeEntryId>", ok: true } }
+```
 
 - **You can assign or update groups and filters for knowledge entries at any time.**
 
@@ -158,7 +202,7 @@ The system will automatically include the relevant knowledge for the assistant.
    }
    ```
 
-2. **Add a knowledge entry to the group:**
+2. **Add a knowledge entry to the group (returns a Job):**
    ```http
    POST /api/v1/tenant/0000-000-0000/knowledge/from-text
    Content-Type: application/json
@@ -170,6 +214,9 @@ The system will automatically include the relevant knowledge for the assistant.
      "knowledgeGroupId": "<ID from previous step>"
    }
    ```
+   The response is a `knowledge:ingest` Job. Poll
+   `GET /api/v1/tenant/0000-000-0000/jobs/<jobId>` until `status` is
+   `completed`; the created entry id is on `job.result.id`.
 
 3. **Use the knowledge in chat:**
    ```http

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ import defineNotificationRoutes from "./routes/user/notifications";
 import { addMessageToAllAdmins } from "./lib/notifications";
 // Jobs
 import { defineJob, startJobQueue } from "./lib/jobs";
+import { knowledgeIngestJobRegister } from "./lib/knowledge/ingestion-jobs";
 // Cron
 import scheduler from "./lib/cron";
 import { cleanupExpiredFiles } from "./lib/knowledge/knowledge-text-files";
@@ -420,16 +421,30 @@ export const defineServer = (config: ServerSpecificConfig) => {
       );
 
       /**
-       * Start job queue if needed
-       * These are used to perform background tasks
+       * Register job handlers and start the job queue.
+       *
+       * The framework ships built-in handlers (e.g. document ingestion, which
+       * powers the async knowledge routes) that must always be available, so
+       * the queue is started unconditionally unless the consumer explicitly
+       * disables it via `disableJobQueue` (e.g. when running a dedicated worker
+       * process). Consumer-provided `jobHandlers` are registered on top.
        */
-      if (config.jobHandlers && config.jobHandlers.length > 0) {
+      const builtInJobHandlers = [knowledgeIngestJobRegister];
+      const allJobHandlers = [
+        ...builtInJobHandlers,
+        ...(config.jobHandlers ?? []),
+      ];
+      allJobHandlers.forEach((jobHandler) => {
+        log.debug(`Registering job handler: ${jobHandler.type}`);
+        defineJob(jobHandler.type, jobHandler.handler);
+      });
+      if (!config.disableJobQueue) {
         log.debug("Starting job queue...");
-        config.jobHandlers.forEach((jobHandler) => {
-          log.debug(`Registering job handler: ${jobHandler.type}`);
-          defineJob(jobHandler.type, jobHandler.handler);
-        });
         startJobQueue();
+      } else {
+        log.debug(
+          "Job queue disabled via config.disableJobQueue; async jobs will not be processed by this instance."
+        );
       }
 
       /**

--- a/src/lib/jobs/index.ts
+++ b/src/lib/jobs/index.ts
@@ -79,7 +79,10 @@ async function processJob(job: Job) {
       await executor.onError(e as Error);
     } else {
       log.error(`Error executing job: ${job.id} from type ${job.type}: ${e}`);
-      getDb()
+      // Must be awaited: otherwise processJob/processDueJobsOnce resolves
+      // before the failed status is persisted, leaving the job stuck in
+      // "running" for any caller that reads it right after the cycle.
+      await getDb()
         .update(jobs)
         .set({ status: "failed", error: { message: (e as Error).message } })
         .where(eq(jobs.id, job.id));

--- a/src/lib/knowledge/add-knowledge.ts
+++ b/src/lib/knowledge/add-knowledge.ts
@@ -24,6 +24,7 @@ import {
 } from "../db/schema/knowledge";
 import { parseDocument, parseFile } from "./parsing";
 import { applyPostProcessors } from "./parsing/post-processors";
+import { urlToMarkdown } from "./parsing/url";
 import type { PageContent } from "./parsing/pdf/types";
 import { generateEmbedding } from "./embedding";
 
@@ -406,4 +407,116 @@ export const extractKnowledgeInOneStep = async (
   else {
     throw new Error("No file or text provided");
   }
+};
+
+/**
+ * Extract knowledge from a web page (HTML → markdown via Readability/Turndown,
+ * or a linked PDF) and store it as a knowledge entry.
+ *
+ * Extracted from the former synchronous `POST .../knowledge/from-url` route so
+ * the exact same logic can now run inside a background job. Returns
+ * `{ id, ok }` — the created knowledge entry id.
+ */
+export const extractKnowledgeFromUrl = async (data: {
+  tenantId: string;
+  url: string;
+  filters?: Record<string, string>;
+  teamId?: string;
+  userId?: string;
+  workspaceId?: string;
+  knowledgeGroupId?: string;
+  userOwned?: boolean;
+  usePostProcessors?: string[];
+}) => {
+  if (!data.url.startsWith("http://") && !data.url.startsWith("https://")) {
+    throw new Error("URL must start with http:// or https://");
+  }
+
+  const parsed = await urlToMarkdown(data.url, {
+    parseContext: { tenantId: data.tenantId },
+  });
+
+  if (!parsed.markdown || parsed.markdown.trim().length === 0) {
+    throw new Error(`No readable content could be extracted from ${data.url}`);
+  }
+
+  const processed = await applyPostProcessors(
+    {
+      text: parsed.markdown,
+      title: parsed.title,
+      source: { type: "url", url: data.url, includesImages: false },
+      context: { tenantId: data.tenantId, userId: data.userId },
+    },
+    data.usePostProcessors
+  );
+
+  return extractKnowledgeFromText({
+    userId: data.userId,
+    tenantId: data.tenantId,
+    title: processed.title ?? parsed.title,
+    text: processed.text,
+    filters: data.filters,
+    teamId: data.teamId,
+    workspaceId: data.workspaceId,
+    knowledgeGroupId: data.knowledgeGroupId,
+    userOwned: data.userOwned,
+    sourceType: "url",
+    sourceUrl: data.url,
+    sourceFileBucket: "default",
+    metadata: {
+      ...(parsed.excerpt ? { excerpt: parsed.excerpt } : {}),
+      ...(parsed.byline ? { byline: parsed.byline } : {}),
+      ...(parsed.siteName ? { siteName: parsed.siteName } : {}),
+    },
+    includesLocalImages: false,
+  });
+};
+
+/**
+ * Extract knowledge from a plain text (with optional post-processing) and store
+ * it as a knowledge entry.
+ *
+ * Extracted from the former synchronous `POST .../knowledge/from-text` route so
+ * the exact same logic can now run inside a background job. Returns
+ * `{ id, ok }` — the created knowledge entry id.
+ */
+export const extractKnowledgeFromPlainText = async (data: {
+  tenantId: string;
+  text: string;
+  title: string;
+  filters?: Record<string, string>;
+  teamId?: string;
+  userId?: string;
+  workspaceId?: string;
+  knowledgeGroupId?: string;
+  userOwned?: boolean;
+  meta?: { sourceUri: string; sourceId: string };
+  usePostProcessors?: string[];
+}) => {
+  const processed = await applyPostProcessors(
+    {
+      text: data.text,
+      title: data.title,
+      source: { type: "text", includesImages: false },
+      context: { tenantId: data.tenantId, userId: data.userId },
+    },
+    data.usePostProcessors
+  );
+
+  return extractKnowledgeFromText({
+    userId: data.userId,
+    tenantId: data.tenantId,
+    title: processed.title ?? data.title,
+    text: processed.text,
+    filters: data.filters,
+    teamId: data.teamId,
+    workspaceId: data.workspaceId,
+    knowledgeGroupId: data.knowledgeGroupId,
+    userOwned: data.userOwned,
+    sourceExternalId: data.meta?.sourceId ?? data.title,
+    sourceType: "external",
+    sourceFileBucket: "default",
+    sourceUrl: data.meta?.sourceUri ?? data.title,
+    includesLocalImages: false,
+  });
 };

--- a/src/lib/knowledge/ingestion-jobs.test.ts
+++ b/src/lib/knowledge/ingestion-jobs.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+import { processDueJobsOnce, getJob } from "../jobs";
+import {
+  createKnowledgeIngestJob,
+  storeIngestFileInDb,
+  KNOWLEDGE_INGEST_JOB_TYPE,
+} from "./ingestion-jobs";
+
+/**
+ * These tests exercise the document-ingestion job pipeline end-to-end without
+ * the HTTP layer: create a `knowledge:ingest` job, drain the queue once, and
+ * assert the job completed with a knowledge-entry result.
+ *
+ * The built-in handler is registered inside `initTests`, and the queue is
+ * drained deterministically via `processDueJobsOnce` (no background worker).
+ */
+describe("Knowledge ingestion jobs", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("runs a rag-text ingest job to completion", async () => {
+    const job = await createKnowledgeIngestJob(
+      {
+        kind: "rag-text",
+        tenantId: TEST_ORGANISATION_1.id,
+        params: {
+          text: "Symbiosika ingestion job unit test content about widgets.",
+          title: "Ingest Job Text Test",
+        },
+      },
+      TEST_ORGANISATION_1.id
+    );
+
+    expect(job.type).toBe(KNOWLEDGE_INGEST_JOB_TYPE);
+    expect(job.status).toBe("pending");
+
+    await processDueJobsOnce();
+
+    const finished = await getJob(job.id);
+    expect(finished.status).toBe("completed");
+    expect((finished.result as any)?.ok).toBe(true);
+    expect((finished.result as any)?.id).toBeDefined();
+  }, 30000);
+
+  it("runs a rag-upload ingest job from a stored file and cleans it up", async () => {
+    const file = new File(
+      ["Uploaded plain text document for the ingestion job test."],
+      "ingest-upload-test.txt",
+      { type: "text/plain" }
+    );
+    const storage = await storeIngestFileInDb(file, TEST_ORGANISATION_1.id);
+    expect(storage.fileId).toBeDefined();
+
+    const job = await createKnowledgeIngestJob(
+      {
+        kind: "rag-upload",
+        tenantId: TEST_ORGANISATION_1.id,
+        storage,
+        deleteAfter: true,
+        options: {},
+      },
+      TEST_ORGANISATION_1.id
+    );
+
+    await processDueJobsOnce();
+
+    const finished = await getJob(job.id);
+    expect(finished.status).toBe("completed");
+    expect((finished.result as any)?.id).toBeDefined();
+  }, 30000);
+
+  it("marks a job as failed when the source does not exist", async () => {
+    const job = await createKnowledgeIngestJob(
+      {
+        kind: "rag-existing",
+        tenantId: TEST_ORGANISATION_1.id,
+        params: {
+          sourceType: "text",
+          sourceId: "00000000-0000-0000-0000-000000000000",
+        },
+      },
+      TEST_ORGANISATION_1.id
+    );
+
+    await processDueJobsOnce();
+
+    const finished = await getJob(job.id);
+    expect(finished.status).toBe("failed");
+    expect((finished.error as any)?.message).toBeDefined();
+  }, 30000);
+});

--- a/src/lib/knowledge/ingestion-jobs.ts
+++ b/src/lib/knowledge/ingestion-jobs.ts
@@ -1,0 +1,316 @@
+/**
+ * Background-job ingestion for documents (PDF, files, URLs, plain text).
+ *
+ * The knowledge ingestion routes used to parse + chunk + embed documents
+ * synchronously inside the HTTP request. Parsing a large PDF (external OCR
+ * services that busy-poll) plus embedding every chunk can take minutes and
+ * held the request open the whole time.
+ *
+ * This module moves that work onto the framework's existing job queue
+ * (`src/lib/jobs`). The routes now:
+ *   1. persist the input (store the uploaded file, keep the URL/text in the
+ *      job metadata),
+ *   2. create a `knowledge:ingest` job, and
+ *   3. return the Job immediately.
+ *
+ * A UI polls `GET /tenant/:tenantId/jobs/:jobId` and decides what to do with
+ * the result once `status === "completed"`. The handler's return value (e.g.
+ * `{ id, ok }` for a knowledge entry, or `{ knowledgeText, blocks }` for a
+ * wiki page) is stored on `job.result`.
+ *
+ * A single job type (`knowledge:ingest`) covers every ingestion flavour; the
+ * `kind` discriminator on the metadata selects the concrete work.
+ */
+
+import { eq } from "drizzle-orm";
+import { createJob, getJob } from "../jobs";
+import type { JobHandlerRegister } from "../jobs";
+import { getDb } from "../db/db-connection";
+import { jobs, type Job } from "../db/schema/jobs";
+import {
+  saveFileToDb,
+  getFileFromDb,
+  deleteFileFromDB,
+} from "../storage/db";
+import {
+  extractKnowledgeInOneStep,
+  extractKnowledgeFromExistingDbEntry,
+  extractKnowledgeFromUrl,
+  extractKnowledgeFromPlainText,
+} from "./add-knowledge";
+import {
+  importKnowledgeTextFromFile,
+  importKnowledgeTextFromUrl,
+  type ImportKnowledgeTextOptions,
+} from "./knowledge-text-import";
+import log from "../log";
+
+/** The single job type used for all document ingestion flavours. */
+export const KNOWLEDGE_INGEST_JOB_TYPE = "knowledge:ingest";
+
+/** Bucket used to stash uploaded files until the job has processed them. */
+export const KNOWLEDGE_INGEST_BUCKET = "knowledge-ingest-jobs";
+
+/**
+ * Reference to an uploaded file that was stashed in the DB storage so a job
+ * can pick it up later. Kept minimal + JSON-serialisable (job metadata is
+ * `jsonb`).
+ */
+export type StoredIngestFile = {
+  storageType: "db";
+  bucket: string;
+  fileId: string;
+  fileName: string;
+};
+
+/** Options forwarded to `extractKnowledgeInOneStep` for an uploaded file. */
+type RagUploadOptions = {
+  filters?: Record<string, string>;
+  teamId?: string;
+  workspaceId?: string;
+  knowledgeGroupId?: string;
+  userOwned?: boolean;
+  meta?: { sourceUri: string; sourceId: string };
+  model?: string;
+  usePostProcessors?: string[];
+  generateSummary?: boolean;
+  summaryCustomPrompt?: string;
+  summaryModel?: string;
+  extractImages?: boolean;
+};
+
+/** Params for extracting knowledge from an already-stored source (db/local/url/text). */
+type RagExistingParams = {
+  sourceType: "db" | "local" | "url" | "text" | "external";
+  sourceId?: string;
+  sourceFileBucket?: string;
+  sourceUrl?: string;
+  filters?: Record<string, string>;
+  metadata?: Record<string, string | number | boolean | undefined>;
+  teamId?: string;
+  workspaceId?: string;
+  knowledgeGroupId?: string;
+  userOwned?: boolean;
+  model?: string;
+  extractImages?: boolean;
+  generateSummary?: boolean;
+  summaryCustomPrompt?: string;
+  summaryModel?: string;
+  usePostProcessors?: string[];
+};
+
+type RagUrlParams = {
+  url: string;
+  filters?: Record<string, string>;
+  teamId?: string;
+  workspaceId?: string;
+  knowledgeGroupId?: string;
+  userOwned?: boolean;
+  usePostProcessors?: string[];
+};
+
+type RagTextParams = {
+  text: string;
+  title: string;
+  filters?: Record<string, string>;
+  teamId?: string;
+  workspaceId?: string;
+  knowledgeGroupId?: string;
+  userOwned?: boolean;
+  meta?: { sourceUri: string; sourceId: string };
+  usePostProcessors?: string[];
+};
+
+/** Options forwarded to `importKnowledgeTextFrom*` (minus tenantId/userId). */
+type TextImportOptions = Omit<ImportKnowledgeTextOptions, "tenantId" | "userId">;
+
+/**
+ * Discriminated metadata for a `knowledge:ingest` job. Every variant carries
+ * `tenantId` / `userId` for context and a `kind` selecting the work.
+ */
+export type KnowledgeIngestJobMetadata =
+  | {
+      kind: "rag-upload";
+      tenantId: string;
+      userId?: string;
+      storage: StoredIngestFile;
+      deleteAfter: boolean;
+      options: RagUploadOptions;
+    }
+  | {
+      kind: "rag-existing";
+      tenantId: string;
+      userId?: string;
+      params: RagExistingParams;
+    }
+  | {
+      kind: "rag-url";
+      tenantId: string;
+      userId?: string;
+      params: RagUrlParams;
+    }
+  | {
+      kind: "rag-text";
+      tenantId: string;
+      userId?: string;
+      params: RagTextParams;
+    }
+  | {
+      kind: "text-import-file";
+      tenantId: string;
+      userId?: string;
+      storage: StoredIngestFile;
+      deleteAfter: boolean;
+      options: TextImportOptions;
+    }
+  | {
+      kind: "text-import-url";
+      tenantId: string;
+      userId?: string;
+      params: { url: string; options: TextImportOptions };
+    };
+
+/**
+ * Stash an uploaded file in DB storage so a background job can process it
+ * later. Returns a JSON-serialisable reference to embed into the job metadata.
+ */
+export const storeIngestFileInDb = async (
+  file: File,
+  tenantId: string
+): Promise<StoredIngestFile> => {
+  const saved = await saveFileToDb(file, KNOWLEDGE_INGEST_BUCKET, tenantId);
+  return {
+    storageType: "db",
+    bucket: KNOWLEDGE_INGEST_BUCKET,
+    fileId: saved.id,
+    fileName: saved.name,
+  };
+};
+
+const deleteStoredIngestFile = async (
+  storage: StoredIngestFile,
+  tenantId: string
+) => {
+  try {
+    await deleteFileFromDB(storage.fileId, storage.bucket, tenantId);
+  } catch (e) {
+    log.error(
+      `Failed to delete temporary ingest file ${storage.fileId} in bucket ${storage.bucket}: ${e}`
+    );
+  }
+};
+
+/**
+ * The actual work of a `knowledge:ingest` job. Reconstructs the input from the
+ * job metadata and calls the same ingestion helpers the synchronous routes
+ * used to call directly. Returns the value stored on `job.result`.
+ */
+export const processKnowledgeIngestJob = async (
+  metadata: KnowledgeIngestJobMetadata
+): Promise<unknown> => {
+  switch (metadata.kind) {
+    case "rag-upload": {
+      const file = await getFileFromDb(
+        metadata.storage.fileId,
+        metadata.storage.bucket,
+        metadata.tenantId
+      );
+      try {
+        return await extractKnowledgeInOneStep(
+          { ...metadata.options, tenantId: metadata.tenantId, file },
+          true
+        );
+      } finally {
+        if (metadata.deleteAfter) {
+          await deleteStoredIngestFile(metadata.storage, metadata.tenantId);
+        }
+      }
+    }
+
+    case "rag-existing":
+      return await extractKnowledgeFromExistingDbEntry({
+        ...metadata.params,
+        tenantId: metadata.tenantId,
+        userId: metadata.userId,
+      });
+
+    case "rag-url":
+      return await extractKnowledgeFromUrl({
+        ...metadata.params,
+        tenantId: metadata.tenantId,
+        userId: metadata.userId,
+      });
+
+    case "rag-text":
+      return await extractKnowledgeFromPlainText({
+        ...metadata.params,
+        tenantId: metadata.tenantId,
+        userId: metadata.userId,
+      });
+
+    case "text-import-file": {
+      const file = await getFileFromDb(
+        metadata.storage.fileId,
+        metadata.storage.bucket,
+        metadata.tenantId
+      );
+      try {
+        return await importKnowledgeTextFromFile(file, {
+          ...metadata.options,
+          tenantId: metadata.tenantId,
+          userId: metadata.userId,
+        });
+      } finally {
+        if (metadata.deleteAfter) {
+          await deleteStoredIngestFile(metadata.storage, metadata.tenantId);
+        }
+      }
+    }
+
+    case "text-import-url":
+      return await importKnowledgeTextFromUrl(metadata.params.url, {
+        ...metadata.params.options,
+        tenantId: metadata.tenantId,
+        userId: metadata.userId,
+      });
+
+    default: {
+      // Exhaustiveness guard — a new kind must be handled above.
+      const _exhaustive: never = metadata;
+      throw new Error(
+        `Unknown knowledge ingest job kind: ${JSON.stringify(_exhaustive)}`
+      );
+    }
+  }
+};
+
+/**
+ * Handler registration for the framework's built-in `knowledge:ingest` job.
+ * Wired up in `src/index.ts` alongside any consumer-provided job handlers.
+ */
+export const knowledgeIngestJobRegister: JobHandlerRegister = {
+  type: KNOWLEDGE_INGEST_JOB_TYPE,
+  handler: {
+    async execute(metadata: KnowledgeIngestJobMetadata) {
+      return await processKnowledgeIngestJob(metadata);
+    },
+  },
+};
+
+/**
+ * Create a `knowledge:ingest` job and (optionally) stamp the creating user on
+ * it. Returns the created Job, which the route hands straight back to the
+ * caller so a UI can poll for progress/result.
+ */
+export const createKnowledgeIngestJob = async (
+  metadata: KnowledgeIngestJobMetadata,
+  tenantId: string,
+  userId?: string
+): Promise<Job> => {
+  const job = await createJob(KNOWLEDGE_INGEST_JOB_TYPE, metadata, tenantId);
+  if (userId) {
+    await getDb().update(jobs).set({ userId }).where(eq(jobs.id, job.id));
+    return await getJob(job.id);
+  }
+  return job;
+};

--- a/src/routes/tenant/[tenantId]/knowledge/edge-cases.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/edge-cases.test.ts
@@ -9,6 +9,7 @@ import {
   createDatabaseClient,
   waitForDbConnection,
 } from "../../../../lib/db/db-connection";
+import { processDueJobsOnce, getJob } from "../../../../lib/jobs";
 
 let appKnowledge = new Hono<{ Variables: SFContextVariables }>();
 let appKnowledgeTexts = new Hono<{ Variables: SFContextVariables }>();
@@ -120,9 +121,16 @@ describe("Knowledge API Edge Cases", () => {
       extractData
     );
 
-    // Should return an error for non-existent source
-    expect(response.status).toBe(400);
-  });
+    // Ingestion is now asynchronous: the endpoint accepts the request and
+    // returns a Job. The non-existent source surfaces as a failed job, not a
+    // synchronous 400.
+    expect(response.status).toBe(200);
+    expect(response.jsonResponse.id).toBeDefined();
+
+    await processDueJobsOnce();
+    const finished = await getJob(response.jsonResponse.id);
+    expect(finished.status).toBe("failed");
+  }, 30000);
 
   test("Get non-existent knowledge entry", async () => {
     const nonExistentId = "00000000-0000-0000-0000-000000000000";

--- a/src/routes/tenant/[tenantId]/knowledge/index.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/index.test.ts
@@ -16,6 +16,19 @@ import {
 import { readFileSync } from "fs";
 import { join } from "path";
 import { TEST_PDF_TEXT } from "../../../../test/files.test";
+import { processDueJobsOnce, getJob } from "../../../../lib/jobs";
+
+/**
+ * The knowledge ingestion routes now return a Job instead of the finished
+ * entry. This helper runs the just-created job to completion (the built-in
+ * ingest handler is registered in `initTests`) and returns the final job.
+ */
+const runIngestJob = async (job: any) => {
+  expect(job.id).toBeDefined();
+  expect(job.type).toBe("knowledge:ingest");
+  await processDueJobsOnce();
+  return await getJob(job.id);
+};
 
 let appKnowledge = new Hono<{ Variables: SFContextVariables }>();
 let appTexts = new Hono<{ Variables: SFContextVariables }>();
@@ -74,10 +87,14 @@ describe("Knowledge API Endpoints", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.jsonResponse.id).toBeDefined();
+
+    // The endpoint now returns a Job; run it and read the result.
+    const finished = await runIngestJob(response.jsonResponse);
+    expect(finished.status).toBe("completed");
+    expect((finished.result as any)?.id).toBeDefined();
 
     // Save the ID for later tests
-    createdKnowledgeEntryId = response.jsonResponse.id;
+    createdKnowledgeEntryId = (finished.result as any).id;
   }, 30000);
 
   test("Get knowledge entries", async () => {
@@ -118,9 +135,12 @@ describe("Knowledge API Endpoints", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.jsonResponse.ok).toBe(true);
-    expect(response.jsonResponse.id).toBeDefined();
-  });
+
+    const finished = await runIngestJob(response.jsonResponse);
+    expect(finished.status).toBe("completed");
+    expect((finished.result as any)?.ok).toBe(true);
+    expect((finished.result as any)?.id).toBeDefined();
+  }, 30000);
 
   test("Add knowledge from text", async () => {
     const textData = {
@@ -136,10 +156,12 @@ describe("Knowledge API Endpoints", () => {
       textData
     );
 
-    console.log(response.textResponse);
     expect(response.status).toBe(200);
-    expect(response.jsonResponse.id).toBeDefined();
-  });
+
+    const finished = await runIngestJob(response.jsonResponse);
+    expect(finished.status).toBe("completed");
+    expect((finished.result as any)?.id).toBeDefined();
+  }, 30000);
 
   test("Perform similarity search", async () => {
     const searchData = {

--- a/src/routes/tenant/[tenantId]/knowledge/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/index.ts
@@ -6,12 +6,10 @@ import type { SymbiosikaFrameworkHonoApp } from "../../../../types";
 import * as v from "valibot";
 import { HTTPException } from "hono/http-exception";
 import {
-  extractKnowledgeFromExistingDbEntry,
-  extractKnowledgeFromText,
-  extractKnowledgeInOneStep,
-} from "../../../../lib/knowledge/add-knowledge";
-import { parseDocument } from "../../../../lib/knowledge/parsing";
-import { urlToMarkdown } from "../../../../lib/knowledge/parsing/url";
+  createKnowledgeIngestJob,
+  storeIngestFileInDb,
+} from "../../../../lib/knowledge/ingestion-jobs";
+import { jobsSelectSchema } from "../../../../lib/db/schema/jobs";
 import {
   getFullSourceDocumentsForKnowledgeEntry,
   getKnowledgeEntries,
@@ -36,10 +34,7 @@ import { resolver, validator } from "hono-openapi";
 import { knowledgeEntrySchema } from "../../../../lib/db/db-schema";
 import { isTenantAdmin, isTenantMember } from "../..";
 import { validateScope } from "../../../../lib/utils/validate-scope";
-import {
-  applyPostProcessors,
-  getAllPostProcessors,
-} from "../../../../lib/knowledge/parsing/post-processors";
+import { getAllPostProcessors } from "../../../../lib/knowledge/parsing/post-processors";
 
 const FileSourceType = {
   DB: "db",
@@ -500,8 +495,13 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
   );
 
   /**
-   * Call the knowledge extraction from a document to generate embeddings in the database
-   * A document can be a plain text in the DB, a markdown file, an PDF file, an image, etc.
+   * Start a background job that extracts knowledge from a document to generate
+   * embeddings in the database. A document can be a plain text in the DB, a
+   * markdown file, a PDF file, an image, etc.
+   *
+   * NOTE: this endpoint no longer waits for the extraction to finish. It
+   * returns the created Job immediately; poll `GET /tenant/:tenantId/jobs/:id`
+   * for status and the `{ id, ok }` result.
    */
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/knowledge/extract-knowledge",
@@ -509,18 +509,14 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
     checkUserPermission,
     describeRoute({
       tags: ["knowledge"],
-      summary: "Extract knowledge from a document",
+      summary:
+        "Start a background job to extract knowledge from a document (returns the Job)",
       responses: {
         200: {
-          description: "Successful response",
+          description: "The created ingestion job",
           content: {
             "application/json": {
-              schema: resolver(
-                v.object({
-                  id: v.string(),
-                  ok: v.boolean(),
-                })
-              ),
+              schema: resolver(jobsSelectSchema),
             },
           },
         },
@@ -535,13 +531,15 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
         const body = c.req.valid("json");
         const { tenantId } = c.req.valid("param");
         validateOrganisationId(body, tenantId);
+        const userId = c.get("usersId");
 
-        const r = await extractKnowledgeFromExistingDbEntry({
-          ...body,
+        const { tenantId: _t, ...params } = body;
+        const job = await createKnowledgeIngestJob(
+          { kind: "rag-existing", tenantId, userId, params },
           tenantId,
-          userId: c.get("usersId"),
-        });
-        return c.json(r);
+          userId
+        );
+        return c.json(job);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
       }
@@ -549,8 +547,13 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
   );
 
   /**
-   * Upload a file, learn from it, and then delete it
-   * This endpoint combines file upload and knowledge extraction in one step
+   * Upload a file and start a background job that learns from it.
+   *
+   * The uploaded file is stashed in DB storage and processed asynchronously;
+   * the temporary file is deleted once the job has run. This endpoint returns
+   * the created Job immediately instead of waiting for parsing + embedding.
+   * Poll `GET /tenant/:tenantId/jobs/:id` for status and the `{ id, ok }`
+   * result.
    */
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/knowledge/upload-and-extract",
@@ -558,7 +561,8 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
     checkUserPermission,
     describeRoute({
       tags: ["knowledge"],
-      summary: "Upload a file and extract knowledge in one step",
+      summary:
+        "Upload a file and start a background job to extract knowledge (returns the Job)",
       requestBody: {
         content: {
           "multipart/form-data": {
@@ -578,15 +582,10 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
       },
       responses: {
         200: {
-          description: "Successful response",
+          description: "The created ingestion job",
           content: {
             "application/json": {
-              schema: resolver(
-                v.object({
-                  id: v.string(),
-                  ok: v.boolean(),
-                })
-              ),
+              schema: resolver(jobsSelectSchema),
             },
           },
         },
@@ -599,7 +598,7 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
     validator("param", v.object({ tenantId: v.string() })),
     isTenantMember,
     async (c) => {
-      const tenantId = c.req.param("tenantId");
+      const { tenantId } = c.req.valid("param");
       const contentType = c.req.header("content-type");
       const userId = c.get("usersId");
 
@@ -672,20 +671,45 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
 
       try {
         const parsedData = v.parse(uploadAndLearnValidation, data);
-        const r = await extractKnowledgeInOneStep(
-          { ...parsedData, file },
-          true
+
+        if (!(file instanceof File)) {
+          throw new HTTPException(400, {
+            message: "No file provided for upload-and-extract.",
+          });
+        }
+
+        // Stash the file so the background job can read it later, then hand
+        // back the job. The job deletes the temporary file when it is done.
+        const storage = await storeIngestFileInDb(file, tenantId);
+        const { tenantId: _t, userId: _u, ...options } = parsedData;
+        const job = await createKnowledgeIngestJob(
+          {
+            kind: "rag-upload",
+            tenantId,
+            userId,
+            storage,
+            deleteAfter: true,
+            options,
+          },
+          tenantId,
+          userId
         );
-        return c.json(r);
+        return c.json(job);
       } catch (e) {
+        if (e instanceof HTTPException) {
+          throw e;
+        }
         throw new HTTPException(400, { message: e + "" });
       }
     }
   );
 
   /**
-   * Add a text knowledge entry from a Text
-   * This will create a knowledge-text entry
+   * Add a text knowledge entry from a Text.
+   *
+   * Starts a background job (post-processing + chunking + embedding) and
+   * returns the created Job immediately. Poll
+   * `GET /tenant/:tenantId/jobs/:id` for status and the `{ id, ok }` result.
    */
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/knowledge/from-text",
@@ -693,13 +717,14 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
     checkUserPermission,
     describeRoute({
       tags: ["knowledge"],
-      summary: "Add a text knowledge entry from text",
+      summary:
+        "Start a background job to add a text knowledge entry (returns the Job)",
       responses: {
         200: {
-          description: "Successful response",
+          description: "The created ingestion job",
           content: {
             "application/json": {
-              schema: resolver(knowledgeEntrySchema),
+              schema: resolver(jobsSelectSchema),
             },
           },
         },
@@ -714,36 +739,30 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
         const data = c.req.valid("json");
         const { tenantId } = c.req.valid("param");
         validateOrganisationId(data, tenantId);
+        const userId = c.get("usersId");
 
-        const processed = await applyPostProcessors(
+        const job = await createKnowledgeIngestJob(
           {
-            text: data.text,
-            title: data.title,
-            source: { type: "text", includesImages: false },
-            context: { tenantId, userId: c.get("usersId") },
+            kind: "rag-text",
+            tenantId,
+            userId,
+            params: {
+              text: data.text,
+              title: data.title,
+              filters: data.filters,
+              teamId: data.teamId,
+              workspaceId: data.workspaceId,
+              knowledgeGroupId: data.knowledgeGroupId,
+              userOwned: data.userOwned,
+              meta: data.meta,
+              usePostProcessors: data.usePostProcessors,
+            },
           },
-          data.usePostProcessors
+          tenantId,
+          userId
         );
-        const text = processed.text;
 
-        const r = await extractKnowledgeFromText({
-          userId: c.get("usersId"),
-          tenantId: data.tenantId,
-          title: processed.title ?? data.title,
-          text,
-          filters: data.filters,
-          teamId: data.teamId,
-          workspaceId: data.workspaceId,
-          knowledgeGroupId: data.knowledgeGroupId,
-          userOwned: data.userOwned,
-          sourceExternalId: data.meta?.sourceId ?? data.title,
-          sourceType: "external",
-          sourceFileBucket: "default",
-          sourceUrl: data.meta?.sourceUri ?? data.title,
-          includesLocalImages: false,
-        });
-
-        return c.json(r);
+        return c.json(job);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
       }
@@ -751,9 +770,12 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
   );
 
   /**
-   * Add a knowledge entry from a URL (HTML page)
-   * Fetches the URL, extracts the readable article using Mozilla Readability
-   * and converts it to markdown via Turndown (with GFM tables/strikethrough/task-lists).
+   * Add a knowledge entry from a URL (HTML page or linked PDF).
+   *
+   * Starts a background job that fetches the URL, extracts the readable
+   * article (Mozilla Readability + Turndown) or parses a linked PDF, and
+   * embeds it. Returns the created Job immediately; poll
+   * `GET /tenant/:tenantId/jobs/:id` for status and the `{ id, ok }` result.
    */
   app.post(
     API_BASE_PATH + "/tenant/:tenantId/knowledge/from-url",
@@ -761,13 +783,14 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
     checkUserPermission,
     describeRoute({
       tags: ["knowledge"],
-      summary: "Add a knowledge entry from a URL (HTML → markdown)",
+      summary:
+        "Start a background job to add a knowledge entry from a URL (returns the Job)",
       responses: {
         200: {
-          description: "Successful response",
+          description: "The created ingestion job",
           content: {
             "application/json": {
-              schema: resolver(knowledgeEntrySchema),
+              schema: resolver(jobsSelectSchema),
             },
           },
         },
@@ -782,7 +805,10 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
         const data = c.req.valid("json");
         const { tenantId } = c.req.valid("param");
         validateOrganisationId(data, tenantId);
+        const userId = c.get("usersId");
 
+        // Cheap synchronous guard so obviously-bad input fails fast instead of
+        // via a failed job.
         if (
           !data.url.startsWith("http://") &&
           !data.url.startsWith("https://")
@@ -790,49 +816,26 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
           throw new Error("URL must start with http:// or https://");
         }
 
-        const parsed = await urlToMarkdown(data.url, {
-          parseContext: { tenantId },
-        });
-
-        if (!parsed.markdown || parsed.markdown.trim().length === 0) {
-          throw new Error(
-            `No readable content could be extracted from ${data.url}`
-          );
-        }
-
-        const processed = await applyPostProcessors(
+        const job = await createKnowledgeIngestJob(
           {
-            text: parsed.markdown,
-            title: parsed.title,
-            source: { type: "url", url: data.url, includesImages: false },
-            context: { tenantId, userId: c.get("usersId") },
+            kind: "rag-url",
+            tenantId,
+            userId,
+            params: {
+              url: data.url,
+              filters: data.filters,
+              teamId: data.teamId,
+              workspaceId: data.workspaceId,
+              knowledgeGroupId: data.knowledgeGroupId,
+              userOwned: data.userOwned,
+              usePostProcessors: data.usePostProcessors,
+            },
           },
-          data.usePostProcessors
+          tenantId,
+          userId
         );
-        const text = processed.text;
 
-        const r = await extractKnowledgeFromText({
-          userId: c.get("usersId"),
-          tenantId: data.tenantId,
-          title: processed.title ?? parsed.title,
-          text,
-          filters: data.filters,
-          teamId: data.teamId,
-          workspaceId: data.workspaceId,
-          knowledgeGroupId: data.knowledgeGroupId,
-          userOwned: data.userOwned,
-          sourceType: "url",
-          sourceUrl: data.url,
-          sourceFileBucket: "default",
-          metadata: {
-            ...(parsed.excerpt ? { excerpt: parsed.excerpt } : {}),
-            ...(parsed.byline ? { byline: parsed.byline } : {}),
-            ...(parsed.siteName ? { siteName: parsed.siteName } : {}),
-          },
-          includesLocalImages: false,
-        });
-
-        return c.json(r);
+        return c.json(job);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
       }

--- a/src/routes/tenant/[tenantId]/knowledge/security.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/security.test.ts
@@ -14,6 +14,7 @@ import {
   createDatabaseClient,
   waitForDbConnection,
 } from "../../../../lib/db/db-connection";
+import { processDueJobsOnce, getJob } from "../../../../lib/jobs";
 
 let appKnowledge = new Hono<{ Variables: SFContextVariables }>();
 let appKnowledgeTexts = new Hono<{ Variables: SFContextVariables }>();
@@ -64,7 +65,11 @@ beforeAll(async () => {
     parseData
   );
 
-  createdKnowledgeEntryId = parseResponse.jsonResponse.id;
+  // Ingestion is asynchronous now: the endpoint returns a Job. Run it and read
+  // the created knowledge entry id from the job result.
+  await processDueJobsOnce();
+  const finishedJob = await getJob(parseResponse.jsonResponse.id);
+  createdKnowledgeEntryId = (finishedJob.result as any)?.id;
 });
 
 describe("Knowledge API Security Tests", () => {

--- a/src/routes/tenant/[tenantId]/knowledge/texts/import-api.test.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/import-api.test.ts
@@ -8,9 +8,24 @@ import {
   createDatabaseClient,
   waitForDbConnection,
 } from "../../../../../lib/db/db-connection";
+import { processDueJobsOnce, getJob } from "../../../../../lib/jobs";
 
 let app = new Hono<{ Variables: SFContextVariables }>();
 let TEST_USER_1_TOKEN: string;
+
+/**
+ * The import routes now return a Job. Run the just-created job to completion
+ * (the built-in ingest handler is registered in `initTests`) and return the
+ * `{ knowledgeText, blocks }` result stored on the job.
+ */
+const runImportJob = async (job: any) => {
+  expect(job.id).toBeDefined();
+  expect(job.type).toBe("knowledge:ingest");
+  await processDueJobsOnce();
+  const finished = await getJob(job.id);
+  expect(finished.status).toBe("completed");
+  return finished.result as any;
+};
 
 const SCOPE_ID = crypto.randomUUID();
 
@@ -43,10 +58,11 @@ describe("Knowledge Text Import & Sync API", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.jsonResponse.knowledgeText.title).toBe("imported-doc");
-    expect(response.jsonResponse.knowledgeText.contentMode).toBe("blocks");
-    expect(response.jsonResponse.blocks.length).toBe(2);
-  });
+    const result = await runImportJob(response.jsonResponse);
+    expect(result.knowledgeText.title).toBe("imported-doc");
+    expect(result.knowledgeText.contentMode).toBe("blocks");
+    expect(result.blocks.length).toBe(2);
+  }, 30000);
 
   test("POST import honors title and splitIntoBlocks fields", async () => {
     const form = new FormData();
@@ -65,9 +81,10 @@ describe("Knowledge Text Import & Sync API", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.jsonResponse.knowledgeText.title).toBe("My Custom Title");
-    expect(response.jsonResponse.knowledgeText.contentMode).toBe("text");
-  });
+    const result = await runImportJob(response.jsonResponse);
+    expect(result.knowledgeText.title).toBe("My Custom Title");
+    expect(result.knowledgeText.contentMode).toBe("text");
+  }, 30000);
 
   test("POST import without a file returns 400", async () => {
     const form = new FormData();

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -32,9 +32,9 @@ import {
   getRelatedKnowledgeTexts,
 } from "../../../../../lib/knowledge/knowledge-text-links";
 import {
-  importKnowledgeTextFromFile,
-  importKnowledgeTextFromUrl,
-} from "../../../../../lib/knowledge/knowledge-text-import";
+  createKnowledgeIngestJob,
+  storeIngestFileInDb,
+} from "../../../../../lib/knowledge/ingestion-jobs";
 import {
   upsertKnowledgeTextFromSource,
   deleteOrphanedKnowledgeTexts,
@@ -52,6 +52,7 @@ import {
   knowledgeTextInsertSchema,
   knowledgeTextUpdateSchema,
   knowledgeTextBlockSchema,
+  jobsSelectSchema,
 } from "../../../../../lib/db/db-schema";
 import { isTenantMember } from "../../..";
 import { validateScope } from "../../../../../lib/utils/validate-scope";
@@ -205,7 +206,7 @@ export default function defineRoutesForKnowledgeTexts(
     describeRoute({
       tags: ["knowledge"],
       summary:
-        "Import a file (markdown, html, txt, PDF, ...) as a knowledge text wiki page",
+        "Start a background job to import a file (markdown, html, txt, PDF, ...) as a knowledge text wiki page (returns the Job)",
       requestBody: {
         content: {
           "multipart/form-data": {
@@ -224,8 +225,12 @@ export default function defineRoutesForKnowledgeTexts(
       },
       responses: {
         200: {
-          description:
-            "Successful response with the created page and its blocks",
+          description: "The created ingestion job",
+          content: {
+            "application/json": {
+              schema: resolver(jobsSelectSchema),
+            },
+          },
         },
       },
     }),
@@ -243,25 +248,37 @@ export default function defineRoutesForKnowledgeTexts(
           throw new Error("Missing 'file' form field");
         }
 
-        const r = await importKnowledgeTextFromFile(file, {
+        // Stash the file so the background job can read it later; the job
+        // deletes the temporary file when it is done.
+        const storage = await storeIngestFileInDb(file, tenantId);
+        const job = await createKnowledgeIngestJob(
+          {
+            kind: "text-import-file",
+            tenantId,
+            userId,
+            storage,
+            deleteAfter: true,
+            options: {
+              title: form.get("title")?.toString() || undefined,
+              parentId: form.get("parentId")?.toString() || undefined,
+              teamId: form.get("teamId")?.toString() || undefined,
+              tenantWide: form.get("tenantWide")?.toString() === "true",
+              embeddingEnabled:
+                form.get("embeddingEnabled")?.toString() === "true",
+              splitIntoBlocks:
+                form.get("splitIntoBlocks")?.toString() !== "false",
+              usePostProcessors: form
+                .get("usePostProcessors")
+                ?.toString()
+                .split(",")
+                .map((s) => s.trim())
+                .filter((s) => s.length > 0),
+            },
+          },
           tenantId,
-          userId,
-          title: form.get("title")?.toString() || undefined,
-          parentId: form.get("parentId")?.toString() || undefined,
-          teamId: form.get("teamId")?.toString() || undefined,
-          tenantWide: form.get("tenantWide")?.toString() === "true",
-          embeddingEnabled:
-            form.get("embeddingEnabled")?.toString() === "true",
-          splitIntoBlocks:
-            form.get("splitIntoBlocks")?.toString() !== "false",
-          usePostProcessors: form
-            .get("usePostProcessors")
-            ?.toString()
-            .split(",")
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0),
-        });
-        return c.json(r);
+          userId
+        );
+        return c.json(job);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
       }
@@ -277,11 +294,16 @@ export default function defineRoutesForKnowledgeTexts(
     checkUserPermission,
     describeRoute({
       tags: ["knowledge"],
-      summary: "Import a web page as a knowledge text wiki page",
+      summary:
+        "Start a background job to import a web page as a knowledge text wiki page (returns the Job)",
       responses: {
         200: {
-          description:
-            "Successful response with the created page and its blocks",
+          description: "The created ingestion job",
+          content: {
+            "application/json": {
+              schema: resolver(jobsSelectSchema),
+            },
+          },
         },
       },
     }),
@@ -307,18 +329,28 @@ export default function defineRoutesForKnowledgeTexts(
         const userId = c.get("usersId");
         const body = c.req.valid("json");
 
-        const r = await importKnowledgeTextFromUrl(body.url, {
+        const job = await createKnowledgeIngestJob(
+          {
+            kind: "text-import-url",
+            tenantId,
+            userId,
+            params: {
+              url: body.url,
+              options: {
+                title: body.title,
+                parentId: body.parentId,
+                teamId: body.teamId,
+                tenantWide: body.tenantWide,
+                embeddingEnabled: body.embeddingEnabled,
+                splitIntoBlocks: body.splitIntoBlocks,
+                usePostProcessors: body.usePostProcessors,
+              },
+            },
+          },
           tenantId,
-          userId,
-          title: body.title,
-          parentId: body.parentId,
-          teamId: body.teamId,
-          tenantWide: body.tenantWide,
-          embeddingEnabled: body.embeddingEnabled,
-          splitIntoBlocks: body.splitIntoBlocks,
-          usePostProcessors: body.usePostProcessors,
-        });
-        return c.json(r);
+          userId
+        );
+        return c.json(job);
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
       }

--- a/src/test/init.test.ts
+++ b/src/test/init.test.ts
@@ -14,6 +14,8 @@ import {
 } from "../lib/db/db-schema";
 import { and, eq, inArray, or } from "drizzle-orm";
 import { addTenantMember } from "../lib/usermanagement/tenants";
+import { defineJob } from "../lib/jobs";
+import { knowledgeIngestJobRegister } from "../lib/knowledge/ingestion-jobs";
 
 /**
  * FIXED TESTING DATA
@@ -295,6 +297,14 @@ const getJwtTokenForTesting = async (email: string) => {
 export const initTests = async () => {
   await createDatabaseClient();
   await waitForDbConnection();
+
+  // Register the framework's built-in document-ingestion job handler so tests
+  // can drain the queue (via `processDueJobsOnce`) after hitting the async
+  // knowledge routes. `defineJob` is idempotent and does not start the worker.
+  defineJob(
+    knowledgeIngestJobRegister.type,
+    knowledgeIngestJobRegister.handler
+  );
 
   await initTestOrganisations().catch((err) => {
     console.info("Error initialising test tenants", err);

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,14 @@ export interface ServerSpecificConfig {
   };
 
   jobHandlers?: JobHandlerRegister[];
+  /**
+   * Disable the background job queue on this instance. The framework normally
+   * starts the queue unconditionally because built-in handlers (e.g. async
+   * document ingestion for the knowledge routes) depend on it. Set this to
+   * `true` only when a separate, dedicated worker process drains the queue —
+   * otherwise ingestion jobs created via the knowledge routes stay `pending`.
+   */
+  disableJobQueue?: boolean;
 
   customEnvVariablesToCheckOnStartup?: string[];
   customHonoApps?: {


### PR DESCRIPTION
## Summary

This PR moves document ingestion (PDF parsing, chunking, embedding) from synchronous HTTP request handlers to the framework's background job queue. Knowledge ingestion endpoints now return immediately with a Job object instead of blocking for minutes while processing large documents.

## Key Changes

- **New `ingestion-jobs.ts` module**: Implements the `knowledge:ingest` job type with support for multiple ingestion flavors (file upload, URL, plain text, existing sources). Handles file storage/cleanup and dispatches to existing extraction helpers.

- **Async knowledge routes**: Updated endpoints to:
  - Store uploaded files temporarily in DB storage
  - Create a `knowledge:ingest` job with appropriate metadata
  - Return the Job immediately (202-style semantics with HTTP 200)
  - Let clients poll `GET /tenant/:tenantId/jobs/:jobId` for status and results

- **Extracted helper functions**: Moved logic from synchronous routes into reusable functions (`extractKnowledgeFromUrl`, `extractKnowledgeFromPlainText`) so the same code runs in background jobs.

- **Built-in job handler registration**: The framework now automatically registers and starts the knowledge ingestion job handler in `src/index.ts`, with an option to disable via `disableJobQueue` config for dedicated worker processes.

- **Updated routes**:
  - `POST /knowledge/from-text` → returns Job
  - `POST /knowledge/upload-and-extract` → returns Job
  - `POST /knowledge/from-url` → returns Job
  - `POST /knowledge/extract-knowledge` → returns Job
  - `POST /knowledge/texts/import-file` → returns Job
  - `POST /knowledge/texts/import-url` → returns Job

- **Test updates**: Added `ingestion-jobs.test.ts` with end-to-end job pipeline tests; updated existing tests to run jobs to completion and verify results.

- **Documentation**: Updated knowledge base docs to explain the async behavior, job polling, and result handling.

## Implementation Details

- Job metadata uses a discriminated union (`KnowledgeIngestJobMetadata`) with a `kind` field to select the concrete ingestion work (rag-upload, rag-existing, rag-url, rag-text, text-import-file, text-import-url).
- Uploaded files are stored in a dedicated `knowledge-ingest-jobs` bucket and cleaned up after the job completes (if `deleteAfter: true`).
- The job handler reconstructs the input from metadata and calls the same extraction helpers the synchronous routes used to call directly.
- All ingestion flavors use a single job type, reducing framework complexity while supporting diverse document sources.

https://claude.ai/code/session_01JZUct1Tgan1r1gL3ETvh7i