### PR TITLE
Restore generic PDF parser microservice integration (lost in #72 merge)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -41,9 +41,14 @@ POSTGRES_DB=dev
 #PDF_PARSER_SERVICE="llama"
 #PDF_PARSER_SERVICE="local"
 #PDF_PARSER_SERVICE="mistral"
+#PDF_PARSER_SERVICE="generic"
 #LOCAL_PDF_PARSER_API_KEY="demo-xxx"
 #LOCAL_PDF_PARSER_BASE_URL="https://document-services.perlecto.de"
 #LLAMA_CLOUD_API_KEY=llx-xxx
+# Generic parsing microservice (PDF_PARSER_SERVICE="generic")
+#PDF_PARSER_SERVICE_API_KEY="sk-xxx"
+#PDF_PARSER_SERVICE_URL="https://parser.example.com"
+#PDF_PARSER_SERVICE_MODE="sync" # "sync" (default) | "async"
 
 # MISTRAL_API_KEY
 # OPENAI_API_KEY

--- a/docs/framework/18_PDF_Parser_Generic_Microservice_Spec.md
+++ b/docs/framework/18_PDF_Parser_Generic_Microservice_Spec.md
@@ -1,0 +1,439 @@
+# Generic PDF Parser — Microservice Specification
+
+This is the complete, self-contained contract for a **generic PDF parsing
+microservice** that plugs into the Symbiosika framework. Implement this and your
+service is a drop-in parser — no framework code changes needed, only
+configuration.
+
+> Framework-side integration (types, parser wiring) is documented separately in
+> `19_PDF_Parser_Generic_Framework_Integration.md`. You do **not** need it to
+> build the service.
+
+---
+
+## 1. Authentication
+
+Every request carries an API key in the `X-API-Key` header:
+
+```
+X-API-Key: sk-abc123...
+```
+
+Reject any request with a missing or wrong key with `401` and body
+`{ "error": "invalid_api_key" }`.
+
+---
+
+## 2. Endpoints
+
+| Method | Path                   | Mode  | Required |
+|--------|------------------------|-------|----------|
+| `GET`  | `/health`              | –     | optional |
+| `GET`  | `/v1/capabilities`     | –     | **yes**  |
+| `POST` | `/v1/parse`            | sync  | **yes**  |
+| `POST` | `/v1/jobs`             | async | optional |
+| `GET`  | `/v1/jobs/:id`         | async | optional |
+| `GET`  | `/v1/jobs/:id/result`  | async | optional |
+
+You MUST implement `/v1/capabilities` (§2.1) and synchronous `/v1/parse`. The
+async job endpoints are OPTIONAL and only needed for large documents where one
+HTTP request would exceed proxy/load-balancer timeouts (typically 30–60 s). The
+**result body is identical** for sync and async (§5).
+
+### 2.1 Capability discovery — `GET /v1/capabilities`
+
+Declares which **modalities** (document types) the service can process, so the
+framework knows whether to route a given file to it. A service is not limited to
+PDF — it can advertise images, audio, video, etc. All modalities go through the
+same `/v1/parse` (and job) endpoints; the file's content type identifies it.
+
+```bash
+curl https://parser.example.com/v1/capabilities -H "X-API-Key: sk-abc123..."
+```
+
+```json
+{
+  "service": "generic-v1",
+  "modalities": [
+    {
+      "modality": "pdf",
+      "mime_types": ["application/pdf"],
+      "extensions": [".pdf"],
+      "features": { "extract_images": true, "extract_fields": true, "async": true }
+    },
+    {
+      "modality": "image",
+      "mime_types": ["image/png", "image/jpeg", "image/webp"],
+      "extensions": [".png", ".jpg", ".jpeg", ".webp"],
+      "features": { "extract_fields": true }
+    },
+    {
+      "modality": "audio",
+      "mime_types": ["audio/mpeg", "audio/wav"],
+      "extensions": [".mp3", ".wav"],
+      "features": { "async": true }
+    }
+  ]
+}
+```
+
+| Field                  | Type      | Required | Description |
+|------------------------|-----------|----------|-------------|
+| `service`              | string    | ✅       | Service/build identifier (matches `model` in results). |
+| `modalities`           | array     | ✅       | Every modality the service accepts. At least one entry. |
+| `modalities[].modality`| string    | ✅       | Canonical class: `pdf`, `image`, `audio`, `video`, `text`, or `office`. |
+| `modalities[].mime_types` | string[] | ✅    | Accepted MIME types for this modality. Used as the primary routing key. |
+| `modalities[].extensions` | string[] | ✅    | Accepted file extensions (lowercase, leading dot). Fallback when MIME is unknown. |
+| `modalities[].features` | object   | ❌       | Optional per-modality flags: `extract_images`, `extract_fields`, `async` (all default `false`). Tells the framework which request options are meaningful for this type. |
+
+The response MUST be stable and cheap (no file processing). The framework may
+cache it. `/v1/parse` MUST reject a file whose type is not in any advertised
+modality with `415` `{ "error": "unsupported_modality" }`.
+
+---
+
+## 3. Request payload (same for `/v1/parse` and `/v1/jobs`)
+
+`multipart/form-data`:
+
+```
+POST /v1/parse HTTP/1.1
+Host: parser.example.com
+X-API-Key: sk-abc123...
+Content-Type: multipart/form-data; boundary=...
+
+--...
+Content-Disposition: form-data; name="file"; filename="document.pdf"
+Content-Type: application/pdf
+
+<binary>
+--...
+Content-Disposition: form-data; name="extract_images"
+
+true
+--...
+Content-Disposition: form-data; name="extract"
+
+[{"key":"hersteller","name":"Hersteller","description":"Name des Herstellers laut Typenschild","required":true,"type":"string"},{"key":"typ","name":"Typ","description":"Typ-/Modellbezeichnung des Geräts","required":false,"type":"string"}]
+--...
+```
+
+### Form fields
+
+| Field            | Type              | Required | Default | Description |
+|------------------|-------------------|----------|---------|-------------|
+| `file`           | file (PDF)        | ✅       | –       | The document to parse |
+| `extract_images` | `"true"`/`"false"`| ❌       | `false` | Emit extracted images as base64 |
+| `extract`        | JSON string       | ❌       | `[]`    | Structured extraction targets (see §3.1) |
+
+### 3.1 The `extract` field — structured extraction targets
+
+A JSON array. Each entry declares one value to pull out of the document. The
+caller names the fields (`key`, `name`, `description`); your service fills them.
+
+```json
+[
+  {
+    "key": "hersteller",
+    "name": "Hersteller",
+    "description": "Name des Herstellers laut Typenschild",
+    "required": true,
+    "type": "string"
+  },
+  {
+    "key": "baujahr",
+    "name": "Baujahr",
+    "description": "Herstellungsjahr",
+    "required": false,
+    "type": "number"
+  },
+  {
+    "key": "geraeteart",
+    "name": "Geräteart",
+    "description": "Kategorie des Geräts",
+    "required": false,
+    "type": "enum",
+    "options": ["Pumpe", "Ventil", "Motor", "Sonstiges"]
+  }
+]
+```
+
+| Attribute     | Type      | Required | Meaning |
+|---------------|-----------|----------|---------|
+| `key`         | string    | ✅       | Stable machine key. Use it verbatim as the key in the response `metadata`. `snake_case` recommended. |
+| `name`        | string    | ✅       | Human-readable label. Feed it to the extraction model as the field name. |
+| `description` | string    | ✅       | What exactly to extract — the primary instruction to the extractor. |
+| `required`    | boolean   | ❌ (default `false`) | Whether the field is expected to exist. See below. |
+| `type`        | string    | ❌ (default `"string"`) | One of `string`, `number`, `date`, `boolean`, `enum`. `date` values are ISO-8601 strings. |
+| `options`     | string[]  | ❌       | Only for `type: "enum"`. Allowed values. |
+
+**Required fields:** a `required` field that cannot be found MUST still appear in
+`metadata` with `found: false` and `value: null`. **Do NOT fail the request**
+because a required field is missing — the framework decides how to handle gaps.
+List every missing required `key` in the top-level `warnings` array.
+
+---
+
+## 4. Synchronous endpoint — `POST /v1/parse`
+
+Parse and return the result in one request. Response is the result object (§5).
+
+```bash
+curl -X POST https://parser.example.com/v1/parse \
+  -H "X-API-Key: sk-abc123..." \
+  -F "file=@muster.pdf;type=application/pdf" \
+  -F "extract_images=true" \
+  -F 'extract=[{"key":"hersteller","name":"Hersteller","description":"Name des Herstellers","required":true}]'
+```
+
+---
+
+## 5. Result object (returned by `/v1/parse` and `/v1/jobs/:id/result`)
+
+`200 OK`, `Content-Type: application/json`:
+
+```json
+{
+  "model": "generic-v1",
+  "pages": [
+    {
+      "page": 1,
+      "text": "# Typenschild\n\nHersteller: Siemens\n\n![img-p1-1](img-p1-1)",
+      "images": [
+        { "id": "img-p1-1", "base64": "data:image/png;base64,iVBORw0KGgo..." }
+      ]
+    },
+    { "page": 2, "text": "Weitere technische Daten ..." }
+  ],
+  "metadata": {
+    "hersteller": { "value": "Siemens", "found": true, "confidence": 0.96, "page": 1 },
+    "typ":        { "value": "3RT2026-1BB40", "found": true, "confidence": 0.88, "page": 1 },
+    "baujahr":    { "value": 2021, "found": true, "confidence": 0.72, "page": 2 },
+    "geraeteart": { "value": null, "found": false, "confidence": 0 }
+  },
+  "warnings": []
+}
+```
+
+### Top-level fields
+
+| Field      | Type    | Required | Description |
+|------------|---------|----------|-------------|
+| `model`    | string  | ✅       | Free-form identifier of your parser build, e.g. `generic-v1`, `docling-0.3`. |
+| `pages`    | array   | ✅       | One entry per page, `page` 1-based and ascending. |
+| `metadata` | object  | ❌       | Extracted key/value results, keyed by each `extract` target's `key`. Omit or `{}` when no targets were requested. |
+| `warnings` | string[]| ❌       | Non-fatal notes, e.g. `"required field 'geraeteart' not found"`. |
+
+### `pages[]`
+
+| Field    | Type   | Required | Description |
+|----------|--------|----------|-------------|
+| `page`   | number | ✅       | 1-based page number. |
+| `text`   | string | ✅       | Page content as **Markdown**. |
+| `images` | array  | ❌       | Extracted images for this page. Only when `extract_images=true`. |
+
+### `pages[].images[]`
+
+| Field    | Type   | Required | Description |
+|----------|--------|----------|-------------|
+| `id`     | string | ✅       | Image id, unique within the document. |
+| `base64` | string | ✅       | Image bytes. Raw base64 **or** a `data:<mime>;base64,...` URL — both accepted. |
+
+**Image placeholders:** every image referenced in `text` MUST use the id as both
+alt-text and URL: `![img-p1-1](img-p1-1)`. The framework replaces this with the
+real storage path after saving the image.
+
+### `metadata[key]` — extracted value
+
+| Field        | Type              | Required | Description |
+|--------------|-------------------|----------|-------------|
+| `value`      | string/number/bool/null | ✅ | The extracted value, typed per the target's `type`. `null` when not found. |
+| `found`      | boolean           | ✅       | `true` if a value was extracted. |
+| `confidence` | number (0..1)     | ❌       | Optional extraction confidence. |
+| `page`       | number            | ❌       | Optional 1-based page where the value was found. |
+
+---
+
+## 6. Asynchronous endpoints (optional)
+
+For large documents. Same request payload as `/v1/parse` (§3). Three steps:
+**create → poll → fetch result.**
+
+### 6.1 Create — `POST /v1/jobs`
+
+Same multipart body as `/v1/parse`. Returns immediately with `202 Accepted`:
+
+```bash
+curl -X POST https://parser.example.com/v1/jobs \
+  -H "X-API-Key: sk-abc123..." \
+  -F "file=@muster.pdf;type=application/pdf" \
+  -F "extract_images=true" \
+  -F 'extract=[{"key":"hersteller","name":"Hersteller","description":"...","required":true}]'
+```
+
+```json
+// 202 Accepted
+{ "job_id": "job_7f3a9c", "status": "pending" }
+```
+
+### 6.2 Poll — `GET /v1/jobs/:id`
+
+```bash
+curl https://parser.example.com/v1/jobs/job_7f3a9c \
+  -H "X-API-Key: sk-abc123..."
+```
+
+```json
+// still running
+{ "job_id": "job_7f3a9c", "status": "processing", "progress": 0.4 }
+
+// done
+{ "job_id": "job_7f3a9c", "status": "completed" }
+
+// failed
+{ "job_id": "job_7f3a9c", "status": "failed", "error": "cannot_parse" }
+```
+
+| Field      | Type   | Required | Description |
+|------------|--------|----------|-------------|
+| `job_id`   | string | ✅       | Echoes the id from create. |
+| `status`   | string | ✅       | One of `pending`, `processing`, `completed`, `failed`. |
+| `progress` | number (0..1) | ❌ | Optional progress hint while `processing`. |
+| `error`    | string | ❌       | Error code, present only when `status: "failed"`. |
+
+The framework polls this endpoint (≈ once per second) until `status` is
+`completed` or `failed`.
+
+### 6.3 Result — `GET /v1/jobs/:id/result`
+
+Only valid once `status: "completed"`. Returns the **exact same result object as
+`/v1/parse`** (§5).
+
+```bash
+curl https://parser.example.com/v1/jobs/job_7f3a9c/result \
+  -H "X-API-Key: sk-abc123..."
+```
+
+```json
+// 200 OK — identical schema to POST /v1/parse
+{ "model": "generic-v1", "pages": [ ... ], "metadata": { ... }, "warnings": [] }
+```
+
+If called before completion, return `409 Conflict`:
+`{ "error": "not_ready", "status": "processing" }`.
+
+---
+
+## 7. Errors
+
+Any non-2xx response is treated as a failure. Use a JSON body:
+
+```json
+// 401 – missing/invalid API key
+{ "error": "invalid_api_key" }
+
+// 415 – file type not in any advertised modality
+{ "error": "unsupported_modality" }
+
+// 415 / 422 – corrupt or unsupported file
+{ "error": "cannot_parse", "detail": "unsupported or corrupt file" }
+
+// 400 – malformed 'extract' JSON
+{ "error": "invalid_extract", "detail": "extract must be a JSON array" }
+
+// 409 – async result requested too early
+{ "error": "not_ready", "status": "processing" }
+```
+
+A **missing required extraction field is NOT an error** — return the normal
+result with `found: false` and a `warnings` entry (§3.1).
+
+---
+
+## 8. Reference implementation (FastAPI)
+
+```python
+from fastapi import FastAPI, UploadFile, Form, Header, HTTPException
+import json
+
+app = FastAPI()
+API_KEY = "sk-abc123..."
+
+def require_key(x_api_key: str):
+    if x_api_key != API_KEY:
+        raise HTTPException(401, "invalid_api_key")
+
+def build_result(data: bytes, extract_images: bool, extract: str) -> dict:
+    try:
+        targets = json.loads(extract)
+    except json.JSONDecodeError:
+        raise HTTPException(400, "invalid_extract")
+
+    pages = your_parser(data, extract_images)        # -> [{page, text, images?}, ...]
+    metadata = your_extractor(pages, targets)        # -> {key: {value, found, ...}}
+    warnings = [f"required field '{t['key']}' not found"
+                for t in targets
+                if t.get("required") and not metadata.get(t["key"], {}).get("found")]
+    return {"model": "generic-v1", "pages": pages,
+            "metadata": metadata, "warnings": warnings}
+
+CAPABILITIES = {
+    "service": "generic-v1",
+    "modalities": [
+        {"modality": "pdf", "mime_types": ["application/pdf"],
+         "extensions": [".pdf"],
+         "features": {"extract_images": True, "extract_fields": True, "async": True}},
+        {"modality": "image", "mime_types": ["image/png", "image/jpeg"],
+         "extensions": [".png", ".jpg", ".jpeg"],
+         "features": {"extract_fields": True}},
+    ],
+}
+ACCEPTED_MIME = {m for c in CAPABILITIES["modalities"] for m in c["mime_types"]}
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.get("/v1/capabilities")
+def capabilities(x_api_key: str = Header(None)):
+    require_key(x_api_key)
+    return CAPABILITIES
+
+# --- synchronous (required) ---
+@app.post("/v1/parse")
+async def parse(
+    file: UploadFile,
+    extract_images: bool = Form(False),
+    extract: str = Form("[]"),
+    x_api_key: str = Header(None),
+):
+    require_key(x_api_key)
+    if file.content_type not in ACCEPTED_MIME:
+        raise HTTPException(415, "unsupported_modality")
+    return build_result(await file.read(), extract_images, extract)
+
+# --- asynchronous (optional) ---
+@app.post("/v1/jobs", status_code=202)
+async def create_job(
+    file: UploadFile,
+    extract_images: bool = Form(False),
+    extract: str = Form("[]"),
+    x_api_key: str = Header(None),
+):
+    require_key(x_api_key)
+    job_id = enqueue(await file.read(), extract_images, extract)   # your queue
+    return {"job_id": job_id, "status": "pending"}
+
+@app.get("/v1/jobs/{job_id}")
+def job_status(job_id: str, x_api_key: str = Header(None)):
+    require_key(x_api_key)
+    return get_status(job_id)          # {job_id, status, progress?, error?}
+
+@app.get("/v1/jobs/{job_id}/result")
+def job_result(job_id: str, x_api_key: str = Header(None)):
+    require_key(x_api_key)
+    st = get_status(job_id)
+    if st["status"] != "completed":
+        raise HTTPException(409, {"error": "not_ready", "status": st["status"]})
+    return get_result(job_id)          # same schema as /v1/parse
+```

--- a/docs/framework/19_PDF_Parser_Generic_Framework_Integration.md
+++ b/docs/framework/19_PDF_Parser_Generic_Framework_Integration.md
@@ -1,0 +1,337 @@
+# Generic PDF Parser — Framework Integration
+
+How the `generic` PDF parser is wired into the framework. The HTTP contract with
+the microservice is specified separately in
+`18_PDF_Parser_Generic_Microservice_Spec.md`.
+
+The `generic` parser reuses the existing conventions of the Mistral OCR parser
+(base64 images inline, `![id](id)` markdown placeholders replaced with storage
+paths), so it slots into the current pipeline with no changes downstream of
+`parsePdfFileAsMardown`.
+
+---
+
+## 1. Configuration
+
+Three environment variables select and reach the service:
+
+```bash
+PDF_PARSER_SERVICE="generic"
+PDF_PARSER_SERVICE_API_KEY="sk-abc123..."
+PDF_PARSER_SERVICE_URL="https://parser.example.com"
+```
+
+Add these to `.env.default` (commented, as examples):
+
+```bash
+#PDF_PARSER_SERVICE="generic"
+#PDF_PARSER_SERVICE_API_KEY="sk-abc123..."
+#PDF_PARSER_SERVICE_URL="https://parser.example.com"
+```
+
+Authentication uses the `X-API-Key` header — same scheme as the existing
+Symbiosika parser.
+
+---
+
+## 2. Types — `src/lib/knowledge/parsing/pdf/types.ts`
+
+```ts
+export const PDF_PARSER = {
+  // ...existing...
+  GENERIC: "generic",
+} as const;
+
+/** One structured value to extract from a document. */
+export type ExtractionTarget = {
+  key: string;
+  name: string;
+  description: string;
+  required?: boolean;
+  type?: "string" | "number" | "date" | "boolean" | "enum";
+  options?: string[];
+};
+
+/** One extracted value in the result. */
+export type ExtractedValue = {
+  value: string | number | boolean | null;
+  found: boolean;
+  confidence?: number;
+  page?: number;
+};
+
+export type PdfParserOptions = {
+  model?: string;
+  extractImages?: boolean;
+  /** Structured extraction targets passed through to the service. */
+  extract?: ExtractionTarget[];
+};
+
+export interface PdfParserResult {
+  includesImages: boolean;
+  model: string;
+  pages?: PageContent[];
+  /** Extracted key/value metadata, keyed by ExtractionTarget.key. */
+  metadata?: Record<string, ExtractedValue>;
+}
+```
+
+`PdfParserResult.metadata` is the new field carrying the service's extraction
+results. It can be persisted as JSON on the document immediately; downstream
+consumption (search, filtering, validation of required fields) can be added
+later without changing the wire contract.
+
+---
+
+## 3. Parser — `src/lib/knowledge/parsing/pdf/generic.ts`
+
+Uses the synchronous endpoint by default and falls back to the async job flow if
+`PDF_PARSER_SERVICE_MODE=async` is set.
+
+```ts
+import log from "../../../log";
+import { saveBase64ImageToStorage } from "./images";
+import {
+  PDF_PARSER,
+  type ExtractedValue,
+  type PdfParser,
+} from "./types";
+
+const API_KEY = process.env.PDF_PARSER_SERVICE_API_KEY;
+const BASE_URL = process.env.PDF_PARSER_SERVICE_URL;
+const MODE = process.env.PDF_PARSER_SERVICE_MODE ?? "sync"; // "sync" | "async"
+
+type RawImage = { id: string; base64: string };
+type RawPage = { page: number; text: string; images?: RawImage[] };
+type RawResult = {
+  model: string;
+  pages: RawPage[];
+  metadata?: Record<string, ExtractedValue>;
+};
+
+const authHeaders = () => ({ "X-API-Key": API_KEY as string });
+
+const buildForm = (file: File, options?: Parameters<PdfParser>[2]) => {
+  const form = new FormData();
+  form.append("file", file, "document.pdf");
+  form.append("extract_images", String(options?.extractImages ?? false));
+  if (options?.extract?.length) {
+    form.append("extract", JSON.stringify(options.extract));
+  }
+  return form;
+};
+
+/** Synchronous: one POST /v1/parse. */
+const runSync = async (form: FormData): Promise<RawResult> => {
+  const res = await fetch(`${BASE_URL}/v1/parse`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`Parsing failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as RawResult;
+};
+
+/** Asynchronous: create job -> poll -> fetch result. */
+const runAsync = async (form: FormData): Promise<RawResult> => {
+  const createRes = await fetch(`${BASE_URL}/v1/jobs`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!createRes.ok) {
+    throw new Error(`Job creation failed: ${createRes.status} ${createRes.statusText}`);
+  }
+  const { job_id: jobId } = (await createRes.json()) as { job_id: string };
+
+  // Poll until completed/failed.
+  while (true) {
+    const statusRes = await fetch(`${BASE_URL}/v1/jobs/${jobId}`, {
+      headers: authHeaders(),
+    });
+    if (!statusRes.ok) {
+      throw new Error(`Status check failed: ${statusRes.status} ${statusRes.statusText}`);
+    }
+    const status = (await statusRes.json()) as { status: string; error?: string };
+    log.debug(`Generic parser job ${jobId}: ${status.status}`);
+    if (status.status === "completed") break;
+    if (status.status === "failed") {
+      throw new Error(`PDF parsing failed: ${status.error ?? "unknown error"}`);
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  const resultRes = await fetch(`${BASE_URL}/v1/jobs/${jobId}/result`, {
+    headers: authHeaders(),
+  });
+  if (!resultRes.ok) {
+    throw new Error(`Result retrieval failed: ${resultRes.status} ${resultRes.statusText}`);
+  }
+  return (await resultRes.json()) as RawResult;
+};
+
+export const parsePdfFileAsMarkdownGeneric: PdfParser = async (
+  file,
+  context,
+  options
+) => {
+  if (!API_KEY) throw new Error("No API key set for generic parsing service.");
+  if (!BASE_URL) throw new Error("No base URL set for generic parsing service.");
+
+  const form = buildForm(file, options);
+  const data = MODE === "async" ? await runAsync(form) : await runSync(form);
+
+  // Save images + replace placeholders (identical to the Mistral parser).
+  let includesImages = false;
+  for (const page of data.pages) {
+    for (const img of page.images ?? []) {
+      const savedPath = await saveBase64ImageToStorage(
+        img.base64,
+        img.id,
+        context.tenantId
+      );
+      if (!savedPath) continue;
+      includesImages = true;
+      const ref = new RegExp(`!\\[${img.id}\\]\\(${img.id}\\)`, "g");
+      page.text = page.text.replace(ref, `![${img.id}](${savedPath})`);
+    }
+  }
+
+  return {
+    model: data.model ?? PDF_PARSER.GENERIC,
+    pages: data.pages.map((p) => ({ page: p.page, text: p.text })),
+    includesImages,
+    metadata: data.metadata,
+  };
+};
+```
+
+---
+
+## 4. Capability discovery
+
+The service advertises which **modalities** (document types) it accepts via
+`GET /v1/capabilities` (see the microservice spec §2.1). This lets the framework
+route a file to the service only when its type is supported, and know which
+request options (`extract_images`, `extract`, async) are meaningful.
+
+### 4.1 Types — `src/lib/knowledge/parsing/pdf/types.ts`
+
+```ts
+export type ParserModality =
+  | "pdf" | "image" | "audio" | "video" | "text" | "office";
+
+export type ServiceModality = {
+  modality: ParserModality;
+  mimeTypes: string[];
+  extensions: string[];
+  features?: {
+    extractImages?: boolean;
+    extractFields?: boolean;
+    async?: boolean;
+  };
+};
+
+export type ServiceCapabilities = {
+  service: string;
+  modalities: ServiceModality[];
+};
+```
+
+### 4.2 Fetch + cache — `src/lib/knowledge/parsing/pdf/generic.ts`
+
+```ts
+let cachedCapabilities: ServiceCapabilities | null = null;
+
+export const getGenericParserCapabilities =
+  async (): Promise<ServiceCapabilities> => {
+    if (cachedCapabilities) return cachedCapabilities;
+    if (!API_KEY || !BASE_URL) {
+      throw new Error("Generic parsing service not configured.");
+    }
+    const res = await fetch(`${BASE_URL}/v1/capabilities`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) {
+      throw new Error(`Capabilities fetch failed: ${res.status} ${res.statusText}`);
+    }
+    const raw = (await res.json()) as {
+      service: string;
+      modalities: {
+        modality: ServiceModality["modality"];
+        mime_types: string[];
+        extensions: string[];
+        features?: Record<string, boolean>;
+      }[];
+    };
+    cachedCapabilities = {
+      service: raw.service,
+      modalities: raw.modalities.map((m) => ({
+        modality: m.modality,
+        mimeTypes: m.mime_types,
+        extensions: m.extensions,
+        features: {
+          extractImages: m.features?.extract_images ?? false,
+          extractFields: m.features?.extract_fields ?? false,
+          async: m.features?.async ?? false,
+        },
+      })),
+    };
+    return cachedCapabilities;
+  };
+
+/** True if the service accepts a file of this MIME type / extension. */
+export const genericParserSupports = async (
+  mimeType?: string,
+  extension?: string
+): Promise<boolean> => {
+  const caps = await getGenericParserCapabilities();
+  return caps.modalities.some(
+    (m) =>
+      (mimeType && m.mimeTypes.includes(mimeType)) ||
+      (extension && m.extensions.includes(extension.toLowerCase()))
+  );
+};
+```
+
+The wire field names are `snake_case` (`mime_types`, `extract_images`); the
+mapper normalizes them to the framework's `camelCase` types. Capabilities are
+cached in-process — the service guarantees a cheap, stable response.
+
+---
+
+## 5. Registration — `src/lib/knowledge/parsing/pdf/index.ts`
+
+One line in the registry:
+
+```ts
+const PDF_PARSERS: Record<string, PdfParser> = {
+  [PDF_PARSER.SYMBIOSIKA_V1]: parsePdfFileAsMarkdownSymbiosika,
+  [PDF_PARSER.MISTRAL]: parsePdfFileAsMarkdownMistral,
+  [PDF_PARSER.MISTRAL_OPENROUTER]: parsePdfFileAsMarkdownMistralOpenRouter,
+  [PDF_PARSER.LLAMA]: parsePdfFileAsMarkdownLlama,
+  [PDF_PARSER.GENERIC]: parsePdfFileAsMarkdownGeneric, // <-- new
+};
+```
+
+`parsePdfFileAsMardown` reads `PDF_PARSER_SERVICE=generic`, resolves the parser,
+and returns the `PdfParserResult` into the existing splitter/embedding pipeline
+unchanged.
+
+---
+
+## 6. Open items (not blocking the wire contract)
+
+- **Where do `extract` targets come from?** They need to be plumbed into
+  `PdfParserOptions.extract` at the call site (upload/import flow). The contract
+  is defined; the UI/config source for the targets is a separate task.
+- **Persisting `metadata`.** Store as JSON on the document record. Consuming it
+  (search, required-field validation) can follow later.
+- **Sync vs. async selection.** Currently a global `PDF_PARSER_SERVICE_MODE`.
+  Could later be per-document (e.g. by file size) without a contract change.
+- **Modality-based routing.** `genericParserSupports()` enables routing files to
+  the service only for advertised modalities (PDF/image/audio/video). Extending
+  the parser registry beyond PDF to a general "file parser" dispatcher is a
+  follow-up; the capability contract already supports it.

--- a/src/lib/knowledge/parsing/pdf/generic.test.ts
+++ b/src/lib/knowledge/parsing/pdf/generic.test.ts
@@ -1,0 +1,246 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  mock,
+} from "bun:test";
+import type { Server } from "bun";
+
+// Provide DB env defaults so importing the logger (which constructs a Postgres
+// client at module load) does not crash in an isolated run. postgres.js is
+// lazy, so no real connection is opened — and nothing here ever queries.
+process.env.POSTGRES_HOST ??= "localhost";
+process.env.POSTGRES_PORT ??= "5432";
+process.env.POSTGRES_USER ??= "postgres";
+process.env.POSTGRES_PASSWORD ??= "postgres";
+process.env.POSTGRES_DB ??= "symbiosika";
+
+// Stub the image saver so the image-rewrite path does not touch real storage.
+// The only other importers are the (disabled) Mistral parser tests.
+mock.module("./images", () => ({
+  saveBase64ImageToStorage: async (_base64: string, id: string) =>
+    `/storage/${id}`,
+}));
+
+const {
+  parsePdfFileAsMarkdownGeneric,
+  getGenericParserCapabilities,
+  genericParserSupports,
+  resetGenericParserCapabilitiesCache,
+} = await import("./generic");
+
+// --- A mini fake parsing service implementing the wire contract ------------
+
+const API_KEY = "test-key";
+
+// Observable state so tests can assert what the framework actually sent.
+let lastParseForm: {
+  filename?: string;
+  extractImages: string | null;
+  extract: string | null;
+} | null = null;
+let capabilitiesHits = 0;
+let failNextParse = false;
+
+const CAPABILITIES_BODY = {
+  service: "generic-v1",
+  modalities: [
+    {
+      modality: "pdf",
+      mime_types: ["application/pdf"],
+      extensions: [".pdf"],
+      features: { extract_images: true, extract_fields: true, async: true },
+    },
+    {
+      modality: "image",
+      mime_types: ["image/png"],
+      extensions: [".png"],
+    },
+  ],
+};
+
+const RESULT_BODY = {
+  model: "generic-v1",
+  pages: [
+    {
+      page: 1,
+      text: "Hersteller ![img-1](img-1)",
+      images: [{ id: "img-1", base64: "data:image/png;base64,AAAA" }],
+    },
+    { page: 2, text: "Seite zwei" },
+  ],
+  metadata: {
+    hersteller: { value: "Siemens", found: true, confidence: 0.9 },
+    typ: { value: null, found: false },
+  },
+};
+
+// Minimal in-memory job store for the async flow: a created job is immediately
+// "completed", so the first status poll succeeds without the 1s backoff.
+const jobs = new Set<string>();
+let jobCounter = 0;
+
+let server: Server;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+
+      if (req.headers.get("X-API-Key") !== API_KEY) {
+        return Response.json({ error: "invalid_api_key" }, { status: 401 });
+      }
+
+      if (url.pathname === "/v1/capabilities") {
+        capabilitiesHits += 1;
+        return Response.json(CAPABILITIES_BODY);
+      }
+
+      if (url.pathname === "/v1/parse" && req.method === "POST") {
+        const form = await req.formData();
+        lastParseForm = {
+          filename: (form.get("file") as File | null)?.name,
+          extractImages: form.get("extract_images") as string | null,
+          extract: form.get("extract") as string | null,
+        };
+        if (failNextParse) {
+          return Response.json({ error: "cannot_parse" }, { status: 422 });
+        }
+        return Response.json(RESULT_BODY);
+      }
+
+      if (url.pathname === "/v1/jobs" && req.method === "POST") {
+        await req.formData();
+        const jobId = `job_${(jobCounter += 1)}`;
+        jobs.add(jobId);
+        return Response.json({ job_id: jobId, status: "pending" }, { status: 202 });
+      }
+
+      const jobResultMatch = url.pathname.match(/^\/v1\/jobs\/([^/]+)\/result$/);
+      if (jobResultMatch) {
+        return jobs.has(jobResultMatch[1])
+          ? Response.json(RESULT_BODY)
+          : Response.json({ error: "not_ready" }, { status: 409 });
+      }
+
+      const jobStatusMatch = url.pathname.match(/^\/v1\/jobs\/([^/]+)$/);
+      if (jobStatusMatch) {
+        return jobs.has(jobStatusMatch[1])
+          ? Response.json({ job_id: jobStatusMatch[1], status: "completed" })
+          : Response.json({ error: "unknown_job" }, { status: 404 });
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  process.env.PDF_PARSER_SERVICE_API_KEY = API_KEY;
+  process.env.PDF_PARSER_SERVICE_URL = `http://localhost:${server.port}`;
+});
+
+afterAll(() => {
+  server.stop(true);
+  delete process.env.PDF_PARSER_SERVICE_URL;
+  delete process.env.PDF_PARSER_SERVICE_API_KEY;
+});
+
+afterEach(() => {
+  resetGenericParserCapabilitiesCache();
+  failNextParse = false;
+  delete process.env.PDF_PARSER_SERVICE_MODE;
+});
+
+const pdfFile = () =>
+  new File([new Uint8Array([1, 2, 3])], "muster.pdf", {
+    type: "application/pdf",
+  });
+
+describe("Generic PDF Parser Service (against a fake service)", () => {
+  test("sends the expected request and maps the sync result", async () => {
+    const result = await parsePdfFileAsMarkdownGeneric(
+      pdfFile(),
+      { tenantId: "tenant-1" },
+      {
+        extractImages: true,
+        extract: [
+          {
+            key: "hersteller",
+            name: "Hersteller",
+            description: "Name des Herstellers",
+            required: true,
+          },
+        ],
+      }
+    );
+
+    // What the framework actually sent to the service.
+    expect(lastParseForm?.filename).toBe("muster.pdf");
+    expect(lastParseForm?.extractImages).toBe("true");
+    expect(JSON.parse(lastParseForm?.extract as string)).toEqual([
+      {
+        key: "hersteller",
+        name: "Hersteller",
+        description: "Name des Herstellers",
+        required: true,
+      },
+    ]);
+
+    // Result mapping: image placeholder rewritten, metadata passed through.
+    expect(result.model).toBe("generic-v1");
+    expect(result.includesImages).toBe(true);
+    expect(result.pages).toEqual([
+      { page: 1, text: "Hersteller ![img-1](/storage/img-1)" },
+      { page: 2, text: "Seite zwei" },
+    ]);
+    expect(result.metadata?.hersteller.value).toBe("Siemens");
+    expect(result.metadata?.typ.found).toBe(false);
+  });
+
+  test("omits the extract field when no targets are given", async () => {
+    await parsePdfFileAsMarkdownGeneric(pdfFile(), { tenantId: "tenant-1" });
+    expect(lastParseForm?.extractImages).toBe("false");
+    expect(lastParseForm?.extract).toBeNull();
+  });
+
+  test("throws on a non-2xx response", async () => {
+    failNextParse = true;
+    await expect(
+      parsePdfFileAsMarkdownGeneric(pdfFile(), { tenantId: "tenant-1" })
+    ).rejects.toThrow("Parsing failed");
+  });
+
+  test("async mode runs create -> poll -> result", async () => {
+    process.env.PDF_PARSER_SERVICE_MODE = "async";
+    const result = await parsePdfFileAsMarkdownGeneric(pdfFile(), {
+      tenantId: "tenant-1",
+    });
+    expect(result.model).toBe("generic-v1");
+    expect(result.pages?.[1]).toEqual({ page: 2, text: "Seite zwei" });
+  });
+
+  test("fetches capabilities, normalizes fields, and caches", async () => {
+    const before = capabilitiesHits;
+
+    const caps = await getGenericParserCapabilities();
+    expect(caps.service).toBe("generic-v1");
+    expect(caps.modalities[0].mimeTypes).toEqual(["application/pdf"]);
+    expect(caps.modalities[0].features?.extractImages).toBe(true);
+    // Missing features default to false after normalization.
+    expect(caps.modalities[1].features?.async).toBe(false);
+
+    // Second call is served from cache — service hit only once.
+    await getGenericParserCapabilities();
+    expect(capabilitiesHits - before).toBe(1);
+  });
+
+  test("genericParserSupports matches by mime type and extension", async () => {
+    expect(await genericParserSupports("application/pdf")).toBe(true);
+    // Extension match is case-insensitive.
+    expect(await genericParserSupports(undefined, ".PNG")).toBe(true);
+    expect(await genericParserSupports("audio/mpeg", ".mp3")).toBe(false);
+  });
+});

--- a/src/lib/knowledge/parsing/pdf/generic.ts
+++ b/src/lib/knowledge/parsing/pdf/generic.ts
@@ -1,0 +1,231 @@
+import log from "../../../log";
+import { saveBase64ImageToStorage } from "./images";
+import {
+  PDF_PARSER,
+  type ExtractedValue,
+  type PdfParser,
+  type PdfParserOptions,
+  type ServiceCapabilities,
+  type ServiceModality,
+} from "./types";
+
+// Generic self-hosted parsing microservice. See
+// `docs/framework/18_PDF_Parser_Generic_Microservice_Spec.md` for the wire
+// contract and `19_..._Framework_Integration.md` for this integration.
+//
+// Config is read lazily (at call time, not module load) so the parser can be
+// registered/imported before the environment is fully set up — and so tests
+// can point it at a local server.
+const getApiKey = (): string | undefined =>
+  process.env.PDF_PARSER_SERVICE_API_KEY;
+const getBaseUrl = (): string | undefined => process.env.PDF_PARSER_SERVICE_URL;
+// "sync" (default) uses POST /v1/parse; "async" uses the job endpoints.
+const getMode = (): string => process.env.PDF_PARSER_SERVICE_MODE ?? "sync";
+
+type RawImage = { id: string; base64: string };
+type RawPage = { page: number; text: string; images?: RawImage[] };
+type RawResult = {
+  model: string;
+  pages: RawPage[];
+  metadata?: Record<string, ExtractedValue>;
+};
+
+const authHeaders = (): Record<string, string> => ({
+  "X-API-Key": getApiKey() as string,
+});
+
+const requireConfig = (): void => {
+  if (!getApiKey()) {
+    throw new Error("No API key set for generic parsing service.");
+  }
+  if (!getBaseUrl()) {
+    throw new Error("No base URL set for generic parsing service.");
+  }
+};
+
+const buildForm = (file: File, options?: PdfParserOptions): FormData => {
+  const form = new FormData();
+  form.append("file", file, file.name || "document.pdf");
+  form.append("extract_images", String(options?.extractImages ?? false));
+  if (options?.extract?.length) {
+    form.append("extract", JSON.stringify(options.extract));
+  }
+  return form;
+};
+
+/** Synchronous flow: a single POST /v1/parse. */
+const runSync = async (form: FormData): Promise<RawResult> => {
+  const res = await fetch(`${getBaseUrl()}/v1/parse`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`Parsing failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as RawResult;
+};
+
+/** Asynchronous flow: create job -> poll -> fetch result. */
+const runAsync = async (form: FormData): Promise<RawResult> => {
+  const createRes = await fetch(`${getBaseUrl()}/v1/jobs`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!createRes.ok) {
+    throw new Error(
+      `Job creation failed: ${createRes.status} ${createRes.statusText}`
+    );
+  }
+  const { job_id: jobId } = (await createRes.json()) as { job_id: string };
+  log.debug(`Generic parser job created: ${jobId}`);
+
+  // Poll until completed/failed.
+  let isComplete = false;
+  while (!isComplete) {
+    const statusRes = await fetch(`${getBaseUrl()}/v1/jobs/${jobId}`, {
+      headers: authHeaders(),
+    });
+    if (!statusRes.ok) {
+      throw new Error(
+        `Status check failed: ${statusRes.status} ${statusRes.statusText}`
+      );
+    }
+    const status = (await statusRes.json()) as {
+      status: string;
+      error?: string;
+    };
+    log.debug(`Generic parser job ${jobId}: ${status.status}`);
+    if (status.status === "completed") {
+      isComplete = true;
+    } else if (status.status === "failed") {
+      throw new Error(`PDF parsing failed: ${status.error ?? "unknown error"}`);
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+
+  const resultRes = await fetch(`${getBaseUrl()}/v1/jobs/${jobId}/result`, {
+    headers: authHeaders(),
+  });
+  if (!resultRes.ok) {
+    throw new Error(
+      `Result retrieval failed: ${resultRes.status} ${resultRes.statusText}`
+    );
+  }
+  return (await resultRes.json()) as RawResult;
+};
+
+/**
+ * Parse a file as markdown using the generic parsing microservice
+ * (parser id: "generic").
+ */
+export const parsePdfFileAsMarkdownGeneric: PdfParser = async (
+  fileContent,
+  context,
+  options
+) => {
+  requireConfig();
+
+  const form = buildForm(fileContent, options);
+  const data = getMode() === "async" ? await runAsync(form) : await runSync(form);
+
+  // Save images and rewrite `![id](id)` placeholders to storage paths, exactly
+  // as the Mistral OCR parser does.
+  let includesImages = false;
+  for (const page of data.pages) {
+    for (const img of page.images ?? []) {
+      const savedPath = await saveBase64ImageToStorage(
+        img.base64,
+        img.id,
+        context.tenantId
+      );
+      if (!savedPath) {
+        continue;
+      }
+      includesImages = true;
+      const ref = new RegExp(`!\\[${img.id}\\]\\(${img.id}\\)`, "g");
+      page.text = page.text.replace(ref, `![${img.id}](${savedPath})`);
+    }
+  }
+
+  return {
+    model: data.model ?? PDF_PARSER.GENERIC,
+    pages: data.pages.map((p) => ({ page: p.page, text: p.text })),
+    includesImages,
+    metadata: data.metadata,
+  };
+};
+
+// --- Capability discovery ---------------------------------------------------
+
+let cachedCapabilities: ServiceCapabilities | null = null;
+
+/**
+ * Fetch (and cache in-process) the modalities the generic parsing service
+ * advertises via `GET /v1/capabilities`. The service guarantees a cheap, stable
+ * response, so caching for the lifetime of the process is safe.
+ */
+export const getGenericParserCapabilities =
+  async (): Promise<ServiceCapabilities> => {
+    if (cachedCapabilities) {
+      return cachedCapabilities;
+    }
+    requireConfig();
+
+    const res = await fetch(`${getBaseUrl()}/v1/capabilities`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Capabilities fetch failed: ${res.status} ${res.statusText}`
+      );
+    }
+    const raw = (await res.json()) as {
+      service: string;
+      modalities: {
+        modality: ServiceModality["modality"];
+        mime_types: string[];
+        extensions: string[];
+        features?: Record<string, boolean>;
+      }[];
+    };
+
+    cachedCapabilities = {
+      service: raw.service,
+      modalities: raw.modalities.map((m) => ({
+        modality: m.modality,
+        mimeTypes: m.mime_types,
+        extensions: m.extensions,
+        features: {
+          extractImages: m.features?.extract_images ?? false,
+          extractFields: m.features?.extract_fields ?? false,
+          async: m.features?.async ?? false,
+        },
+      })),
+    };
+    return cachedCapabilities;
+  };
+
+/** Reset the in-process capabilities cache (mainly for tests). */
+export const resetGenericParserCapabilitiesCache = (): void => {
+  cachedCapabilities = null;
+};
+
+/**
+ * Whether the generic parsing service accepts a file of the given MIME type
+ * and/or extension, based on its advertised capabilities.
+ */
+export const genericParserSupports = async (
+  mimeType?: string,
+  extension?: string
+): Promise<boolean> => {
+  const caps = await getGenericParserCapabilities();
+  const ext = extension?.toLowerCase();
+  return caps.modalities.some(
+    (m) =>
+      (mimeType !== undefined && m.mimeTypes.includes(mimeType)) ||
+      (ext !== undefined && m.extensions.includes(ext))
+  );
+};

--- a/src/lib/knowledge/parsing/pdf/index.ts
+++ b/src/lib/knowledge/parsing/pdf/index.ts
@@ -1,4 +1,5 @@
 import log from "../../../log";
+import { parsePdfFileAsMarkdownGeneric } from "./generic";
 import { parsePdfFileAsMarkdownLlama } from "./llama-api";
 import { parsePdfFileAsMarkdownMistral } from "./mistral-ocr";
 import { parsePdfFileAsMarkdownMistralOpenRouter } from "./mistral-openrouter";
@@ -24,6 +25,7 @@ const PDF_PARSERS: Record<string, PdfParser> = {
   [PDF_PARSER.MISTRAL]: parsePdfFileAsMarkdownMistral,
   [PDF_PARSER.MISTRAL_OPENROUTER]: parsePdfFileAsMarkdownMistralOpenRouter,
   [PDF_PARSER.LLAMA]: parsePdfFileAsMarkdownLlama,
+  [PDF_PARSER.GENERIC]: parsePdfFileAsMarkdownGeneric,
 };
 
 /** Resolve a requested model id to a registered parser, applying legacy aliases. */

--- a/src/lib/knowledge/parsing/pdf/types.ts
+++ b/src/lib/knowledge/parsing/pdf/types.ts
@@ -5,9 +5,38 @@ export type PdfParserContext = {
   workspaceId?: string;
 };
 
+/**
+ * One structured value a parsing service should try to extract from a document.
+ * The caller names the field (`key`, `name`, `description`); the service fills
+ * it. See `docs/framework/18_PDF_Parser_Generic_Microservice_Spec.md` §3.1.
+ */
+export type ExtractionTarget = {
+  /** Stable machine key. Used verbatim as the key in the result metadata. */
+  key: string;
+  /** Human-readable label handed to the extractor as the field name. */
+  name: string;
+  /** What exactly to extract — the primary instruction to the extractor. */
+  description: string;
+  /** Whether the field is expected to exist. Missing != error. */
+  required?: boolean;
+  type?: "string" | "number" | "date" | "boolean" | "enum";
+  /** Allowed values, only for `type: "enum"`. */
+  options?: string[];
+};
+
+/** One extracted value in a parser result, keyed by `ExtractionTarget.key`. */
+export type ExtractedValue = {
+  value: string | number | boolean | null;
+  found: boolean;
+  confidence?: number;
+  page?: number;
+};
+
 export type PdfParserOptions = {
   model?: string;
   extractImages?: boolean;
+  /** Structured extraction targets passed through to the service. */
+  extract?: ExtractionTarget[];
 };
 
 export interface PageContent {
@@ -19,7 +48,36 @@ export interface PdfParserResult {
   includesImages: boolean;
   model: string;
   pages?: PageContent[];
+  /** Extracted key/value metadata, keyed by `ExtractionTarget.key`. */
+  metadata?: Record<string, ExtractedValue>;
 }
+
+/** Canonical class of document a parsing service can accept. */
+export type ParserModality =
+  | "pdf"
+  | "image"
+  | "audio"
+  | "video"
+  | "text"
+  | "office";
+
+/** One modality a service advertises via `GET /v1/capabilities`. */
+export type ServiceModality = {
+  modality: ParserModality;
+  mimeTypes: string[];
+  extensions: string[];
+  features?: {
+    extractImages?: boolean;
+    extractFields?: boolean;
+    async?: boolean;
+  };
+};
+
+/** The set of modalities a parsing service can process. */
+export type ServiceCapabilities = {
+  service: string;
+  modalities: ServiceModality[];
+};
 
 /**
  * Canonical identifiers for the available PDF parser services.
@@ -37,6 +95,8 @@ export const PDF_PARSER = {
   MISTRAL_OPENROUTER: "mistral-openrouter",
   /** LlamaParse (LlamaIndex Cloud). */
   LLAMA: "llama",
+  /** Generic self-hosted parsing microservice (X-API-Key + URL from env). */
+  GENERIC: "generic",
 } as const;
 
 export type PdfParserId = (typeof PDF_PARSER)[keyof typeof PDF_PARSER];


### PR DESCRIPTION
## Why

The generic PDF parser integration was merged into `develop` via **#73** (commit `bc21f11`, 12:13), but then **disappeared** from `develop`. Root cause: **#72** (`claude/refactor-knowledge-text-ytqqnq`, merged 13:19) was branched off an older `develop` from *before* #73 and, when merged on top, removed #73's additions. Verified: `generic.ts` still exists at the #74 merge (`4e33f1b`, 12:52) but is gone at the #72 merge (`ea54863`, 13:19).

No work is lost — this PR re-applies #73 cleanly onto current `develop`.

## What

Re-applies the exact content of #73 on top of the current `develop`:

- **Parser** (`src/lib/knowledge/parsing/pdf/generic.ts`): sync `POST /v1/parse` (default) + optional async job flow (`/v1/jobs` → poll → result); `X-API-Key` auth; base64 image persistence with `[id](id)` placeholder rewrite (Mistral convention); cached capability discovery (`GET /v1/capabilities`) and `genericParserSupports()` routing helper. Config (`PDF_PARSER_SERVICE_{API_KEY,URL,MODE}`) is read lazily at call time.
- **Types** (`types.ts`): `GENERIC` parser id; `ExtractionTarget` / `ExtractedValue`; `extract` on `PdfParserOptions`; `metadata` on `PdfParserResult`; `ServiceModality` / `ServiceCapabilities`.
- **Registry** (`index.ts`): register the generic parser.
- **Config** (`.env.default`): `PDF_PARSER_SERVICE_API_KEY`, `PDF_PARSER_SERVICE_URL`, `PDF_PARSER_SERVICE_MODE`.
- **Tests** (`generic.test.ts`): run against an in-process fake service (`Bun.serve`) implementing the contract — request shape, result mapping, image rewrite, async flow, capability normalization + caching, routing, error path. 6/6 pass.
- **Docs**: microservice spec (`18_...`) + framework integration guide (`19_...`).

## Safety of the re-apply

Diff of the three shared files (`index.ts`, `types.ts`, `.env.default`) between current `develop` and this branch contains **only these additions** — the attributes work from #72/#75 lives in different files and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkHcXbWbHRPVHkQwgbkKkz)_