### PR TITLE
Model-aware vector search + re-embed job for embedding model changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import {
   summaryJobRegister,
   sweepStaleSummaries,
 } from "./lib/knowledge/summaries";
+import { reEmbedJobRegister } from "./lib/knowledge/re-embed";
 import { isAiEnabled } from "./lib/ai";
 // Cron
 import scheduler from "./lib/cron";
@@ -457,6 +458,7 @@ export const defineServer = (config: ServerSpecificConfig) => {
       const builtInJobHandlers = [
         knowledgeIngestJobRegister,
         summaryJobRegister,
+        reEmbedJobRegister,
       ];
       const allJobHandlers = [
         ...builtInJobHandlers,
@@ -581,6 +583,17 @@ export {
   sweepStaleSummaries,
   enqueueSummaryBackfill,
 } from "./lib/knowledge/summaries";
+
+/**
+ * Export re-embedding controls (embedding model/provider changes).
+ */
+export {
+  RE_EMBED_JOB_TYPE,
+  findKnowledgeEntriesNeedingReEmbed,
+  reEmbedKnowledgeEntry,
+  enqueueReEmbedding,
+} from "./lib/knowledge/re-embed";
+export { getConfiguredEmbeddingModelId } from "./lib/knowledge/embedding";
 export {
   getKnowledgeTenantConfig,
   setKnowledgeTenantConfig,

--- a/src/lib/knowledge/embedding.ts
+++ b/src/lib/knowledge/embedding.ts
@@ -26,6 +26,19 @@ const getEmbeddingProvider = (): EmbeddingProviderId =>
   DEFAULT_EMBEDDING_PROVIDER;
 
 /**
+ * The model id the configured embedding provider would use for new embeddings,
+ * resolved without an API call. Returns `null` when the provider is not
+ * configured. Vectors are only comparable within one model, so searches filter
+ * stored chunks by this id and the re-embed job finds chunks that differ.
+ */
+export const getConfiguredEmbeddingModelId = (): string | null => {
+  const provider = getEmbeddingProvider();
+  if (!isEmbeddingProviderConfigured(provider)) return null;
+  const model = buildEmbeddingModel(provider);
+  return typeof model === "string" ? model : model.modelId;
+};
+
+/**
  * Generate an embedding for the given text using the configured embedding
  * provider (Mistral by default).
  * @param text - The text to generate an embedding for

--- a/src/lib/knowledge/knowledge-text-links.test.ts
+++ b/src/lib/knowledge/knowledge-text-links.test.ts
@@ -12,6 +12,13 @@ import {
 } from "./knowledge-texts";
 import { syncKnowledgeTextBlocks } from "./knowledge-text-blocks";
 import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+import { getDb } from "../db/db-connection";
+import {
+  knowledgeEntry,
+  knowledgeChunks,
+  knowledgeText,
+} from "../db/db-schema";
+import { eq } from "drizzle-orm";
 
 const ctx = { tenantId: TEST_ORGANISATION_1.id };
 
@@ -196,5 +203,48 @@ describe("Knowledge Text Links", () => {
     });
     const related = await getRelatedKnowledgeTexts(page.id, ctx);
     expect(related).toEqual([]);
+  });
+
+  it("only relates pages embedded with the same model", async () => {
+    const db = getDb();
+    const vec = () => {
+      const v = new Array(1024).fill(0);
+      v[0] = 1;
+      return v;
+    };
+    const createEmbeddedPage = async (name: string, model: string) => {
+      const page = await createKnowledgeText({
+        title: uniqueTitle(name),
+        text: "embedded content",
+        tenantId: ctx.tenantId,
+      });
+      const [entry] = await db
+        .insert(knowledgeEntry)
+        .values({ tenantId: ctx.tenantId, name: page.title })
+        .returning();
+      await db.insert(knowledgeChunks).values({
+        knowledgeEntryId: entry!.id,
+        text: `chunk of ${page.title}`,
+        order: 0,
+        embeddingModel: model,
+        dimensions: 1024,
+        textEmbedding1024: vec(),
+      });
+      await db
+        .update(knowledgeText)
+        .set({ knowledgeEntryId: entry!.id })
+        .where(eq(knowledgeText.id, page.id));
+      return page;
+    };
+
+    // A + B share a model, C is embedded with a different (incompatible) one
+    const pageA = await createEmbeddedPage("Model Filter A", "test-model-a");
+    const pageB = await createEmbeddedPage("Model Filter B", "test-model-a");
+    const pageC = await createEmbeddedPage("Model Filter C", "other-model");
+
+    const related = await getRelatedKnowledgeTexts(pageA.id, ctx);
+    const relatedIds = related.map((r) => r.id);
+    expect(relatedIds).toContain(pageB.id);
+    expect(relatedIds).not.toContain(pageC.id);
   });
 });

--- a/src/lib/knowledge/knowledge-text-links.ts
+++ b/src/lib/knowledge/knowledge-text-links.ts
@@ -29,6 +29,7 @@ import {
   getKnowledgeTextById,
   buildKnowledgeTextVisibilityConditions,
 } from "./knowledge-texts";
+import { getConfiguredEmbeddingModelId } from "./embedding";
 
 type Context = {
   tenantId: string;
@@ -264,13 +265,26 @@ export const getRelatedKnowledgeTexts = async (
   const ownChunks = await getDb()
     .select({
       dimensions: knowledgeChunks.dimensions,
+      embeddingModel: knowledgeChunks.embeddingModel,
       textEmbedding1536: knowledgeChunks.textEmbedding1536,
       textEmbedding1024: knowledgeChunks.textEmbedding1024,
     })
     .from(knowledgeChunks)
     .where(eq(knowledgeChunks.knowledgeEntryId, page.knowledgeEntryId));
 
+  // Vectors are only comparable within one model. Prefer the currently
+  // configured model; fall back to this page's stored model (page not yet
+  // re-embedded), so centroid and candidates always share one vector space.
+  const configuredModel = getConfiguredEmbeddingModelId();
+  const model =
+    configuredModel &&
+    ownChunks.some((c) => c.embeddingModel === configuredModel)
+      ? configuredModel
+      : ownChunks[0]?.embeddingModel;
+  if (!model) return [];
+
   const vectors = ownChunks
+    .filter((c) => c.embeddingModel === model)
     .map((c) =>
       c.dimensions === 1536 ? c.textEmbedding1536 : c.textEmbedding1024
     )
@@ -301,6 +315,7 @@ export const getRelatedKnowledgeTexts = async (
     WHERE ${visibility}
       AND ${knowledgeChunks.knowledgeEntryId} != ${page.knowledgeEntryId}
       AND ${embeddingColumn} IS NOT NULL
+      AND ${knowledgeChunks.embeddingModel} = ${model}
     GROUP BY ${knowledgeText.id}, ${knowledgeText.title}
     ORDER BY "distance" ASC
     LIMIT ${limit};

--- a/src/lib/knowledge/knowledge-text-search.ts
+++ b/src/lib/knowledge/knowledge-text-search.ts
@@ -177,7 +177,9 @@ const semanticSearch = async (
     FROM ${knowledgeChunks}
     JOIN ${knowledgeText}
       ON ${knowledgeText.knowledgeEntryId} = ${knowledgeChunks.knowledgeEntryId}
-    WHERE ${visibility} AND ${embeddingColumn} IS NOT NULL${extra}
+    WHERE ${visibility}
+      AND ${embeddingColumn} IS NOT NULL
+      AND ${knowledgeChunks.embeddingModel} = ${embed.model}${extra}
     ORDER BY "distance" ASC
     LIMIT ${limit * 4};
   `)) as RankedHit[];

--- a/src/lib/knowledge/re-embed.test.ts
+++ b/src/lib/knowledge/re-embed.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import {
+  findKnowledgeEntriesNeedingReEmbed,
+  enqueueReEmbedding,
+  reEmbedKnowledgeEntry,
+} from "./re-embed";
+import { getConfiguredEmbeddingModelId } from "./embedding";
+import { getDb } from "../db/db-connection";
+import { knowledgeEntry, knowledgeChunks } from "../db/db-schema";
+import { initTests, TEST_ORGANISATION_3 } from "../../test/init.test";
+
+// TEST_ORGANISATION_3 keeps this suite isolated from other tests that insert
+// chunks into organisation 1.
+const TENANT = TEST_ORGANISATION_3.id;
+
+const fakeVector = () => {
+  const v = new Array(1024).fill(0);
+  v[0] = 1;
+  return v;
+};
+
+const insertEntryWithChunks = async (
+  models: string[]
+): Promise<string> => {
+  const db = getDb();
+  const [entry] = await db
+    .insert(knowledgeEntry)
+    .values({
+      tenantId: TENANT,
+      name: `Re-Embed Test Entry ${crypto.randomUUID()}`,
+    })
+    .returning();
+  for (const [order, model] of models.entries()) {
+    await db.insert(knowledgeChunks).values({
+      knowledgeEntryId: entry!.id,
+      text: `chunk ${order} of ${entry!.name}`,
+      order,
+      embeddingModel: model,
+      dimensions: 1024,
+      textEmbedding1024: fakeVector(),
+    });
+  }
+  return entry!.id;
+};
+
+describe("Re-embed after embedding model change", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  it("finds entries with outdated chunks and enqueues deduped jobs", async () => {
+    const currentModel = getConfiguredEmbeddingModelId();
+    if (!currentModel) return; // provider not configured in this environment
+
+    // one entry with a single outdated chunk, one entry fully current
+    const outdatedEntryId = await insertEntryWithChunks([
+      "legacy-model",
+      currentModel,
+    ]);
+    await insertEntryWithChunks([currentModel]);
+
+    const found = await findKnowledgeEntriesNeedingReEmbed(TENANT);
+    expect(found.length).toBe(1);
+    expect(found[0]!.knowledgeEntryId).toBe(outdatedEntryId);
+    expect(found[0]!.outdatedChunks).toBe(1);
+
+    const first = await enqueueReEmbedding(TENANT);
+    expect(first).toEqual({ enqueued: 1, outdatedEntries: 1 });
+
+    // a second trigger must not pile up duplicate jobs
+    const second = await enqueueReEmbedding(TENANT);
+    expect(second).toEqual({ enqueued: 0, outdatedEntries: 1 });
+  });
+
+  it("no-ops gracefully when no embedding provider is configured", async () => {
+    const previous = process.env.EMBEDDING_PROVIDER;
+    process.env.EMBEDDING_PROVIDER = "__not-configured__";
+    try {
+      expect(getConfiguredEmbeddingModelId()).toBeNull();
+      expect(await findKnowledgeEntriesNeedingReEmbed(TENANT)).toEqual([]);
+      expect(
+        await reEmbedKnowledgeEntry(crypto.randomUUID(), TENANT)
+      ).toEqual({ status: "skipped", chunks: 0 });
+    } finally {
+      if (previous === undefined) delete process.env.EMBEDDING_PROVIDER;
+      else process.env.EMBEDDING_PROVIDER = previous;
+    }
+  });
+});

--- a/src/lib/knowledge/re-embed.ts
+++ b/src/lib/knowledge/re-embed.ts
@@ -1,0 +1,189 @@
+/**
+ * Re-embedding after an embedding model/provider change.
+ *
+ * Vectors are only comparable within one model, so the searches filter stored
+ * chunks by the currently configured model id (see embedding.ts). After a
+ * model/provider switch, chunks embedded with the old model therefore become
+ * invisible to the semantic legs until they are re-embedded — this module
+ * closes that gap via the framework's durable job queue:
+ *
+ *   1. `findKnowledgeEntriesNeedingReEmbed` lists a tenant's knowledge entries
+ *      that still have chunks of a different model than the configured one.
+ *   2. `enqueueReEmbedding` creates one `knowledge:re-embed` job per such
+ *      entry (deduped against already queued/running jobs), so a big knowledge
+ *      base is worked off gradually by the queue instead of one giant task.
+ *   3. The job handler re-embeds an entry's outdated chunks in place: same
+ *      row, same text/order/meta — only model, dimensions and the vector
+ *      columns change. Idempotent; chunks already on the configured model are
+ *      never touched, so a re-run only processes what is still outdated.
+ *
+ * Everything no-ops gracefully when no embedding provider is configured.
+ */
+
+import { and, eq, ne, sql, inArray } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { knowledgeChunks, knowledgeEntry } from "../db/schema/knowledge";
+import { jobs } from "../db/schema/jobs";
+import { createJob } from "../jobs";
+import type { JobHandlerRegister } from "../jobs";
+import {
+  generateEmbedding,
+  getConfiguredEmbeddingModelId,
+} from "./embedding";
+import log from "../log";
+
+/** Job type for the durable per-entry re-embedding. */
+export const RE_EMBED_JOB_TYPE = "knowledge:re-embed";
+
+export type ReEmbedJobMetadata = {
+  knowledgeEntryId: string;
+  tenantId: string;
+};
+
+/**
+ * Knowledge entries of a tenant that still have chunks embedded with a
+ * different model than the currently configured one. Returns [] when no
+ * embedding provider is configured.
+ */
+export const findKnowledgeEntriesNeedingReEmbed = async (
+  tenantId: string
+): Promise<{ knowledgeEntryId: string; outdatedChunks: number }[]> => {
+  const model = getConfiguredEmbeddingModelId();
+  if (!model) return [];
+
+  const rows = await getDb()
+    .select({
+      knowledgeEntryId: knowledgeChunks.knowledgeEntryId,
+      outdatedChunks: sql<number>`count(*)::int`,
+    })
+    .from(knowledgeChunks)
+    .innerJoin(
+      knowledgeEntry,
+      eq(knowledgeChunks.knowledgeEntryId, knowledgeEntry.id)
+    )
+    .where(
+      and(
+        eq(knowledgeEntry.tenantId, tenantId),
+        ne(knowledgeChunks.embeddingModel, model)
+      )
+    )
+    .groupBy(knowledgeChunks.knowledgeEntryId);
+
+  return rows;
+};
+
+/**
+ * Re-embed one entry's outdated chunks in place with the configured model
+ * (the job body). Idempotent — chunks already on the configured model are
+ * skipped, so a retried job resumes where it stopped.
+ */
+export const reEmbedKnowledgeEntry = async (
+  knowledgeEntryId: string,
+  tenantId: string
+): Promise<{ status: "re-embedded" | "skipped"; chunks: number }> => {
+  const model = getConfiguredEmbeddingModelId();
+  if (!model) {
+    log.debug("Re-embed skipped: no embedding provider configured");
+    return { status: "skipped", chunks: 0 };
+  }
+
+  const chunks = await getDb()
+    .select({ id: knowledgeChunks.id, text: knowledgeChunks.text })
+    .from(knowledgeChunks)
+    .innerJoin(
+      knowledgeEntry,
+      eq(knowledgeChunks.knowledgeEntryId, knowledgeEntry.id)
+    )
+    .where(
+      and(
+        eq(knowledgeChunks.knowledgeEntryId, knowledgeEntryId),
+        eq(knowledgeEntry.tenantId, tenantId),
+        ne(knowledgeChunks.embeddingModel, model)
+      )
+    )
+    .orderBy(knowledgeChunks.order);
+
+  if (chunks.length === 0) return { status: "skipped", chunks: 0 };
+
+  // Sequential on purpose: a background job should drain gently instead of
+  // firing one embedding request per chunk at the provider simultaneously.
+  for (const chunk of chunks) {
+    const embedding = await generateEmbedding(chunk.text, { tenantId });
+    await getDb()
+      .update(knowledgeChunks)
+      .set({
+        embeddingModel: embedding.model,
+        dimensions: embedding.dimensions,
+        textEmbedding1536:
+          embedding.dimensions === 1536 ? embedding.embedding : null,
+        textEmbedding1024:
+          embedding.dimensions === 1024 ? embedding.embedding : null,
+      })
+      .where(eq(knowledgeChunks.id, chunk.id));
+  }
+
+  log.debug(
+    `Re-embedded ${chunks.length} chunk(s) of knowledge entry ${knowledgeEntryId} with model "${model}"`
+  );
+  return { status: "re-embedded", chunks: chunks.length };
+};
+
+/** Durable job registration for per-entry re-embedding. */
+export const reEmbedJobRegister: JobHandlerRegister = {
+  type: RE_EMBED_JOB_TYPE,
+  handler: {
+    execute: async (metadata: ReEmbedJobMetadata) => {
+      return reEmbedKnowledgeEntry(metadata.knowledgeEntryId, metadata.tenantId);
+    },
+  },
+};
+
+/**
+ * Enqueue one re-embed job per knowledge entry whose chunks are not on the
+ * currently configured embedding model. Dedupes against entries that already
+ * have a queued/running re-embed job, so the trigger can be called repeatedly
+ * (e.g. from an admin route) without piling up duplicate work.
+ */
+export const enqueueReEmbedding = async (
+  tenantId: string
+): Promise<{ enqueued: number; outdatedEntries: number }> => {
+  const candidates = await findKnowledgeEntriesNeedingReEmbed(tenantId);
+  if (candidates.length === 0) return { enqueued: 0, outdatedEntries: 0 };
+
+  const pending = await getDb()
+    .select({ metadata: jobs.metadata })
+    .from(jobs)
+    .where(
+      and(
+        eq(jobs.type, RE_EMBED_JOB_TYPE),
+        inArray(jobs.status, ["pending", "running"])
+      )
+    );
+  const alreadyQueued = new Set(
+    pending
+      .map(
+        (j) => (j.metadata as { knowledgeEntryId?: string } | null)
+          ?.knowledgeEntryId
+      )
+      .filter((id): id is string => typeof id === "string")
+  );
+
+  let enqueued = 0;
+  for (const candidate of candidates) {
+    if (alreadyQueued.has(candidate.knowledgeEntryId)) continue;
+    await createJob(
+      RE_EMBED_JOB_TYPE,
+      {
+        knowledgeEntryId: candidate.knowledgeEntryId,
+        tenantId,
+      } satisfies ReEmbedJobMetadata,
+      tenantId
+    );
+    enqueued++;
+  }
+
+  if (enqueued > 0) {
+    log.debug(`Re-embed: enqueued ${enqueued} knowledge entry job(s)`);
+  }
+  return { enqueued, outdatedEntries: candidates.length };
+};

--- a/src/lib/knowledge/similarity-search.ts
+++ b/src/lib/knowledge/similarity-search.ts
@@ -99,6 +99,8 @@ export async function getNearestEmbeddings(q: {
   const perLeg = Math.max(q.n * 2, 20);
 
   // Semantic leg: query embedding vs. stored chunk embeddings (HNSW, cosine).
+  // Restricted to chunks of the same model as the query embedding — vectors
+  // of different models share no vector space, comparing them is meaningless.
   const semanticLeg = async (): Promise<KnowledgeChunk[]> => {
     const embed = await generateEmbedding(q.searchText, {
       tenantId: q.tenantId,
@@ -110,6 +112,7 @@ export async function getNearestEmbeddings(q: {
       JOIN
         ${knowledgeEntry} ON ${knowledgeChunks.knowledgeEntryId} = ${knowledgeEntry.id}
       ${whereClause}
+        AND ${knowledgeChunks.embeddingModel} = ${embed.model}
       ORDER BY
         ${
           embed.dimensions === 1536

--- a/src/routes/tenant/[tenantId]/knowledge/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/index.ts
@@ -35,6 +35,7 @@ import { knowledgeEntrySchema } from "../../../../lib/db/db-schema";
 import { isTenantAdmin, isTenantMember } from "../..";
 import { validateScope } from "../../../../lib/utils/validate-scope";
 import { getAllPostProcessors } from "../../../../lib/knowledge/parsing/post-processors";
+import { enqueueReEmbedding } from "../../../../lib/knowledge/re-embed";
 
 const FileSourceType = {
   DB: "db",
@@ -900,6 +901,45 @@ export default function defineRoutes(app: SymbiosikaFrameworkHonoApp, API_BASE_P
       } catch (e) {
         throw new HTTPException(400, { message: e + "" });
       }
+    }
+  );
+
+  /**
+   * Trigger re-embedding after an embedding model/provider change — enqueue
+   * one background job per knowledge entry whose chunks are not on the
+   * currently configured embedding model. Admin only. Safe to call repeatedly
+   * (already queued/running entries are skipped).
+   */
+  app.post(
+    API_BASE_PATH + "/tenant/:tenantId/knowledge/re-embed",
+    authAndSetUsersInfo,
+    checkUserPermission,
+    describeRoute({
+      tags: ["knowledge"],
+      summary:
+        "Enqueue re-embed jobs for entries not on the configured embedding model",
+      responses: {
+        200: {
+          description: "Enqueue result",
+          content: {
+            "application/json": {
+              schema: resolver(
+                v.object({
+                  enqueued: v.number(),
+                  outdatedEntries: v.number(),
+                })
+              ),
+            },
+          },
+        },
+      },
+    }),
+    validateScope("knowledge:write"),
+    validator("param", v.object({ tenantId: v.string() })),
+    isTenantAdmin,
+    async (c) => {
+      const { tenantId } = c.req.valid("param");
+      return c.json(await enqueueReEmbedding(tenantId));
     }
   );
 }


### PR DESCRIPTION
Follow-up to #69 / #70 — implements point 3 of the knowledgeText optimization review: safe embedding model/provider changes.

## Problem

Vectors are only comparable within one model. Until now, switching the embedding provider/model either silently mixed incompatible vector spaces (same dimensions → garbage ranking) or made old content invisible to semantic search (different dimensions → chunks live in the other column). `embedding_model` was stored per chunk but never used at query time.

## Changes

- **`getConfiguredEmbeddingModelId()`** (embedding.ts): resolves the currently configured embedding model id without an API call; `null` when unconfigured.
- **Model filter in all three vector search paths:**
  - semantic leg of the RAG chunk search (`similarity-search.ts`) and of the knowledgeText page search (`knowledge-text-search.ts`) filter by the query embedding's model;
  - the related-pages centroid search (`knowledge-text-links.ts`) picks one model — the configured one when the page has it, otherwise the page's stored model — for both the centroid and the candidates, so both sides always share one vector space.
- **New durable job `knowledge:re-embed`** (`re-embed.ts`): finds knowledge entries whose chunks are not on the configured model and re-embeds them in place (same rows — only model, dimensions and vector columns change). Idempotent; enqueue is deduped against queued/running jobs; graceful no-op without a configured provider. Registered as a built-in job handler.
- **New admin route** `POST /tenant/:tenantId/knowledge/re-embed` (tenant admin, `knowledge:write`) to trigger the backfill; helpers are exported from the framework index.

## Operational notes

After switching `EMBEDDING_PROVIDER` / the embedding model, old-model content is excluded from semantic search (instead of being wrongly ranked) but still findable via the full-text leg of the hybrid search (#70). Calling the re-embed route per tenant migrates the chunks gradually via the job queue.

## Verification

- New tests: find/enqueue/dedupe of re-embed jobs, graceful no-op without provider, and a related-pages test proving cross-model chunks are excluded.
- Knowledge test suite: identical results to baseline (only the pre-existing failures that need live Mistral API access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HF2jcdehZE6TRs7fAwp5AE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HF2jcdehZE6TRs7fAwp5AE)_