### PR TITLE
Refactor PDF parser architecture with OpenRouter support

### DIFF
--- a/src/lib/knowledge/parsing/pdf/images.ts
+++ b/src/lib/knowledge/parsing/pdf/images.ts
@@ -1,0 +1,29 @@
+import { saveFile } from "../../../storage";
+
+/**
+ * Persist a base64-encoded image (raw base64 or a `data:` URL) to storage and
+ * return the stored file path. Returns null when the payload is empty.
+ *
+ * Shared by the Mistral OCR parsers, which receive extracted images as base64.
+ */
+export const saveBase64ImageToStorage = async (
+  base64OrDataUrl: string,
+  id: string,
+  tenantId: string
+): Promise<string | null> => {
+  // Accept both raw base64 and `data:<mime>;base64,<payload>` URLs.
+  const base64Data = base64OrDataUrl.includes(",")
+    ? base64OrDataUrl.split(",")[1]
+    : base64OrDataUrl;
+
+  if (!base64Data) {
+    return null;
+  }
+
+  const bytes = Buffer.from(base64Data, "base64");
+  const blob = new Blob([bytes], { type: "image/jpeg" });
+  const file = new File([blob], id, { type: "image/jpeg" });
+
+  const savedFile = await saveFile(file, "images", tenantId, "db");
+  return savedFile.path;
+};

--- a/src/lib/knowledge/parsing/pdf/index.ts
+++ b/src/lib/knowledge/parsing/pdf/index.ts
@@ -1,26 +1,55 @@
-import { parsePdfFileAsMardownLlama } from "./llama-api";
-import { parsePdfFileAsMardownLocal } from "./local-service";
+import log from "../../../log";
+import { parsePdfFileAsMarkdownLlama } from "./llama-api";
 import { parsePdfFileAsMarkdownMistral } from "./mistral-ocr";
-import type {
-  PdfParserContext,
-  PdfParserOptions,
-  PdfParserResult,
+import { parsePdfFileAsMarkdownMistralOpenRouter } from "./mistral-openrouter";
+import { parsePdfFileAsMarkdownSymbiosika } from "./symbiosika-parse";
+import {
+  DEFAULT_PDF_PARSER,
+  PDF_PARSER,
+  PDF_PARSER_ALIASES,
+  type PdfParser,
+  type PdfParserContext,
+  type PdfParserOptions,
+  type PdfParserResult,
 } from "./types";
+
+/**
+ * Registry of available PDF parser services, keyed by their canonical id.
+ *
+ * To add a new parser: implement it as a `PdfParser`, then add one entry here
+ * (and its id to `PDF_PARSER` in `./types.ts`). Nothing else needs to change.
+ */
+const PDF_PARSERS: Record<string, PdfParser> = {
+  [PDF_PARSER.SYMBIOSIKA_V1]: parsePdfFileAsMarkdownSymbiosika,
+  [PDF_PARSER.MISTRAL]: parsePdfFileAsMarkdownMistral,
+  [PDF_PARSER.MISTRAL_OPENROUTER]: parsePdfFileAsMarkdownMistralOpenRouter,
+  [PDF_PARSER.LLAMA]: parsePdfFileAsMarkdownLlama,
+};
+
+/** Resolve a requested model id to a registered parser, applying legacy aliases. */
+const resolveParser = (requested: string): PdfParser => {
+  const id = PDF_PARSER_ALIASES[requested] ?? requested;
+  const parser = PDF_PARSERS[id];
+  if (!parser) {
+    throw new Error(
+      `Unknown PDF parser service "${requested}". Available: ${Object.keys(
+        PDF_PARSERS
+      ).join(", ")}`
+    );
+  }
+  if (id !== requested) {
+    log.debug(`PDF parser "${requested}" resolved to "${id}" (legacy alias).`);
+  }
+  return parser;
+};
 
 export const parsePdfFileAsMardown = async (
   fileContent: File,
   context: PdfParserContext,
   options?: PdfParserOptions
 ): Promise<PdfParserResult> => {
-  const model = options?.model ?? process.env.PDF_PARSER_SERVICE ?? "local";
-
-  if (model === "local") {
-    return parsePdfFileAsMardownLocal(fileContent, context, options);
-  } else if (model === "mistral") {
-    return parsePdfFileAsMarkdownMistral(fileContent, context, options);
-  } else if (model === "llama") {
-    return parsePdfFileAsMardownLlama(fileContent, context, options);
-  } else {
-    throw new Error("No PDF parser service configured");
-  }
+  const requested =
+    options?.model ?? process.env.PDF_PARSER_SERVICE ?? DEFAULT_PDF_PARSER;
+  const parser = resolveParser(requested);
+  return parser(fileContent, context, options);
 };

--- a/src/lib/knowledge/parsing/pdf/llama-api.test.ts
+++ b/src/lib/knowledge/parsing/pdf/llama-api.test.ts
@@ -1,5 +1,5 @@
 // import { describe, test, expect, beforeAll } from "bun:test";
-// import { parsePdfFileAsMardownLlama } from "./llama-api";
+// import { parsePdfFileAsMarkdownLlama } from "./llama-api";
 // import fs from "fs";
 
 // import { TEST_ORGANISATION_1 } from "../../../../test/init.test";
@@ -17,7 +17,7 @@
 //       type: "application/pdf",
 //     });
 
-//     const result = await parsePdfFileAsMardownLlama(file, {
+//     const result = await parsePdfFileAsMarkdownLlama(file, {
 //       tenantId: TEST_ORGANISATION_1.id,
 //     });
 

--- a/src/lib/knowledge/parsing/pdf/llama-api.ts
+++ b/src/lib/knowledge/parsing/pdf/llama-api.ts
@@ -1,7 +1,8 @@
-import type {
-  PdfParserContext,
-  PdfParserOptions,
-  PdfParserResult,
+import {
+  PDF_PARSER,
+  type PdfParserContext,
+  type PdfParserOptions,
+  type PdfParserResult,
 } from "./types";
 import log from "../../../log";
 
@@ -14,7 +15,7 @@ const API_BASE_URL = "https://api.cloud.llamaindex.ai";
 /**
  * Parse a PDF file as markdown
  */
-export const parsePdfFileAsMardownLlama = async (
+export const parsePdfFileAsMarkdownLlama = async (
   fileContent: File,
   context: PdfParserContext,
   options?: PdfParserOptions
@@ -96,7 +97,7 @@ export const parsePdfFileAsMardownLlama = async (
 
   return {
     includesImages: false,
-    model: "llama",
+    model: PDF_PARSER.LLAMA,
     pages: pages,
   };
 };

--- a/src/lib/knowledge/parsing/pdf/mistral-ocr.ts
+++ b/src/lib/knowledge/parsing/pdf/mistral-ocr.ts
@@ -1,9 +1,10 @@
 import log from "../../../log";
-import { saveFile } from "../../../storage";
-import type {
-  PdfParserContext,
-  PdfParserOptions,
-  PdfParserResult,
+import { saveBase64ImageToStorage } from "./images";
+import {
+  PDF_PARSER,
+  type PdfParserContext,
+  type PdfParserOptions,
+  type PdfParserResult,
 } from "./types";
 
 const MISTRAL_API_KEY = process.env.MISTRAL_API_KEY;
@@ -115,27 +116,16 @@ export const parsePdfFileAsMarkdownMistral = async (
     for (const page of ocrResult.pages) {
       if (page.images) {
         for (const image of page.images) {
-          // Convert base64 to blob
-          const base64Data = image.image_base64.split(",")[1];
-          if (!base64Data) {
+          // Persist the extracted image to storage
+          const savedPath = await saveBase64ImageToStorage(
+            image.image_base64,
+            image.id,
+            context.tenantId
+          );
+          if (!savedPath) {
             continue;
           }
-          const binaryData = atob(base64Data);
-          const bytes = new Uint8Array(binaryData.length);
-          for (let i = 0; i < binaryData.length; i++) {
-            bytes[i] = binaryData.charCodeAt(i);
-          }
-          const blob = new Blob([bytes], { type: "image/jpeg" });
-          const file = new File([blob], image.id, { type: "image/jpeg" });
-
-          // Save file to storage
-          const savedFile = await saveFile(
-            file,
-            "images",
-            context.tenantId,
-            "db"
-          );
-          imageMap.set(image.id, savedFile.path);
+          imageMap.set(image.id, savedPath);
 
           // replace the image reference with the new image path
           const imageRef = new RegExp(
@@ -144,7 +134,7 @@ export const parsePdfFileAsMarkdownMistral = async (
           );
           page.markdown = page.markdown.replace(
             imageRef,
-            `![${image.id}](${savedFile.path})`
+            `![${image.id}](${savedPath})`
           );
         }
       }
@@ -164,7 +154,7 @@ export const parsePdfFileAsMarkdownMistral = async (
         text: page.markdown,
       })),
       includesImages: imageMap.size > 0,
-      model: "mistral",
+      model: PDF_PARSER.MISTRAL,
     };
   } catch (error) {
     log.error(`OCR processing failed: ${error}`);

--- a/src/lib/knowledge/parsing/pdf/mistral-openrouter.ts
+++ b/src/lib/knowledge/parsing/pdf/mistral-openrouter.ts
@@ -1,0 +1,205 @@
+import log from "../../../log";
+import { saveBase64ImageToStorage } from "./images";
+import {
+  PDF_PARSER,
+  type PdfParserContext,
+  type PdfParserOptions,
+  type PdfParserResult,
+} from "./types";
+
+// https://openrouter.ai/docs/features/multimodal/pdfs
+//
+// OpenRouter runs Mistral OCR behind its `file-parser` plugin. We send the PDF
+// as a base64 data URL and read the parsed content back from the response's
+// file annotations, so no downstream completion is actually needed.
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const OPENROUTER_API_BASE_URL =
+  process.env.OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1";
+// Any model works — parsing happens in the plugin before inference. We use a
+// small, cheap model and cap the completion, since we only care about the
+// parsed annotations, not the model's reply.
+const OPENROUTER_PDF_MODEL =
+  process.env.OPENROUTER_PDF_MODEL ?? "mistralai/mistral-small-3.2-24b-instruct";
+
+// Optional attribution headers recommended by OpenRouter.
+const OPENROUTER_REFERER = process.env.OPENROUTER_REFERER;
+const OPENROUTER_TITLE = process.env.OPENROUTER_TITLE;
+
+type ContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
+type FileAnnotation = {
+  type: "file";
+  file: {
+    hash: string;
+    name?: string;
+    content: ContentPart[];
+  };
+};
+
+const isFileAnnotation = (value: unknown): value is FileAnnotation => {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { type?: unknown; file?: { hash?: unknown } };
+  return candidate.type === "file" && typeof candidate.file?.hash === "string";
+};
+
+/**
+ * Collect file annotations from both the success path
+ * (`choices[].message.annotations`) and the error path
+ * (`error.metadata.file_annotations`), deduped by file hash.
+ */
+const extractFileAnnotations = (response: unknown): FileAnnotation[] => {
+  if (typeof response !== "object" || response === null) return [];
+
+  const root = response as {
+    choices?: Array<{ message?: { annotations?: unknown[] } }>;
+    error?: { metadata?: { file_annotations?: unknown[] } };
+  };
+
+  const fromMessage = root.choices?.[0]?.message?.annotations ?? [];
+  const fromError = root.error?.metadata?.file_annotations ?? [];
+
+  const seen = new Set<string>();
+  const out: FileAnnotation[] = [];
+  for (const a of [...fromMessage, ...fromError]) {
+    if (isFileAnnotation(a) && !seen.has(a.file.hash)) {
+      seen.add(a.file.hash);
+      out.push(a);
+    }
+  }
+  return out;
+};
+
+/**
+ * Parse a PDF file as markdown using Mistral OCR through OpenRouter's
+ * `file-parser` plugin (parser id: "mistral-openrouter").
+ */
+export const parsePdfFileAsMarkdownMistralOpenRouter = async (
+  fileContent: File,
+  context: PdfParserContext,
+  options?: PdfParserOptions
+): Promise<PdfParserResult> => {
+  if (!OPENROUTER_API_KEY) {
+    throw new Error("No API key set for OpenRouter API.");
+  }
+
+  try {
+    // Encode the PDF as a base64 data URL.
+    const buffer = Buffer.from(await fileContent.arrayBuffer());
+    const dataUrl = `data:application/pdf;base64,${buffer.toString("base64")}`;
+    const filename = fileContent.name || "document.pdf";
+
+    log.debug("Sending PDF to OpenRouter file-parser (mistral-ocr)...");
+    const response = await fetch(
+      `${OPENROUTER_API_BASE_URL}/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+          "Content-Type": "application/json",
+          ...(OPENROUTER_REFERER ? { "HTTP-Referer": OPENROUTER_REFERER } : {}),
+          ...(OPENROUTER_TITLE ? { "X-Title": OPENROUTER_TITLE } : {}),
+        },
+        body: JSON.stringify({
+          model: OPENROUTER_PDF_MODEL,
+          // We only need the parsed annotations, not a real completion.
+          max_tokens: 1,
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "Parse this document." },
+                {
+                  type: "file",
+                  file: {
+                    filename,
+                    file_data: dataUrl,
+                  },
+                },
+              ],
+            },
+          ],
+          plugins: [
+            {
+              id: "file-parser",
+              pdf: {
+                engine: "mistral-ocr",
+              },
+            },
+          ],
+          stream: false,
+        }),
+      }
+    );
+
+    const responseBody: any = await response.json();
+
+    // OpenRouter can return parsed annotations even when the downstream model
+    // fails, so we try to extract them regardless of HTTP status before
+    // deciding the request failed.
+    const annotations = extractFileAnnotations(responseBody);
+
+    if (annotations.length === 0) {
+      if (!response.ok) {
+        const message =
+          responseBody?.error?.message || response.statusText || "Unknown error";
+        throw new Error(`OpenRouter OCR failed: ${message}`);
+      }
+      throw new Error("OpenRouter OCR returned no parsed file content.");
+    }
+
+    log.debug("OpenRouter OCR annotations retrieved successfully.");
+
+    // Flatten all annotation content parts, preserving order. Mistral OCR emits
+    // one text block per page, so each text part becomes a page; images are
+    // persisted to storage and their markdown references rewritten in order.
+    const pages: { page: number; text: string }[] = [];
+    const savedImagePaths: string[] = [];
+
+    for (const annotation of annotations) {
+      for (const part of annotation.file.content) {
+        if (part.type === "text") {
+          pages.push({ page: pages.length + 1, text: part.text });
+        } else if (
+          part.type === "image_url" &&
+          (options?.extractImages ?? true)
+        ) {
+          const path = await saveBase64ImageToStorage(
+            part.image_url.url,
+            `or-img-${savedImagePaths.length}.jpeg`,
+            context.tenantId
+          );
+          if (path) savedImagePaths.push(path);
+        }
+      }
+    }
+
+    // Best-effort: rewrite markdown image references (in order of appearance)
+    // to point at the stored image paths.
+    if (savedImagePaths.length > 0) {
+      let imageIndex = 0;
+      for (const page of pages) {
+        page.text = page.text.replace(
+          /!\[([^\]]*)\]\(([^)]*)\)/g,
+          (match, alt) => {
+            const path = savedImagePaths[imageIndex];
+            if (path === undefined) return match;
+            imageIndex += 1;
+            return `![${alt}](${path})`;
+          }
+        );
+      }
+    }
+
+    return {
+      pages: pages.length > 0 ? pages : [{ page: 1, text: "" }],
+      includesImages: savedImagePaths.length > 0,
+      model: PDF_PARSER.MISTRAL_OPENROUTER,
+    };
+  } catch (error) {
+    log.error(`OpenRouter OCR processing failed: ${error}`);
+    throw new Error(`OpenRouter OCR processing failed: ${error}`);
+  }
+};

--- a/src/lib/knowledge/parsing/pdf/symbiosika-parse.test.ts
+++ b/src/lib/knowledge/parsing/pdf/symbiosika-parse.test.ts
@@ -1,10 +1,10 @@
 // import { describe, test, expect, beforeAll } from "bun:test";
-// import { parsePdfFileAsMardownLocal } from "./local-service";
+// import { parsePdfFileAsMarkdownSymbiosika } from "./symbiosika-parse";
 // import fs from "fs";
 // import { TEST_ORGANISATION_1 } from "../../../../test/init.test";
 // import { TEST_PDF_TEXT } from "../../../../test/files.test";
 
-// describe("Local PDF Parser Service", () => {
+// describe("Symbiosika PDF Parser Service", () => {
 //   beforeAll(() => {
 //     // environment variables are set!
 //   });
@@ -16,7 +16,7 @@
 //       type: "application/pdf",
 //     });
 
-//     const result = await parsePdfFileAsMardownLocal(file, {
+//     const result = await parsePdfFileAsMarkdownSymbiosika(file, {
 //       tenantId: TEST_ORGANISATION_1.id,
 //     });
 

--- a/src/lib/knowledge/parsing/pdf/symbiosika-parse.ts
+++ b/src/lib/knowledge/parsing/pdf/symbiosika-parse.ts
@@ -1,12 +1,20 @@
 import log from "../../../log";
-import type {
-  PdfParserContext,
-  PdfParserOptions,
-  PdfParserResult,
+import {
+  PDF_PARSER,
+  type PdfParserContext,
+  type PdfParserOptions,
+  type PdfParserResult,
 } from "./types";
 
-const LOCAL_API_KEY = process.env.LOCAL_PDF_PARSER_API_KEY;
-const LOCAL_API_BASE_URL = process.env.LOCAL_PDF_PARSER_BASE_URL ?? "";
+// The service was historically called "local" although it always ran as a
+// remote HTTP service. Env vars keep a backward-compatible fallback to the old
+// `LOCAL_PDF_PARSER_*` names.
+const SYMBIOSIKA_API_KEY =
+  process.env.SYMBIOSIKA_PARSE_API_KEY ?? process.env.LOCAL_PDF_PARSER_API_KEY;
+const SYMBIOSIKA_API_BASE_URL =
+  process.env.SYMBIOSIKA_PARSE_BASE_URL ??
+  process.env.LOCAL_PDF_PARSER_BASE_URL ??
+  "";
 
 // Define interfaces for the API response structure
 interface PdfParserPage {
@@ -30,7 +38,7 @@ interface PdfParserChunk {
   metadata: PdfParserChunkMetadata;
 }
 
-interface LocalParserResult {
+interface SymbiosikaParserResult {
   job_id: string;
   original_filename: string;
   num_pages: number;
@@ -42,31 +50,32 @@ interface LocalParserResult {
 }
 
 /**
- * Parse a PDF file as markdown using the local PDF parsing service
+ * Parse a PDF file as markdown using the Symbiosika parsing service
+ * (parser id: "symbiosika-parse-v1", formerly "local").
  */
-export const parsePdfFileAsMardownLocal = async (
+export const parsePdfFileAsMarkdownSymbiosika = async (
   fileContent: File,
   context: PdfParserContext,
-  options?: PdfParserOptions,
+  options?: PdfParserOptions
 ): Promise<PdfParserResult> => {
-  if (!LOCAL_API_KEY) {
-    throw new Error("No API key set for local PDF parser API.");
+  if (!SYMBIOSIKA_API_KEY) {
+    throw new Error("No API key set for Symbiosika parsing service.");
   }
 
-  if (!LOCAL_API_BASE_URL) {
-    throw new Error("No base URL set for local PDF parser API.");
+  if (!SYMBIOSIKA_API_BASE_URL) {
+    throw new Error("No base URL set for Symbiosika parsing service.");
   }
 
   // Upload file and start parsing
   const formData = new FormData();
   formData.append("file", fileContent, "document.pdf");
 
-  log.debug("Uploading file to local PDF parser API...");
-  const uploadResponse = await fetch(`${LOCAL_API_BASE_URL}/upload`, {
+  log.debug("Uploading file to Symbiosika parsing service...");
+  const uploadResponse = await fetch(`${SYMBIOSIKA_API_BASE_URL}/upload`, {
     method: "POST",
     body: formData,
     headers: {
-      "X-API-Key": LOCAL_API_KEY,
+      "X-API-Key": SYMBIOSIKA_API_KEY,
     },
   }).catch((error) => {
     log.error(`Upload failed: ${error}`);
@@ -85,9 +94,12 @@ export const parsePdfFileAsMardownLocal = async (
   // Poll for job completion
   let isComplete = false;
   while (!isComplete) {
-    const statusResponse = await fetch(`${LOCAL_API_BASE_URL}/jobs/${jobId}`, {
-      headers: { "X-API-Key": LOCAL_API_KEY },
-    });
+    const statusResponse = await fetch(
+      `${SYMBIOSIKA_API_BASE_URL}/jobs/${jobId}`,
+      {
+        headers: { "X-API-Key": SYMBIOSIKA_API_KEY },
+      }
+    );
 
     if (!statusResponse.ok) {
       log.error(`Status check failed: ${statusResponse.statusText}`);
@@ -109,10 +121,10 @@ export const parsePdfFileAsMardownLocal = async (
 
   // Get results
   const resultResponse = await fetch(
-    `${LOCAL_API_BASE_URL}/jobs/${jobId}/result`,
+    `${SYMBIOSIKA_API_BASE_URL}/jobs/${jobId}/result`,
     {
-      headers: { "X-API-Key": LOCAL_API_KEY },
-    },
+      headers: { "X-API-Key": SYMBIOSIKA_API_KEY },
+    }
   );
 
   if (!resultResponse.ok) {
@@ -121,7 +133,7 @@ export const parsePdfFileAsMardownLocal = async (
   }
 
   log.debug("Result retrieved successfully.");
-  const result = (await resultResponse.json()) as LocalParserResult;
+  const result = (await resultResponse.json()) as SymbiosikaParserResult;
 
   // Create pages array with page numbers and content
   const pages =
@@ -132,7 +144,7 @@ export const parsePdfFileAsMardownLocal = async (
 
   return {
     includesImages: false,
-    model: "local",
+    model: PDF_PARSER.SYMBIOSIKA_V1,
     pages: pages, // Add pages information
   };
 };

--- a/src/lib/knowledge/parsing/pdf/types.ts
+++ b/src/lib/knowledge/parsing/pdf/types.ts
@@ -20,3 +20,45 @@ export interface PdfParserResult {
   model: string;
   pages?: PageContent[];
 }
+
+/**
+ * Canonical identifiers for the available PDF parser services.
+ *
+ * These are the values accepted for `options.model` / `PDF_PARSER_SERVICE`.
+ * To add a new parser, add its id here and register the handler in
+ * `./index.ts` — nothing else needs to change.
+ */
+export const PDF_PARSER = {
+  /** Symbiosika's own hosted parsing service (formerly called "local"). */
+  SYMBIOSIKA_V1: "symbiosika-parse-v1",
+  /** Mistral OCR, called directly against the Mistral API. */
+  MISTRAL: "mistral",
+  /** Mistral OCR, routed through OpenRouter's file-parser plugin. */
+  MISTRAL_OPENROUTER: "mistral-openrouter",
+  /** LlamaParse (LlamaIndex Cloud). */
+  LLAMA: "llama",
+} as const;
+
+export type PdfParserId = (typeof PDF_PARSER)[keyof typeof PDF_PARSER];
+
+/**
+ * Legacy model/env values mapped onto their current parser id, so existing
+ * deployments and stored configs keep working after a rename.
+ */
+export const PDF_PARSER_ALIASES: Record<string, PdfParserId> = {
+  // "local" was never actually local — it always called a remote Symbiosika
+  // parsing service.
+  local: PDF_PARSER.SYMBIOSIKA_V1,
+};
+
+/** The parser used when neither `options.model` nor `PDF_PARSER_SERVICE` is set. */
+export const DEFAULT_PDF_PARSER: PdfParserId = PDF_PARSER.SYMBIOSIKA_V1;
+
+/**
+ * A single PDF parsing implementation.
+ */
+export type PdfParser = (
+  fileContent: File,
+  context: PdfParserContext,
+  options?: PdfParserOptions
+) => Promise<PdfParserResult>;

--- a/src/routes/tenant/[tenantId]/knowledge/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/index.ts
@@ -56,7 +56,7 @@ const generateKnowledgeValidation = v.object({
   userOwned: v.optional(v.boolean()),
   workspaceId: v.optional(v.string()),
   knowledgeGroupId: v.optional(v.string()),
-  model: v.optional(v.string()), // mistral | llama | local
+  model: v.optional(v.string()), // symbiosika-parse-v1 | mistral | mistral-openrouter | llama
   usePostProcessors: v.optional(v.array(v.string())),
   extractImages: v.optional(v.boolean()),
   generateSummary: v.optional(v.boolean()),
@@ -160,7 +160,7 @@ const uploadAndLearnValidation = v.object({
       sourceId: v.string(),
     })
   ),
-  model: v.optional(v.string()), // mistral | llama | local
+  model: v.optional(v.string()), // symbiosika-parse-v1 | mistral | mistral-openrouter | llama
   usePostProcessors: v.optional(v.array(v.string())),
   extractImages: v.optional(v.boolean()),
   generateSummary: v.optional(v.boolean()),


### PR DESCRIPTION
## Summary
This PR refactors the PDF parser system to support multiple parsing services through a pluggable architecture, adds OpenRouter's Mistral OCR integration, and renames the "local" parser to its actual service name "Symbiosika".

## Key Changes

- **New pluggable parser architecture**: Introduced a registry-based system in `index.ts` that allows parsers to be registered and resolved by canonical IDs, making it easy to add new parsers without modifying the main dispatch logic.

- **Added OpenRouter Mistral OCR support**: New `mistral-openrouter.ts` parser that routes Mistral OCR through OpenRouter's `file-parser` plugin, with support for extracting and persisting images from parsed PDFs.

- **Renamed "local" parser to Symbiosika**: The `local-service.ts` file was renamed to `symbiosika-parse.ts` to accurately reflect that it calls the Symbiosika parsing service (never actually local). Environment variables now use `SYMBIOSIKA_PARSE_*` names with backward-compatible fallbacks to old `LOCAL_PDF_PARSER_*` names.

- **Extracted image handling utility**: Created `images.ts` with `saveBase64ImageToStorage()` to deduplicate base64 image persistence logic used by both Mistral OCR parsers.

- **Standardized parser identifiers**: Added `PDF_PARSER` constant object with canonical IDs for all parsers (`symbiosika-parse-v1`, `mistral`, `mistral-openrouter`, `llama`) and `PDF_PARSER_ALIASES` for legacy name mapping.

- **Fixed function naming**: Corrected typos in function names (`parsePdfFileAsMardownLocal` → `parsePdfFileAsMarkdownSymbiosika`, `parsePdfFileAsMardownLlama` → `parsePdfFileAsMarkdownLlama`).

- **Updated parser result models**: All parsers now return their canonical ID in the `model` field instead of informal names.

## Notable Implementation Details

- The OpenRouter parser extracts file annotations from both success (`choices[].message.annotations`) and error (`error.metadata.file_annotations`) paths, deduped by file hash, allowing parsing to succeed even when the downstream model fails.

- Image references in markdown are rewritten in order of appearance to point to persisted storage paths.

- The system defaults to Symbiosika (`symbiosika-parse-v1`) when no parser is specified, maintaining backward compatibility.

- All parsers conform to the `PdfParser` type signature, enabling straightforward addition of new parsers by implementing the interface and registering in the `PDF_PARSERS` map.

https://claude.ai/code/session_01Luq8ZTFGmnYAF9GCeXm2HT