### PR TITLE
feat(webhooks): event-driven, HMAC-signed outgoing webhooks + knowledge_text events

### DIFF
--- a/drizzle-sql/0032_useful_frog_thor.sql
+++ b/drizzle-sql/0032_useful_frog_thor.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "base_webhooks" ALTER COLUMN "event" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "base_webhooks" ADD COLUMN "enabled" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "base_webhooks" ADD COLUMN "auth_mode" text DEFAULT 'hmac' NOT NULL;--> statement-breakpoint
+UPDATE "base_webhooks" SET "auth_mode" = 'headers';--> statement-breakpoint
+ALTER TABLE "base_webhooks" ADD COLUMN "signing_secret" text;--> statement-breakpoint
+ALTER TABLE "base_webhooks" ADD COLUMN "signing_secret_key_version" integer;--> statement-breakpoint
+DROP TYPE "public"."webhook_event";

--- a/drizzle-sql/meta/0032_snapshot.json
+++ b/drizzle-sql/meta/0032_snapshot.json
@@ -1,0 +1,6669 @@
+{
+  "id": "4be83206-6761-40c9-92eb-a4db795ff9aa",
+  "prevId": "cb7e1831-54a0-49a2-884b-85781d6dc715",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.base_group_permissions": {
+      "name": "base_group_permissions",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "group_permissions_group_id_idx": {
+          "name": "group_permissions_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "group_permissions_permission_id_idx": {
+          "name": "group_permissions_permission_id_idx",
+          "columns": [
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_group_permissions_group_id_base_user_permission_groups_id_fk": {
+          "name": "base_group_permissions_group_id_base_user_permission_groups_id_fk",
+          "tableFrom": "base_group_permissions",
+          "tableTo": "base_user_permission_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_group_permissions_permission_id_base_path_permissions_id_fk": {
+          "name": "base_group_permissions_permission_id_base_path_permissions_id_fk",
+          "tableFrom": "base_group_permissions",
+          "tableTo": "base_path_permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_group_permissions_group_id_permission_id_pk": {
+          "name": "base_group_permissions_group_id_permission_id_pk",
+          "columns": [
+            "group_id",
+            "permission_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_invitation_codes": {
+      "name": "base_invitation_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": -1
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_invitation_code": {
+          "name": "unique_invitation_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_codes_tenant_id_idx": {
+          "name": "invitation_codes_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_codes_expires_at_idx": {
+          "name": "invitation_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_invitation_codes_tenant_id_base_tenants_id_fk": {
+          "name": "base_invitation_codes_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_invitation_codes",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_magic_link_sessions": {
+      "name": "base_magic_link_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "magic_link_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'login'"
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_token": {
+          "name": "unique_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_sessions_user_id_idx": {
+          "name": "magic_link_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "magic_link_sessions_expires_at_idx": {
+          "name": "magic_link_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_magic_link_sessions_user_id_base_users_id_fk": {
+          "name": "base_magic_link_sessions_user_id_base_users_id_fk",
+          "tableFrom": "base_magic_link_sessions",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_path_permissions": {
+      "name": "base_path_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "permission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_expression": {
+          "name": "path_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permissions_method_idx": {
+          "name": "permissions_method_idx",
+          "columns": [
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_type_idx": {
+          "name": "permissions_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_path_permissions_tenant_id_base_tenants_id_fk": {
+          "name": "base_path_permissions_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_path_permissions",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_category_name": {
+          "name": "unique_category_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_sessions": {
+      "name": "base_sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_sessions_user_id_base_users_id_fk": {
+          "name": "base_sessions_user_id_base_users_id_fk",
+          "tableFrom": "base_sessions",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_team_members": {
+      "name": "base_team_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_team_members_user_id_base_users_id_fk": {
+          "name": "base_team_members_user_id_base_users_id_fk",
+          "tableFrom": "base_team_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_team_members_team_id_base_teams_id_fk": {
+          "name": "base_team_members_team_id_base_teams_id_fk",
+          "tableFrom": "base_team_members",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_team_members_user_id_team_id_pk": {
+          "name": "base_team_members_user_id_team_id_pk",
+          "columns": [
+            "user_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_teams": {
+      "name": "base_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_teams_tenant_id_base_tenants_id_fk": {
+          "name": "base_teams_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_teams",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_invitations": {
+      "name": "base_tenant_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_invitation": {
+          "name": "unique_invitation",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_status_idx": {
+          "name": "invitations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_created_at_idx": {
+          "name": "invitations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_email_idx": {
+          "name": "invitations_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_invitations_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_invitations_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_invitations",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_members": {
+      "name": "base_tenant_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "tenant_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_members_user_id_idx": {
+          "name": "tenant_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_members_tenant_id_idx": {
+          "name": "tenant_members_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_members_user_id_base_users_id_fk": {
+          "name": "base_tenant_members_user_id_base_users_id_fk",
+          "tableFrom": "base_tenant_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_tenant_members_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_members_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_members",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_tenant_members_user_id_tenant_id_pk": {
+          "name": "base_tenant_members_user_id_tenant_id_pk",
+          "columns": [
+            "user_id",
+            "tenant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenants": {
+      "name": "base_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "tenant_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenants_name_local_unique_idx": {
+          "name": "tenants_name_local_unique_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"base_tenants\".\"origin\" = 'local'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_group_members": {
+      "name": "base_user_group_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_groups_id": {
+          "name": "user_groups_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_user_group_members_user_id_base_users_id_fk": {
+          "name": "base_user_group_members_user_id_base_users_id_fk",
+          "tableFrom": "base_user_group_members",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_user_group_members_user_groups_id_base_user_permission_groups_id_fk": {
+          "name": "base_user_group_members_user_groups_id_base_user_permission_groups_id_fk",
+          "tableFrom": "base_user_group_members",
+          "tableTo": "base_user_permission_groups",
+          "columnsFrom": [
+            "user_groups_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "base_user_group_members_user_id_user_groups_id_pk": {
+          "name": "base_user_group_members_user_id_user_groups_id_pk",
+          "columns": [
+            "user_id",
+            "user_groups_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_messages": {
+      "name": "base_user_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_messages_user_id_idx": {
+          "name": "user_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_confirmed_at_idx": {
+          "name": "user_messages_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_created_at_idx": {
+          "name": "user_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_messages_message_type_idx": {
+          "name": "user_messages_message_type_idx",
+          "columns": [
+            {
+              "expression": "message_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_messages_user_id_base_users_id_fk": {
+          "name": "base_user_messages_user_id_base_users_id_fk",
+          "tableFrom": "base_user_messages",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_permission_groups": {
+      "name": "base_user_permission_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_permission_groups_name_idx": {
+          "name": "user_permission_groups_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_permission_groups_created_at_idx": {
+          "name": "user_permission_groups_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_permission_groups_tenant_id_base_tenants_id_fk": {
+          "name": "base_user_permission_groups_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_user_permission_groups",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_users": {
+      "name": "base_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "user_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surname": {
+          "name": "surname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salutation": {
+          "name": "salutation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number_verified": {
+          "name": "phone_number_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone_number_as_number": {
+          "name": "phone_number_as_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_pin_number": {
+          "name": "phone_pin_number",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ext_user_id": {
+          "name": "ext_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_name": {
+          "name": "profile_image_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_content_type": {
+          "name": "profile_image_content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_tenant_id": {
+          "name": "last_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_email": {
+          "name": "unique_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_phone_number": {
+          "name": "unique_phone_number",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_phone_number_as_number": {
+          "name": "unique_phone_number_as_number",
+          "columns": [
+            {
+              "expression": "phone_number_as_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_verified_idx": {
+          "name": "users_email_verified_idx",
+          "columns": [
+            {
+              "expression": "email_verified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_users_last_tenant_id_base_tenants_id_fk": {
+          "name": "base_users_last_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_users",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "last_tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_webauthn_credentials": {
+      "name": "base_webauthn_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webauthn_credentials_credential_id_idx": {
+          "name": "webauthn_credentials_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webauthn_credentials_user_id_idx": {
+          "name": "webauthn_credentials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_webauthn_credentials_user_id_base_users_id_fk": {
+          "name": "base_webauthn_credentials_user_id_base_users_id_fk",
+          "tableFrom": "base_webauthn_credentials",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_secrets": {
+      "name": "base_secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference": {
+          "name": "reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "secrets_idx": {
+          "name": "secrets_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_ref_idx": {
+          "name": "secrets_ref_idx",
+          "columns": [
+            {
+              "expression": "reference",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_ref_id_idx": {
+          "name": "secrets_ref_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_name_idx": {
+          "name": "secrets_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_type_idx": {
+          "name": "secrets_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_secrets_tenant_id_base_tenants_id_fk": {
+          "name": "base_secrets_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_secrets",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "secrets_reference_name_idx": {
+          "name": "secrets_reference_name_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "reference",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_files": {
+      "name": "base_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extension": {
+          "name": "extension",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file": {
+          "name": "file",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_id_idx": {
+          "name": "files_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_bucket_name_idx": {
+          "name": "files_bucket_name_idx",
+          "columns": [
+            {
+              "expression": "bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_created_at_idx": {
+          "name": "files_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_updated_at_idx": {
+          "name": "files_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_name_idx": {
+          "name": "files_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_expires_at_idx": {
+          "name": "files_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_files_tenant_id_base_tenants_id_fk": {
+          "name": "base_files_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_files",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_app_specific_data": {
+      "name": "base_app_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_data_created_at_idx": {
+          "name": "app_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_data_version_idx": {
+          "name": "app_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_app_specific_data_key_unique": {
+          "name": "base_app_specific_data_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_team_specific_data": {
+      "name": "base_team_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_data_key_idx": {
+          "name": "team_data_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_data_created_at_idx": {
+          "name": "team_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_data_version_idx": {
+          "name": "team_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_team_specific_data_team_id_base_teams_id_fk": {
+          "name": "base_team_specific_data_team_id_base_teams_id_fk",
+          "tableFrom": "base_team_specific_data",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_team_specific_data_team_id_key_unique": {
+          "name": "base_team_specific_data_team_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_tenant_specific_data": {
+      "name": "base_tenant_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tenant_data_key_idx": {
+          "name": "tenant_data_key_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_data_created_at_idx": {
+          "name": "tenant_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_data_version_idx": {
+          "name": "tenant_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_tenant_specific_data_tenant_id_base_tenants_id_fk": {
+          "name": "base_tenant_specific_data_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_tenant_specific_data",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_tenant_specific_data_tenant_id_category_unique": {
+          "name": "base_tenant_specific_data_tenant_id_category_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "category"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_specific_data": {
+      "name": "base_user_specific_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_data_type_idx": {
+          "name": "user_data_type_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_data_created_at_idx": {
+          "name": "user_data_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_data_version_idx": {
+          "name": "user_data_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_specific_data_user_id_base_users_id_fk": {
+          "name": "base_user_specific_data_user_id_base_users_id_fk",
+          "tableFrom": "base_user_specific_data",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_user_specific_data_user_id_key_unique": {
+          "name": "base_user_specific_data_user_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_chunks": {
+      "name": "base_knowledge_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_entry_id": {
+          "name": "knowledge_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header": {
+          "name": "header",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "text_embedding_1536": {
+          "name": "text_embedding_1536",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_embedding_1024": {
+          "name": "text_embedding_1024",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "knowledge_chunks_knowledge_entry_id_idx": {
+          "name": "knowledge_chunks_knowledge_entry_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_created_at_idx": {
+          "name": "knowledge_chunks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_header_idx": {
+          "name": "knowledge_chunks_header_idx",
+          "columns": [
+            {
+              "expression": "header",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_fts_idx": {
+          "name": "knowledge_chunks_fts_idx",
+          "columns": [
+            {
+              "expression": "base_safe_tsvector('simple', coalesce(\"header\", '') || ' ' || coalesce(\"text\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "knowledge_chunks_embedding_1024_hnsw_idx": {
+          "name": "knowledge_chunks_embedding_1024_hnsw_idx",
+          "columns": [
+            {
+              "expression": "text_embedding_1024",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "text_embedding_1024 IS NOT NULL",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "knowledge_chunks_embedding_1536_hnsw_idx": {
+          "name": "knowledge_chunks_embedding_1536_hnsw_idx",
+          "columns": [
+            {
+              "expression": "text_embedding_1536",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "text_embedding_1536 IS NOT NULL",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_chunks_knowledge_entry_id_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_chunks_knowledge_entry_id_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_chunks",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "knowledge_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_chunks_embedding_required": {
+          "name": "knowledge_chunks_embedding_required",
+          "value": "text_embedding_1536 IS NOT NULL OR text_embedding_1024 IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_entry": {
+      "name": "base_knowledge_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_owned": {
+          "name": "user_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "knowledge_group_id": {
+          "name": "knowledge_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "version_text": {
+          "name": "version_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "knowledgeentry_name_idx": {
+          "name": "knowledgeentry_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_created_at_idx": {
+          "name": "knowledgeentry_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_updated_at_idx": {
+          "name": "knowledgeentry_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_deleted_at_idx": {
+          "name": "knowledgeentry_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledgeentry_tenant_id_idx": {
+          "name": "knowledgeentry_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_entry_team_id_idx": {
+          "name": "knowledge_entry_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_entry_user_id_idx": {
+          "name": "knowledge_entry_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_entry_source_hash_idx": {
+          "name": "knowledge_entry_source_hash_idx",
+          "columns": [
+            {
+              "expression": "source_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "source_hash IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_entry_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_entry_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_entry_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_user_id_base_users_id_fk": {
+          "name": "base_knowledge_entry_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_knowledge_group_id_base_knowledge_group_id_fk": {
+          "name": "base_knowledge_entry_knowledge_group_id_base_knowledge_group_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_knowledge_group",
+          "columnsFrom": [
+            "knowledge_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_entry_parentId_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_entry_parentId_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_entry",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "knowledge_entry_description_max_length": {
+          "name": "knowledge_entry_description_max_length",
+          "value": "length(description) <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_group": {
+      "name": "base_knowledge_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide_access": {
+          "name": "tenant_wide_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_group_tenant_id_idx": {
+          "name": "knowledge_group_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_group_user_id_idx": {
+          "name": "knowledge_group_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_group_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_group_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_group",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_group_user_id_base_users_id_fk": {
+          "name": "base_knowledge_group_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_group",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_group_name_org_idx": {
+          "name": "knowledge_group_name_org_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name",
+            "tenant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_group_team_assignments": {
+      "name": "base_knowledge_group_team_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_group_id": {
+          "name": "knowledge_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_group_team_assignment_knowledge_group_id_idx": {
+          "name": "knowledge_group_team_assignment_knowledge_group_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_group_team_assignment_team_id_idx": {
+          "name": "knowledge_group_team_assignment_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_group_team_assignments_knowledge_group_id_base_knowledge_group_id_fk": {
+          "name": "base_knowledge_group_team_assignments_knowledge_group_id_base_knowledge_group_id_fk",
+          "tableFrom": "base_knowledge_group_team_assignments",
+          "tableTo": "base_knowledge_group",
+          "columnsFrom": [
+            "knowledge_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_group_team_assignments_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_group_team_assignments_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_group_team_assignments",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_group_team_assignment_unique": {
+          "name": "knowledge_group_team_assignment_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "knowledge_group_id",
+            "team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text": {
+      "name": "base_knowledge_text",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "knowledge_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_mode": {
+          "name": "summary_mode",
+          "type": "knowledge_summary_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "summary_stale": {
+          "name": "summary_stale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "summary_content_hash": {
+          "name": "summary_content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_updated_at": {
+          "name": "summary_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_team_id": {
+          "name": "owner_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supersedes_id": {
+          "name": "supersedes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_agent_instructions": {
+          "name": "is_agent_instructions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "embedding_enabled": {
+          "name": "embedding_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "knowledge_entry_id": {
+          "name": "knowledge_entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "knowledge_text_created_at_idx": {
+          "name": "knowledge_text_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_updated_at_idx": {
+          "name": "knowledge_text_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_deleted_at_idx": {
+          "name": "knowledge_text_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_title_idx": {
+          "name": "knowledge_text_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_tenant_id_idx": {
+          "name": "knowledge_text_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_team_id_idx": {
+          "name": "knowledge_text_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_user_id_idx": {
+          "name": "knowledge_text_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_parent_id_idx": {
+          "name": "knowledge_text_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_fts_idx": {
+          "name": "knowledge_text_fts_idx",
+          "columns": [
+            {
+              "expression": "base_safe_tsvector('simple', coalesce(\"title\", '') || ' ' || coalesce(\"text\", ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "knowledge_text_summary_stale_idx": {
+          "name": "knowledge_text_summary_stale_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"base_knowledge_text\".\"summary_stale\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_page_type_idx": {
+          "name": "knowledge_text_page_type_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_status_idx": {
+          "name": "knowledge_text_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_attributes_idx": {
+          "name": "knowledge_text_attributes_idx",
+          "columns": [
+            {
+              "expression": "attributes",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "jsonb_path_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "knowledge_text_agent_instructions_idx": {
+          "name": "knowledge_text_agent_instructions_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"base_knowledge_text\".\"is_agent_instructions\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_text_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_user_id_base_users_id_fk": {
+          "name": "base_knowledge_text_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_parent_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_parent_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_verified_by_base_users_id_fk": {
+          "name": "base_knowledge_text_verified_by_base_users_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "verified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_owner_user_id_base_users_id_fk": {
+          "name": "base_knowledge_text_owner_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_owner_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_text_owner_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "owner_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_supersedes_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_supersedes_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "supersedes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_knowledge_entry_id_base_knowledge_entry_id_fk": {
+          "name": "base_knowledge_text_knowledge_entry_id_base_knowledge_entry_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_knowledge_entry",
+          "columnsFrom": [
+            "knowledge_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_created_by_base_users_id_fk": {
+          "name": "base_knowledge_text_created_by_base_users_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_updated_by_base_users_id_fk": {
+          "name": "base_knowledge_text_updated_by_base_users_id_fk",
+          "tableFrom": "base_knowledge_text",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_block": {
+      "name": "base_knowledge_text_block",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_text_id": {
+          "name": "knowledge_text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "knowledge_block_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'markdown'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_block_page_position_idx": {
+          "name": "knowledge_text_block_page_position_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_block_knowledge_text_id_idx": {
+          "name": "knowledge_text_block_knowledge_text_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_block_tenant_id_idx": {
+          "name": "knowledge_text_block_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_block_knowledge_text_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_block_knowledge_text_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_block",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "knowledge_text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_block_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_block_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_block",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_file": {
+      "name": "base_knowledge_text_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "knowledge_text_id": {
+          "name": "knowledge_text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_file_knowledge_text_id_idx": {
+          "name": "knowledge_text_file_knowledge_text_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_file_file_id_idx": {
+          "name": "knowledge_text_file_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_file_tenant_id_idx": {
+          "name": "knowledge_text_file_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_file_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_file_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_file",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_file_knowledge_text_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_file_knowledge_text_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_file",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "knowledge_text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_file_file_id_base_files_id_fk": {
+          "name": "base_knowledge_text_file_file_id_base_files_id_fk",
+          "tableFrom": "base_knowledge_text_file",
+          "tableTo": "base_files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_text_file_page_file_unique": {
+          "name": "knowledge_text_file_page_file_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "knowledge_text_id",
+            "file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_history": {
+      "name": "base_knowledge_text_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "knowledge_text_id": {
+          "name": "knowledge_text_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "knowledge_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_history_knowledge_text_id_idx": {
+          "name": "knowledge_text_history_knowledge_text_id_idx",
+          "columns": [
+            {
+              "expression": "knowledge_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_history_tenant_id_idx": {
+          "name": "knowledge_text_history_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_history_created_at_idx": {
+          "name": "knowledge_text_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_history_knowledge_text_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_history_knowledge_text_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "knowledge_text_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_history_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_team_id_base_teams_id_fk": {
+          "name": "base_knowledge_text_history_team_id_base_teams_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_history_user_id_base_users_id_fk": {
+          "name": "base_knowledge_text_history_user_id_base_users_id_fk",
+          "tableFrom": "base_knowledge_text_history",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_knowledge_text_link": {
+      "name": "base_knowledge_text_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_text_link_source_id_idx": {
+          "name": "knowledge_text_link_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_link_target_id_idx": {
+          "name": "knowledge_text_link_target_id_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_text_link_tenant_target_title_idx": {
+          "name": "knowledge_text_link_tenant_target_title_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_knowledge_text_link_tenant_id_base_tenants_id_fk": {
+          "name": "base_knowledge_text_link_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_knowledge_text_link",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_link_source_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_link_source_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_link",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_knowledge_text_link_target_id_base_knowledge_text_id_fk": {
+          "name": "base_knowledge_text_link_target_id_base_knowledge_text_id_fk",
+          "tableFrom": "base_knowledge_text_link",
+          "tableTo": "base_knowledge_text",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "knowledge_text_link_source_target_unique": {
+          "name": "knowledge_text_link_source_target_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_id",
+            "target_title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_jobs": {
+      "name": "base_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "jobs_created_at_idx": {
+          "name": "jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_user_id_idx": {
+          "name": "jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_status_idx": {
+          "name": "jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jobs_scheduled_at_idx": {
+          "name": "jobs_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_jobs_user_id_base_users_id_fk": {
+          "name": "base_jobs_user_id_base_users_id_fk",
+          "tableFrom": "base_jobs",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_jobs_tenant_id_base_tenants_id_fk": {
+          "name": "base_jobs_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_jobs",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_app_logs": {
+      "name": "base_app_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_logs_level_idx": {
+          "name": "app_logs_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_category_idx": {
+          "name": "app_logs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_source_idx": {
+          "name": "app_logs_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_created_at_idx": {
+          "name": "app_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_version_idx": {
+          "name": "app_logs_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_logs_tenant_id_idx": {
+          "name": "app_logs_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_app_logs_tenant_id_base_tenants_id_fk": {
+          "name": "base_app_logs_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_app_logs",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_webhooks": {
+      "name": "base_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_wide": {
+          "name": "tenant_wide",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "webhook_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "webhook_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POST'"
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hmac'"
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_secret_key_version": {
+          "name": "signing_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_tenant_id_idx": {
+          "name": "webhooks_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhooks_name_tenant_id_idx": {
+          "name": "webhooks_name_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "webhook_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_webhooks_user_id_base_users_id_fk": {
+          "name": "base_webhooks_user_id_base_users_id_fk",
+          "tableFrom": "base_webhooks",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_webhooks_tenant_id_base_tenants_id_fk": {
+          "name": "base_webhooks_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_webhooks",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_server_keys": {
+      "name": "base_server_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_server_settings": {
+      "name": "base_server_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_key": {
+          "name": "unique_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_api_tokens": {
+      "name": "base_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "auto_delete": {
+          "name": "auto_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "api_tokens_user_id_idx": {
+          "name": "api_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_tenant_id_idx": {
+          "name": "api_tokens_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_auto_delete_idx": {
+          "name": "api_tokens_auto_delete_idx",
+          "columns": [
+            {
+              "expression": "auto_delete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_api_tokens_user_id_base_users_id_fk": {
+          "name": "base_api_tokens_user_id_base_users_id_fk",
+          "tableFrom": "base_api_tokens",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_api_tokens_tenant_id_base_tenants_id_fk": {
+          "name": "base_api_tokens_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_api_tokens",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_idx": {
+          "name": "api_tokens_token_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_connections": {
+      "name": "base_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_connection_id": {
+          "name": "remote_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_public_key": {
+          "name": "remote_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_tenant_id": {
+          "name": "remote_tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "initiated_by",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "role": {
+          "name": "role",
+          "type": "connection_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'leading'"
+        },
+        "status": {
+          "name": "status",
+          "type": "connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "connections_tenant_idx": {
+          "name": "connections_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_remote_url_idx": {
+          "name": "connections_remote_url_idx",
+          "columns": [
+            {
+              "expression": "remote_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_tenant_name_initiated_by_unique_idx": {
+          "name": "connections_tenant_name_initiated_by_unique_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "initiated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_tenant_remote_connection_id_initiated_by_unique_idx": {
+          "name": "connections_tenant_remote_connection_id_initiated_by_unique_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remote_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "initiated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_connections_tenant_id_base_tenants_id_fk": {
+          "name": "base_connections_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_connections",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_clients": {
+      "name": "base_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_type": {
+          "name": "client_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'confidential'"
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"authorization_code\",\"refresh_token\"]'::jsonb"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'client_secret_post'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_clients_tenant_id_idx": {
+          "name": "oauth_clients_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_clients_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_clients_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_clients",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_clients_created_by_base_users_id_fk": {
+          "name": "base_oauth_clients_created_by_base_users_id_fk",
+          "tableFrom": "base_oauth_clients",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_auth_codes": {
+      "name": "base_oauth_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'S256'"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_auth_codes_code_hash_idx": {
+          "name": "oauth_auth_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "code_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_auth_codes_expires_at_idx": {
+          "name": "oauth_auth_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_auth_codes_user_id_base_users_id_fk": {
+          "name": "base_oauth_auth_codes_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_auth_codes",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_auth_codes_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_auth_codes_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_auth_codes",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_refresh_tokens": {
+      "name": "base_oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotated_to": {
+          "name": "rotated_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_refresh_tokens_user_id_base_users_id_fk": {
+          "name": "base_oauth_refresh_tokens_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_refresh_tokens",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "base_oauth_refresh_tokens_tenant_id_base_tenants_id_fk": {
+          "name": "base_oauth_refresh_tokens_tenant_id_base_tenants_id_fk",
+          "tableFrom": "base_oauth_refresh_tokens",
+          "tableTo": "base_tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_oauth_consents": {
+      "name": "base_oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_consents_user_client_idx": {
+          "name": "oauth_consents_user_client_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consents_user_id_idx": {
+          "name": "oauth_consents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_oauth_consents_user_id_base_users_id_fk": {
+          "name": "base_oauth_consents_user_id_base_users_id_fk",
+          "tableFrom": "base_oauth_consents",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_email_login_codes": {
+      "name": "base_email_login_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oauth_login'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_login_codes_email_idx": {
+          "name": "email_login_codes_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_login_codes_expires_at_idx": {
+          "name": "email_login_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_user_settings": {
+      "name": "base_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_key_unique": {
+          "name": "user_settings_user_id_key_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_settings_user_id_idx": {
+          "name": "user_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "base_user_settings_user_id_base_users_id_fk": {
+          "name": "base_user_settings_user_id_base_users_id_fk",
+          "tableFrom": "base_user_settings",
+          "tableTo": "base_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.magic_link_purpose": {
+      "name": "magic_link_purpose",
+      "schema": "public",
+      "values": [
+        "login",
+        "email_verification",
+        "password_reset"
+      ]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error",
+        "success"
+      ]
+    },
+    "public.permission_type": {
+      "name": "permission_type",
+      "schema": "public",
+      "values": [
+        "regex"
+      ]
+    },
+    "public.team_member_role": {
+      "name": "team_member_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.tenant_invitation_status": {
+      "name": "tenant_invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined"
+      ]
+    },
+    "public.tenant_member_role": {
+      "name": "tenant_member_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.tenant_origin": {
+      "name": "tenant_origin",
+      "schema": "public",
+      "values": [
+        "local",
+        "remote"
+      ]
+    },
+    "public.user_provider": {
+      "name": "user_provider",
+      "schema": "public",
+      "values": [
+        "local",
+        "google",
+        "microsoft",
+        "auth0",
+        "hanko"
+      ]
+    },
+    "public.file_source_type": {
+      "name": "file_source_type",
+      "schema": "public",
+      "values": [
+        "db",
+        "local",
+        "url",
+        "text",
+        "finetuning",
+        "plugin",
+        "external"
+      ]
+    },
+    "public.knowledge_block_type": {
+      "name": "knowledge_block_type",
+      "schema": "public",
+      "values": [
+        "markdown",
+        "html"
+      ]
+    },
+    "public.knowledge_content_mode": {
+      "name": "knowledge_content_mode",
+      "schema": "public",
+      "values": [
+        "text",
+        "blocks"
+      ]
+    },
+    "public.knowledge_summary_mode": {
+      "name": "knowledge_summary_mode",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual",
+        "off"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ]
+    },
+    "public.webhook_method": {
+      "name": "webhook_method",
+      "schema": "public",
+      "values": [
+        "POST",
+        "GET"
+      ]
+    },
+    "public.webhook_type": {
+      "name": "webhook_type",
+      "schema": "public",
+      "values": [
+        "n8n"
+      ]
+    },
+    "public.connection_role": {
+      "name": "connection_role",
+      "schema": "public",
+      "values": [
+        "leading",
+        "following"
+      ]
+    },
+    "public.connection_status": {
+      "name": "connection_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "disconnected",
+        "revoked"
+      ]
+    },
+    "public.initiated_by": {
+      "name": "initiated_by",
+      "schema": "public",
+      "values": [
+        "local",
+        "remote"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle-sql/meta/_journal.json
+++ b/drizzle-sql/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1784640445655,
       "tag": "0031_cuddly_namora",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1784648408100,
+      "tag": "0032_useful_frog_thor",
+      "breakpoints": true
     }
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import {
   sweepStaleSummaries,
 } from "./lib/knowledge/summaries";
 import { reEmbedJobRegister } from "./lib/knowledge/re-embed";
+import { webhookDeliveryJobRegister } from "./lib/webhooks/delivery-job";
 import { isAiEnabled } from "./lib/ai";
 // Cron
 import scheduler from "./lib/cron";
@@ -457,6 +458,7 @@ export const defineServer = (config: ServerSpecificConfig) => {
         knowledgeIngestJobRegister,
         summaryJobRegister,
         reEmbedJobRegister,
+        webhookDeliveryJobRegister,
       ];
       const allJobHandlers = [
         ...builtInJobHandlers,

--- a/src/lib/db/schema/webhooks.ts
+++ b/src/lib/db/schema/webhooks.ts
@@ -4,6 +4,7 @@ import {
   text,
   uuid,
   index,
+  integer,
   timestamp,
   jsonb,
   boolean,
@@ -19,11 +20,11 @@ import {
 } from "drizzle-valibot";
 
 export const webhookTypeEnum = pgEnum("webhook_type", ["n8n"]);
-export const webhookEventEnum = pgEnum("webhook_event", [
-  "chat-output",
-  "tool",
-]);
 export const webhookMethodEnum = pgEnum("webhook_method", ["POST", "GET"]);
+
+/** Allowed values for the (text) auth_mode column; validated in code. */
+export const WEBHOOK_AUTH_MODES = ["hmac", "headers", "none"] as const;
+export type WebhookAuthMode = (typeof WEBHOOK_AUTH_MODES)[number];
 
 // Table for webhooks. Webhooks are used to send notifications to external services.
 export const webhooks = pgBaseTable(
@@ -43,12 +44,28 @@ export const webhooks = pgBaseTable(
       })
       .notNull(),
     tenantWide: boolean("tenant_wide").notNull().default(false),
+    // Whether this webhook is active. Disabled webhooks are kept but never
+    // fired by the event dispatcher (and skipped for manual triggering).
+    enabled: boolean("enabled").notNull().default(true),
     name: text("name").notNull(),
     type: webhookTypeEnum("type").notNull(), // 'n8n'
-    event: webhookEventEnum("event").notNull(), // 'chat-output' or 'tool'
+    // The event this webhook subscribes to. Free text validated against the
+    // code-side registry in lib/webhooks/events.ts (was a pgEnum; widened to
+    // text so a new event is a registry entry, not a schema migration).
+    event: text("event").notNull(),
     webhookUrl: text("webhook_url").notNull(),
     method: webhookMethodEnum("method").notNull().default("POST"),
     headers: jsonb("headers").default({}).notNull(),
+    // How outgoing deliveries authenticate themselves to the receiver:
+    //  - 'hmac'    : sign the body (HMAC-SHA256) using `signingSecret`
+    //  - 'headers' : rely solely on the static custom `headers` (e.g. n8n key)
+    //  - 'none'    : send unauthenticated (not recommended)
+    authMode: text("auth_mode").notNull().default("hmac"),
+    // AES-encrypted HMAC signing secret (never stored or returned in clear).
+    // Null when authMode != 'hmac'. Encrypted via lib/crypt/aes.
+    signingSecret: text("signing_secret"),
+    // Key version the signingSecret was encrypted with (for AES key rotation).
+    signingSecretKeyVersion: integer("signing_secret_key_version"),
     meta: jsonb("meta").default({}).notNull(), // additional data for the webhook
     createdAt: timestamp("created_at", { mode: "string" })
       .defaultNow()

--- a/src/lib/knowledge/knowledge-text-blocks.ts
+++ b/src/lib/knowledge/knowledge-text-blocks.ts
@@ -37,6 +37,8 @@ import {
 import { syncKnowledgeTextEmbeddingSafe } from "./knowledge-text-embedding";
 import { syncKnowledgeTextLinks } from "./knowledge-text-links";
 import { syncKnowledgeTextFileReferences } from "./knowledge-text-files";
+import { emitKnowledgeTextUpdated } from "./knowledge-text-events";
+import type { WebhookEventSource } from "../webhooks/dispatch";
 
 /** Minimum age of the newest history entry before a new snapshot is written */
 export const HISTORY_COALESCE_MINUTES = 10;
@@ -62,6 +64,8 @@ type Context = {
   teamId?: string;
   workspaceId?: string;
   includeHidden?: boolean;
+  /** Origin of the change; forwarded to the outgoing webhook (default "user"). */
+  source?: WebhookEventSource;
 };
 
 let turndown: TurndownService | null = null;
@@ -359,6 +363,13 @@ export const syncKnowledgeTextBlocks = async (
     .from(knowledgeTextBlock)
     .where(eq(knowledgeTextBlock.knowledgeTextId, knowledgeTextId))
     .orderBy(asc(knowledgeTextBlock.position));
+
+  // A block-editor save materializes content straight into knowledge_text
+  // (bypassing updateKnowledgeText), so emit the "updated" event here — but
+  // only when something actually changed. Fire-and-forget; never throws.
+  if (!nothingToDo) {
+    await emitKnowledgeTextUpdated(finalPage, context.source ?? "user");
+  }
 
   return {
     knowledgeText: finalPage,

--- a/src/lib/knowledge/knowledge-text-events.test.ts
+++ b/src/lib/knowledge/knowledge-text-events.test.ts
@@ -1,0 +1,147 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { eq } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { webhooks } from "../db/schema/webhooks";
+import { jobs } from "../db/schema/jobs";
+import { createWebhook } from "../webhooks/crud";
+import { WEBHOOK_DELIVERY_JOB_TYPE } from "../webhooks/delivery-types";
+import {
+  createKnowledgeText,
+  updateKnowledgeText,
+  deleteKnowledgeText,
+} from "./knowledge-texts";
+import { syncKnowledgeTextBlocks } from "./knowledge-text-blocks";
+import {
+  initTests,
+  TEST_ORGANISATION_1,
+  TEST_ORG1_USER_1,
+} from "../../test/init.test";
+
+const TENANT = TEST_ORGANISATION_1.id;
+const createdWebhookIds: string[] = [];
+
+/** All delivery-job envelopes fired for a given page id. */
+const envelopesForPage = async (pageId: string) => {
+  const rows = await getDb()
+    .select()
+    .from(jobs)
+    .where(eq(jobs.type, WEBHOOK_DELIVERY_JOB_TYPE));
+  return rows
+    .map((r) => (r.metadata as any)?.envelope)
+    .filter((env) => env && env.data?.id === pageId);
+};
+
+describe("knowledge_text lifecycle webhook events", () => {
+  beforeAll(async () => {
+    await initTests();
+    // subscribe a tenant-wide webhook to each knowledge_text event
+    for (const event of [
+      "knowledge_text.created",
+      "knowledge_text.updated",
+      "knowledge_text.deleted",
+    ]) {
+      const w = await createWebhook(TEST_ORG1_USER_1.id, {
+        userId: TEST_ORG1_USER_1.id,
+        tenantId: TENANT,
+        name: `kt-events-${event}`,
+        type: "n8n",
+        event,
+        webhookUrl: "http://example.com/hook",
+        tenantWide: true,
+        authMode: "headers",
+      });
+      createdWebhookIds.push(w.id);
+    }
+  });
+
+  afterAll(async () => {
+    for (const id of createdWebhookIds) {
+      await getDb().delete(webhooks).where(eq(webhooks.id, id));
+    }
+  });
+
+  test("createKnowledgeText fires knowledge_text.created (source=user, no text)", async () => {
+    const page = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Event Page",
+      text: "some secret body content",
+    });
+
+    const envelopes = await envelopesForPage(page.id);
+    const created = envelopes.find((e) => e.event === "knowledge_text.created");
+    expect(created).toBeDefined();
+    expect(created.source).toBe("user");
+    expect(created.data.id).toBe(page.id);
+    expect(created.data.title).toBe("Event Page");
+    // the page text must never be part of the payload
+    expect(created.data).not.toHaveProperty("text");
+    expect(JSON.stringify(created.data)).not.toContain("secret body");
+  });
+
+  test("updateKnowledgeText fires knowledge_text.updated", async () => {
+    const page = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "To Update",
+      text: "v1",
+    });
+    await updateKnowledgeText(
+      page.id,
+      { title: "Updated Title" },
+      { tenantId: TENANT }
+    );
+
+    const envelopes = await envelopesForPage(page.id);
+    const updated = envelopes.find((e) => e.event === "knowledge_text.updated");
+    expect(updated).toBeDefined();
+    expect(updated.source).toBe("user");
+    expect(updated.data.title).toBe("Updated Title");
+  });
+
+  test("deleteKnowledgeText fires knowledge_text.deleted (data = id only)", async () => {
+    const page = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "To Delete",
+      text: "bye",
+    });
+    await deleteKnowledgeText(page.id, {
+      tenantId: TENANT,
+    });
+
+    const envelopes = await envelopesForPage(page.id);
+    const deleted = envelopes.find((e) => e.event === "knowledge_text.deleted");
+    expect(deleted).toBeDefined();
+    expect(deleted.data).toEqual({ id: page.id });
+  });
+
+  test("source flows through as 'sync' when set", async () => {
+    const page = await createKnowledgeText(
+      { tenantId: TENANT, title: "Synced", text: "x" },
+      { source: "sync" }
+    );
+
+    const envelopes = await envelopesForPage(page.id);
+    const created = envelopes.find((e) => e.event === "knowledge_text.created");
+    expect(created).toBeDefined();
+    expect(created.source).toBe("sync");
+  });
+
+  test("a block-editor save fires knowledge_text.updated", async () => {
+    const page = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Block Page",
+      text: "",
+    });
+
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "markdown", content: "# Hello block" }],
+      { tenantId: TENANT }
+    );
+
+    const envelopes = await envelopesForPage(page.id);
+    // at least one updated event from the block save
+    const updated = envelopes.filter((e) => e.event === "knowledge_text.updated");
+    expect(updated.length).toBeGreaterThanOrEqual(1);
+    expect(updated.every((e) => !("text" in e.data))).toBe(true);
+  });
+});

--- a/src/lib/knowledge/knowledge-text-events.ts
+++ b/src/lib/knowledge/knowledge-text-events.ts
@@ -1,0 +1,124 @@
+/**
+ * Single choke-point for emitting knowledge_text (wiki page) lifecycle webhook
+ * events. Every code path that creates / updates / deletes a knowledge_text row
+ * in a way that "effectively changes a document" calls one of the emit helpers
+ * here — so the payload shape, the event names and the tenant/source handling
+ * live in exactly one place.
+ *
+ * Deliberately NOT wrapped around the raw DB writes: the create/update/delete
+ * functions run a chunk/vector pipeline (bookkeeping + embedding sync) after
+ * the row write, and the block editor writes inside a transaction. Emitting
+ * from the semantic functions AFTER that work has completed (and, for the block
+ * editor, after the transaction has committed) keeps the pipeline untouched and
+ * guarantees we never fire an event for a write that was later rolled back.
+ *
+ * IMPORTANT: the payload never contains the page `text` (wiki pages can be
+ * large). Receivers get the id + metadata and fetch the content via the API if
+ * they need it.
+ *
+ * Pure derived-state writes (AI summary regeneration, embedding-link bookkeeping)
+ * do NOT call these helpers and therefore never emit — they are not a change to
+ * the document a user authored.
+ */
+import { dispatchEvent, type WebhookEventSource } from "../webhooks/dispatch";
+import type { KnowledgeTextSelect } from "../db/schema/knowledge";
+import log from "../log";
+
+/** The subset of a knowledge_text row delivered in the webhook payload. */
+export interface KnowledgeTextEventData {
+  id: string;
+  title: string;
+  parentId: string | null;
+  tenantWide: boolean;
+  teamId: string | null;
+  userId: string | null;
+  contentMode: string;
+  pageType: string | null;
+  status: string | null;
+  hidden: boolean;
+  isAgentInstructions: boolean;
+  embeddingEnabled: boolean;
+  createdBy: string | null;
+  updatedBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Build the metadata payload for a page — intentionally excludes `text`. */
+const toEventData = (page: KnowledgeTextSelect): KnowledgeTextEventData => ({
+  id: page.id,
+  title: page.title,
+  parentId: page.parentId,
+  tenantWide: page.tenantWide,
+  teamId: page.teamId,
+  userId: page.userId,
+  contentMode: page.contentMode,
+  pageType: page.pageType,
+  status: page.status,
+  hidden: page.hidden,
+  isAgentInstructions: page.isAgentInstructions,
+  embeddingEnabled: page.embeddingEnabled,
+  createdBy: page.createdBy,
+  updatedBy: page.updatedBy,
+  createdAt: page.createdAt,
+  updatedAt: page.updatedAt,
+});
+
+/**
+ * A page was created. `source` distinguishes a direct user/API create from a
+ * sync-driven one (e.g. upsertKnowledgeTextFromSource).
+ */
+export const emitKnowledgeTextCreated = async (
+  page: KnowledgeTextSelect,
+  source: WebhookEventSource = "user"
+): Promise<void> => {
+  try {
+    await dispatchEvent(page.tenantId, "knowledge_text.created", toEventData(page), {
+      source,
+      userId: page.userId ?? undefined,
+    });
+  } catch (e) {
+    log.error(
+      `emitKnowledgeTextCreated failed for ${page.id}: ${(e as Error).message}`
+    );
+  }
+};
+
+/** A page's content or metadata effectively changed. */
+export const emitKnowledgeTextUpdated = async (
+  page: KnowledgeTextSelect,
+  source: WebhookEventSource = "user"
+): Promise<void> => {
+  try {
+    await dispatchEvent(page.tenantId, "knowledge_text.updated", toEventData(page), {
+      source,
+      userId: page.userId ?? undefined,
+    });
+  } catch (e) {
+    log.error(
+      `emitKnowledgeTextUpdated failed for ${page.id}: ${(e as Error).message}`
+    );
+  }
+};
+
+/**
+ * A page was deleted. The row is already gone, so the payload carries only the
+ * id (plus the tenant it belonged to, via the dispatch scope).
+ */
+export const emitKnowledgeTextDeleted = async (
+  page: Pick<KnowledgeTextSelect, "id" | "tenantId" | "userId">,
+  source: WebhookEventSource = "user"
+): Promise<void> => {
+  try {
+    await dispatchEvent(
+      page.tenantId,
+      "knowledge_text.deleted",
+      { id: page.id },
+      { source, userId: page.userId ?? undefined }
+    );
+  } catch (e) {
+    log.error(
+      `emitKnowledgeTextDeleted failed for ${page.id}: ${(e as Error).message}`
+    );
+  }
+};

--- a/src/lib/knowledge/knowledge-text-sync.ts
+++ b/src/lib/knowledge/knowledge-text-sync.ts
@@ -98,6 +98,8 @@ export const upsertKnowledgeTextFromSource = async (
     teamId: data.teamId,
     workspaceId: data.workspaceId,
     includeHidden: true,
+    // these writes originate from a source sync, not a direct user edit
+    source: "sync" as const,
   };
 
   const existing = await findKnowledgeTextBySourceIdentifier(
@@ -124,7 +126,7 @@ export const upsertKnowledgeTextFromSource = async (
         ...(data.matchScope ?? {}),
         [TEXT_SOURCE_IDENTIFIER_META_KEY]: data.sourceIdentifier,
       },
-    });
+    }, { source: "sync" });
     return { id: page.id, created: true, changed: true };
   }
 
@@ -204,6 +206,7 @@ export const deleteOrphanedKnowledgeTexts = async (opts: {
     await deleteKnowledgeText(orphan.id, {
       tenantId: opts.tenantId,
       includeHidden: true,
+      source: "sync",
     });
   }
 

--- a/src/lib/knowledge/knowledge-texts.ts
+++ b/src/lib/knowledge/knowledge-texts.ts
@@ -37,6 +37,12 @@ import {
   attributesContainCondition,
   type FacetFilters,
 } from "./facets";
+import {
+  emitKnowledgeTextCreated,
+  emitKnowledgeTextUpdated,
+  emitKnowledgeTextDeleted,
+} from "./knowledge-text-events";
+import type { WebhookEventSource } from "../webhooks/dispatch";
 import log from "../log";
 
 /**
@@ -141,7 +147,10 @@ export const checkKnowledgeTextWritePermission = async (
 /**
  * Create a new knowledgeText entry
  */
-export const createKnowledgeText = async (data: KnowledgeTextInsert) => {
+export const createKnowledgeText = async (
+  data: KnowledgeTextInsert,
+  options?: { source?: WebhookEventSource }
+) => {
   data = sanitizeKnowledgeTextData(data);
 
   // reject facet values outside the tenant's controlled vocabulary.
@@ -195,6 +204,7 @@ export const createKnowledgeText = async (data: KnowledgeTextInsert) => {
   );
 
   // initial embedding sync for pages created with embedding already on
+  let resultPage = e[0];
   if (e[0].embeddingEnabled) {
     const syncResult = await syncKnowledgeTextEmbeddingSafe(
       e[0].id,
@@ -206,11 +216,14 @@ export const createKnowledgeText = async (data: KnowledgeTextInsert) => {
         .select()
         .from(knowledgeText)
         .where(eq(knowledgeText.id, e[0].id));
-      return fresh[0] ?? e[0];
+      resultPage = fresh[0] ?? e[0];
     }
   }
 
-  return e[0];
+  // fire the outgoing "created" webhook (fire-and-forget; never throws)
+  await emitKnowledgeTextCreated(resultPage, options?.source ?? "user");
+
+  return resultPage;
 };
 
 /**
@@ -478,6 +491,8 @@ export const updateKnowledgeText = async (
     teamId?: string;
     workspaceId?: string;
     includeHidden?: boolean;
+    /** Origin of the change; forwarded to the outgoing webhook (default "user"). */
+    source?: WebhookEventSource;
   }
 ) => {
   // Get the current entry (including text) to create history
@@ -601,6 +616,7 @@ export const updateKnowledgeText = async (
   // Keep the RAG mirror in sync: covers newly enabled embedding, changed
   // content, and cleanup after embedding was turned off. No-op otherwise;
   // failures are logged and never fail the update itself.
+  let resultPage = result[0];
   if (result[0].embeddingEnabled || currentEntry.knowledgeEntryId) {
     const syncResult = await syncKnowledgeTextEmbeddingSafe(
       result[0].id,
@@ -608,11 +624,17 @@ export const updateKnowledgeText = async (
     );
     if (syncResult && (syncResult.synced || syncResult.removed)) {
       // the sync wrote knowledgeEntryId/meta — return the fresh row
-      return await getKnowledgeTextById(id, { ...context, includeHidden: true });
+      resultPage = await getKnowledgeTextById(id, {
+        ...context,
+        includeHidden: true,
+      });
     }
   }
 
-  return result[0];
+  // fire the outgoing "updated" webhook (fire-and-forget; never throws)
+  await emitKnowledgeTextUpdated(resultPage, context.source ?? "user");
+
+  return resultPage;
 };
 
 /**
@@ -626,6 +648,8 @@ export const deleteKnowledgeText = async (
     teamId?: string;
     workspaceId?: string;
     includeHidden?: boolean;
+    /** Origin of the change; forwarded to the outgoing webhook (default "user"). */
+    source?: WebhookEventSource;
   }
 ) => {
   const item = await getKnowledgeTextById(id, context);
@@ -658,6 +682,12 @@ export const deleteKnowledgeText = async (
         )
       );
   }
+
+  // fire the outgoing "deleted" webhook (fire-and-forget; never throws)
+  await emitKnowledgeTextDeleted(
+    { id: item.id, tenantId: item.tenantId, userId: item.userId },
+    context.source ?? "user"
+  );
 
   return RESPONSES.SUCCESS;
 };

--- a/src/lib/webhooks/crud.ts
+++ b/src/lib/webhooks/crud.ts
@@ -4,6 +4,22 @@ import type { WebhookInsert, WebhookSelect } from "../db/schema/webhooks";
 import { webhooks } from "../db/schema/webhooks";
 
 /**
+ * The public shape of a webhook: everything EXCEPT the (encrypted) signing
+ * secret and its key version. The secret is only ever revealed once, in clear,
+ * at creation / rotation time — it must never leak through read endpoints.
+ */
+export type PublicWebhook = Omit<
+  WebhookSelect,
+  "signingSecret" | "signingSecretKeyVersion"
+> & { hasSigningSecret: boolean };
+
+/** Strip the signing secret from a webhook row before returning it to a client. */
+export const toPublicWebhook = (w: WebhookSelect): PublicWebhook => {
+  const { signingSecret, signingSecretKeyVersion, ...rest } = w;
+  return { ...rest, hasSigningSecret: signingSecret != null };
+};
+
+/**
  * Returns the webhook only if it belongs to the given tenant. All by-id
  * operations go through this so a webhook of another tenant cannot be read,
  * modified, or deleted by guessing its id (IDOR — webhook rows hold the target

--- a/src/lib/webhooks/delivery-job.test.ts
+++ b/src/lib/webhooks/delivery-job.test.ts
@@ -1,0 +1,200 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from "bun:test";
+import { createServer, type Server } from "http";
+import { eq } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { webhooks } from "../db/schema/webhooks";
+import { jobs } from "../db/schema/jobs";
+import { createWebhook } from "./crud";
+import { encryptAes } from "../crypt/aes";
+import {
+  webhookDeliveryJobRegister,
+  NonRetryableDeliveryError,
+} from "./delivery-job";
+import { WEBHOOK_DELIVERY_JOB_TYPE } from "./delivery-types";
+import type { WebhookDeliveryJobMetadata } from "./delivery-types";
+import type { WebhookEventEnvelope } from "./dispatch";
+import { verifySignature, SIGNATURE_HEADER, TIMESTAMP_HEADER, EVENT_HEADER } from "./signature";
+import {
+  initTests,
+  TEST_ORGANISATION_1,
+  TEST_ORG1_USER_1,
+} from "../../test/init.test";
+
+const TENANT = TEST_ORGANISATION_1.id;
+const PORT = 3998;
+const SECRET = "whsec_deliverytestsecret";
+
+let server: Server;
+let nextStatus = 200;
+let lastRequest: { headers: Record<string, string>; body: string } | null =
+  null;
+
+const execute = (metadata: WebhookDeliveryJobMetadata) =>
+  webhookDeliveryJobRegister.handler.execute(metadata, {} as any);
+
+const makeEnvelope = (): WebhookEventEnvelope => ({
+  id: "11111111-1111-1111-1111-111111111111",
+  event: "knowledge_text.created",
+  source: "user",
+  tenantId: TENANT,
+  occurredAt: "2026-01-01T00:00:00.000Z",
+  data: { id: "page-42" },
+});
+
+const createHmacWebhook = async () => {
+  process.env.SSRF_ALLOW_PRIVATE_TARGETS = "true";
+  const enc = encryptAes(SECRET);
+  return createWebhook(TEST_ORG1_USER_1.id, {
+    userId: TEST_ORG1_USER_1.id,
+    tenantId: TENANT,
+    name: `delivery-test-${Date.now()}`,
+    type: "n8n",
+    event: "knowledge_text.created",
+    webhookUrl: `http://127.0.0.1:${PORT}/hook`,
+    tenantWide: true,
+    authMode: "hmac",
+    signingSecret: enc.value,
+    signingSecretKeyVersion: enc.keyVersion,
+  });
+};
+
+const retryJobsFor = async (webhookId: string) => {
+  const rows = await getDb()
+    .select()
+    .from(jobs)
+    .where(eq(jobs.type, WEBHOOK_DELIVERY_JOB_TYPE));
+  return rows.filter((r) => (r.metadata as any)?.webhookId === webhookId);
+};
+
+describe("webhook delivery job", () => {
+  beforeAll(async () => {
+    await initTests();
+    process.env.SSRF_ALLOW_PRIVATE_TARGETS = "true";
+    server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c.toString()));
+      req.on("end", () => {
+        lastRequest = {
+          headers: req.headers as Record<string, string>,
+          body,
+        };
+        res.writeHead(nextStatus);
+        res.end("");
+      });
+    }).listen(PORT);
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  afterEach(async () => {
+    // remove test webhooks + any enqueued retry jobs
+    const rows = await getDb().select().from(jobs).where(eq(jobs.type, WEBHOOK_DELIVERY_JOB_TYPE));
+    for (const job of rows) {
+      const meta = job.metadata as any;
+      if (typeof meta?.webhookId === "string") {
+        const wh = await getDb().query.webhooks.findFirst({
+          where: eq(webhooks.id, meta.webhookId),
+        });
+        if (wh?.name?.startsWith("delivery-test-")) {
+          await getDb().delete(jobs).where(eq(jobs.id, job.id));
+        }
+      }
+    }
+    await getDb().delete(webhooks).where(eq(webhooks.tenantId, TENANT));
+    lastRequest = null;
+  });
+
+  test("successful delivery sends a valid HMAC signature and event headers", async () => {
+    nextStatus = 200;
+    const webhook = await createHmacWebhook();
+    const envelope = makeEnvelope();
+
+    const result = await execute({
+      webhookId: webhook.id,
+      tenantId: TENANT,
+      envelope,
+      attempt: 1,
+    });
+
+    expect((result as any).ok).toBe(true);
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest!.headers[EVENT_HEADER.toLowerCase()]).toBe(
+      "knowledge_text.created"
+    );
+
+    // the received body must verify against the signature headers
+    const ok = verifySignature({
+      secret: SECRET,
+      payload: lastRequest!.body,
+      signatureHeader: lastRequest!.headers[SIGNATURE_HEADER.toLowerCase()],
+      timestampHeader: lastRequest!.headers[TIMESTAMP_HEADER.toLowerCase()],
+    });
+    expect(ok).toBe(true);
+
+    // the delivered body is exactly the envelope (and carries no page text)
+    expect(JSON.parse(lastRequest!.body).data).toEqual({ id: "page-42" });
+  });
+
+  test("a 5xx response schedules a retry with an incremented attempt", async () => {
+    nextStatus = 500;
+    const webhook = await createHmacWebhook();
+
+    await expect(
+      execute({
+        webhookId: webhook.id,
+        tenantId: TENANT,
+        envelope: makeEnvelope(),
+        attempt: 1,
+      })
+    ).rejects.toThrow();
+
+    const retries = await retryJobsFor(webhook.id);
+    // one retry job with attempt=2 and a future scheduledAt
+    const retry = retries.find((r) => (r.metadata as any).attempt === 2);
+    expect(retry).toBeDefined();
+    expect(retry!.scheduledAt).not.toBeNull();
+  });
+
+  test("a 4xx response is permanent — no retry is scheduled", async () => {
+    nextStatus = 400;
+    const webhook = await createHmacWebhook();
+
+    await expect(
+      execute({
+        webhookId: webhook.id,
+        tenantId: TENANT,
+        envelope: makeEnvelope(),
+        attempt: 1,
+      })
+    ).rejects.toBeInstanceOf(NonRetryableDeliveryError);
+
+    const retries = await retryJobsFor(webhook.id);
+    expect(retries.find((r) => (r.metadata as any).attempt === 2)).toBeUndefined();
+  });
+
+  test("gives up (no retry) once the max attempts is reached", async () => {
+    nextStatus = 500;
+    const webhook = await createHmacWebhook();
+
+    await expect(
+      execute({
+        webhookId: webhook.id,
+        tenantId: TENANT,
+        envelope: makeEnvelope(),
+        attempt: 5, // already at MAX_DELIVERY_ATTEMPTS
+      })
+    ).rejects.toThrow();
+
+    const retries = await retryJobsFor(webhook.id);
+    expect(retries.find((r) => (r.metadata as any).attempt === 6)).toBeUndefined();
+  });
+});

--- a/src/lib/webhooks/delivery-job.ts
+++ b/src/lib/webhooks/delivery-job.ts
@@ -1,0 +1,174 @@
+/**
+ * Background job handler that performs a single outgoing webhook delivery.
+ *
+ * Enqueued by `dispatchEvent` (dispatch.ts), one job per subscribed receiver.
+ * Delivering out-of-band gives us:
+ *   - isolation: a slow/broken receiver never blocks the triggering request,
+ *   - retries: transient failures (network / 5xx) are retried with exponential
+ *     backoff by re-enqueuing the job with a future `scheduledAt`.
+ *
+ * Client (4xx) errors are treated as permanent (the receiver rejected the
+ * payload) and are not retried.
+ */
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { webhooks } from "../db/schema/webhooks";
+import { createJob } from "../jobs";
+import type { JobHandlerRegister } from "../jobs";
+import { fetchWithSsrfGuard, SsrfBlockedError } from "../utils/url-guard";
+import { decryptAes } from "../crypt/aes";
+import log from "../log";
+import {
+  WEBHOOK_DELIVERY_JOB_TYPE,
+  type WebhookDeliveryJobMetadata,
+} from "./delivery-types";
+import {
+  buildSignatureHeaders,
+  DELIVERY_HEADER,
+  EVENT_HEADER,
+} from "./signature";
+
+/** Max number of delivery attempts before the delivery is given up on. */
+export const MAX_DELIVERY_ATTEMPTS = 5;
+/** Base backoff in ms; attempt N waits BASE * 2^(N-1) (30s, 1m, 2m, 4m). */
+export const DELIVERY_BACKOFF_BASE_MS = 30_000;
+/** Per-request timeout. */
+export const DELIVERY_TIMEOUT_MS = 10_000;
+
+const backoffMs = (attempt: number): number =>
+  DELIVERY_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+
+/**
+ * Execute one delivery attempt. Throws only on a retryable failure so the job
+ * queue records the failure; the retry itself is scheduled as a NEW job before
+ * throwing, so the failed row and the pending retry coexist.
+ */
+const deliver = async (
+  metadata: WebhookDeliveryJobMetadata
+): Promise<{ ok: true; statusCode: number } | { skipped: true }> => {
+  const { webhookId, tenantId, envelope, attempt } = metadata;
+
+  const webhook = await getDb().query.webhooks.findFirst({
+    where: and(eq(webhooks.id, webhookId), eq(webhooks.tenantId, tenantId)),
+  });
+
+  // The webhook may have been deleted or disabled between enqueue and delivery.
+  if (!webhook || !webhook.enabled) {
+    log.debug(
+      `Webhook ${webhookId} gone or disabled; skipping delivery of event ${envelope.event}`
+    );
+    return { skipped: true };
+  }
+
+  const rawBody = JSON.stringify(envelope);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    [EVENT_HEADER]: envelope.event,
+    [DELIVERY_HEADER]: envelope.id,
+    ...((webhook.headers as Record<string, string>) || {}),
+  };
+
+  // Authenticate the delivery. HMAC is the default; 'headers' relies on the
+  // static custom headers above; 'none' sends nothing extra.
+  if (webhook.authMode === "hmac" && webhook.signingSecret) {
+    const secret = decryptAes(
+      webhook.signingSecret,
+      "aes-256-cbc",
+      webhook.signingSecretKeyVersion ?? 1
+    ).value;
+    Object.assign(headers, buildSignatureHeaders(secret, rawBody));
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetchWithSsrfGuard(webhook.webhookUrl, {
+      method: webhook.method,
+      headers,
+      body: webhook.method !== "GET" ? rawBody : undefined,
+      signal: controller.signal,
+    });
+  } catch (e) {
+    if (e instanceof SsrfBlockedError) {
+      // A blocked/invalid target is a configuration error, not transient.
+      throw new NonRetryableDeliveryError(
+        `Webhook URL not allowed: ${e.message}`
+      );
+    }
+    // Network error / timeout → retryable.
+    throw new Error(`Webhook request failed: ${(e as Error).message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (response.ok) {
+    // best-effort last-used bookkeeping; never fail the delivery over it.
+    await getDb()
+      .update(webhooks)
+      .set({ lastUsedAt: new Date().toISOString() })
+      .where(eq(webhooks.id, webhook.id))
+      .catch(() => {});
+    return { ok: true, statusCode: response.status };
+  }
+
+  // 4xx (except 429) → the receiver rejected the payload; don't retry.
+  if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+    throw new NonRetryableDeliveryError(
+      `Webhook rejected with status ${response.status}`
+    );
+  }
+
+  // 5xx / 429 → transient; retry.
+  throw new Error(`Webhook responded with status ${response.status}`);
+};
+
+/** Marks a failure that must NOT be retried (permanent). */
+export class NonRetryableDeliveryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NonRetryableDeliveryError";
+  }
+}
+
+export const webhookDeliveryJobRegister: JobHandlerRegister = {
+  type: WEBHOOK_DELIVERY_JOB_TYPE,
+  handler: {
+    async execute(metadata: WebhookDeliveryJobMetadata) {
+      try {
+        const result = await deliver(metadata);
+        return result;
+      } catch (e) {
+        const isPermanent = e instanceof NonRetryableDeliveryError;
+        const canRetry =
+          !isPermanent && metadata.attempt < MAX_DELIVERY_ATTEMPTS;
+
+        if (canRetry) {
+          const nextAttempt = metadata.attempt + 1;
+          const scheduledAt = new Date(
+            Date.now() + backoffMs(metadata.attempt)
+          ).toISOString();
+          // Schedule the retry as a NEW job before this one fails, so the
+          // retry is durably queued regardless of how this job row is recorded.
+          await createJob(
+            WEBHOOK_DELIVERY_JOB_TYPE,
+            { ...metadata, attempt: nextAttempt },
+            metadata.tenantId,
+            scheduledAt
+          );
+          log.info(
+            `Webhook delivery for ${metadata.webhookId} failed (attempt ${metadata.attempt}/${MAX_DELIVERY_ATTEMPTS}), retry #${nextAttempt} scheduled for ${scheduledAt}: ${(e as Error).message}`
+          );
+        } else {
+          log.error(
+            `Webhook delivery for ${metadata.webhookId} ${isPermanent ? "failed permanently" : `gave up after ${MAX_DELIVERY_ATTEMPTS} attempts`}: ${(e as Error).message}`
+          );
+        }
+        // Re-throw so the job itself is marked failed (the retry, if any, is a
+        // separate pending job).
+        throw e;
+      }
+    },
+  },
+};

--- a/src/lib/webhooks/delivery-types.ts
+++ b/src/lib/webhooks/delivery-types.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared types/constants for webhook delivery. Kept in a tiny standalone module
+ * so `dispatch.ts` and `delivery-job.ts` can both import them without creating
+ * an import cycle.
+ */
+import type { WebhookEventEnvelope } from "./dispatch";
+
+/** Job type registered with the background job queue for webhook delivery. */
+export const WEBHOOK_DELIVERY_JOB_TYPE = "webhook.delivery";
+
+/** Metadata persisted on a `webhook.delivery` job. */
+export interface WebhookDeliveryJobMetadata {
+  webhookId: string;
+  tenantId: string;
+  envelope: WebhookEventEnvelope;
+  /** 1-based delivery attempt counter (incremented on each retry). */
+  attempt: number;
+}

--- a/src/lib/webhooks/dispatch.test.ts
+++ b/src/lib/webhooks/dispatch.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, beforeAll, afterEach } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { webhooks } from "../db/schema/webhooks";
+import { jobs } from "../db/schema/jobs";
+import { createWebhook } from "./crud";
+import { dispatchEvent } from "./dispatch";
+import { WEBHOOK_DELIVERY_JOB_TYPE } from "./delivery-types";
+import {
+  initTests,
+  TEST_ORGANISATION_1,
+  TEST_ORG1_USER_1,
+} from "../../test/init.test";
+
+const TENANT = TEST_ORGANISATION_1.id;
+const createdIds: string[] = [];
+
+const makeWebhook = async (opts: {
+  event: string;
+  enabled?: boolean;
+  tenantWide?: boolean;
+  userId?: string;
+}) => {
+  const w = await createWebhook(TEST_ORG1_USER_1.id, {
+    userId: TEST_ORG1_USER_1.id,
+    tenantId: TENANT,
+    name: `dispatch-test-${opts.event}-${createdIds.length}`,
+    type: "n8n",
+    event: opts.event,
+    webhookUrl: "http://example.com/hook",
+    tenantWide: opts.tenantWide ?? true,
+    enabled: opts.enabled ?? true,
+    authMode: "headers",
+  });
+  createdIds.push(w.id);
+  return w;
+};
+
+/** Count enqueued delivery jobs whose target webhook is one we created. */
+const deliveryJobsForCreated = async () => {
+  const rows = await getDb()
+    .select()
+    .from(jobs)
+    .where(eq(jobs.type, WEBHOOK_DELIVERY_JOB_TYPE));
+  return rows.filter((r) =>
+    createdIds.includes((r.metadata as any)?.webhookId)
+  );
+};
+
+describe("dispatchEvent", () => {
+  beforeAll(async () => {
+    await initTests();
+  });
+
+  afterEach(async () => {
+    // Clean up webhooks + their enqueued jobs so tests don't cross-contaminate.
+    for (const id of createdIds) {
+      await getDb().delete(webhooks).where(eq(webhooks.id, id));
+    }
+    const stale = await getDb()
+      .select()
+      .from(jobs)
+      .where(eq(jobs.type, WEBHOOK_DELIVERY_JOB_TYPE));
+    for (const job of stale) {
+      if (createdIds.includes((job.metadata as any)?.webhookId)) {
+        await getDb().delete(jobs).where(eq(jobs.id, job.id));
+      }
+    }
+    createdIds.length = 0;
+  });
+
+  test("enqueues one delivery job per subscribed, enabled, tenant-wide webhook", async () => {
+    await makeWebhook({ event: "knowledge_text.created" });
+    await makeWebhook({ event: "knowledge_text.created" });
+    // not subscribed to this event → must be ignored
+    await makeWebhook({ event: "knowledge_text.deleted" });
+
+    const result = await dispatchEvent(
+      TENANT,
+      "knowledge_text.created",
+      { id: "page-1" },
+      { source: "user" }
+    );
+
+    expect(result.enqueued).toBe(2);
+    const enqueuedJobs = await deliveryJobsForCreated();
+    expect(enqueuedJobs.length).toBe(2);
+
+    // envelope carries the event + source and NO page text
+    const env = (enqueuedJobs[0]!.metadata as any).envelope;
+    expect(env.event).toBe("knowledge_text.created");
+    expect(env.source).toBe("user");
+    expect(env.data).toEqual({ id: "page-1" });
+    // the payload data must never carry the page text
+    expect(env.data).not.toHaveProperty("text");
+  });
+
+  test("disabled webhooks are never fired", async () => {
+    await makeWebhook({ event: "knowledge_text.created", enabled: false });
+    const result = await dispatchEvent(TENANT, "knowledge_text.created", {
+      id: "x",
+    });
+    expect(result.enqueued).toBe(0);
+    expect((await deliveryJobsForCreated()).length).toBe(0);
+  });
+
+  test("no subscribers → nothing enqueued", async () => {
+    const result = await dispatchEvent(TENANT, "knowledge_text.updated", {
+      id: "x",
+    });
+    expect(result.enqueued).toBe(0);
+  });
+
+  test("legacy stored event value 'chat-output' matches canonical 'chat.output'", async () => {
+    await makeWebhook({ event: "chat-output" });
+    const result = await dispatchEvent(TENANT, "chat.output", { msg: "hi" });
+    expect(result.enqueued).toBe(1);
+  });
+
+  test("per-user (non-tenant-wide) webhook only fires for that user", async () => {
+    await makeWebhook({
+      event: "knowledge_text.created",
+      tenantWide: false,
+      userId: TEST_ORG1_USER_1.id,
+    });
+
+    // without the acting user → not delivered
+    const noUser = await dispatchEvent(TENANT, "knowledge_text.created", {
+      id: "x",
+    });
+    expect(noUser.enqueued).toBe(0);
+
+    // with the matching acting user → delivered
+    const withUser = await dispatchEvent(
+      TENANT,
+      "knowledge_text.created",
+      { id: "x" },
+      { userId: TEST_ORG1_USER_1.id }
+    );
+    expect(withUser.enqueued).toBe(1);
+  });
+});

--- a/src/lib/webhooks/dispatch.ts
+++ b/src/lib/webhooks/dispatch.ts
@@ -1,0 +1,120 @@
+/**
+ * Central event dispatcher for OUTGOING webhooks.
+ *
+ * `dispatchEvent` is the one call sites use to fire an event. It looks up every
+ * enabled webhook in the tenant that subscribes to the event and enqueues one
+ * asynchronous delivery job per receiver (see delivery-job.ts). Delivery is
+ * intentionally NOT done inline so a slow or broken receiver can never block or
+ * fail the business operation (a knowledge page write, a chat output, ...).
+ *
+ * Contract: dispatchEvent NEVER throws. A failure to enqueue is logged and
+ * swallowed — emitting a webhook is a side effect and must not break the
+ * primary action.
+ */
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { webhooks } from "../db/schema/webhooks";
+import { createJob } from "../jobs";
+import log from "../log";
+import { resolveWebhookEvent, type WebhookEvent } from "./events";
+import {
+  WEBHOOK_DELIVERY_JOB_TYPE,
+  type WebhookDeliveryJobMetadata,
+} from "./delivery-types";
+
+/** Where an event originated — lets receivers distinguish e.g. user vs sync. */
+export type WebhookEventSource =
+  | "user"
+  | "sync"
+  | "sync-orphan"
+  | "system"
+  | string;
+
+export interface DispatchEventOptions {
+  /** Who/what caused the event (defaults to "user"). */
+  source?: WebhookEventSource;
+  /**
+   * The acting user, if any. When set, per-user webhooks (tenantWide = false)
+   * owned by that user also receive the event; otherwise only tenant-wide
+   * webhooks do.
+   */
+  userId?: string;
+  /** ISO timestamp of when the event occurred (defaults to now). */
+  occurredAt?: string;
+}
+
+/** The JSON envelope delivered to the receiver as the request body. */
+export interface WebhookEventEnvelope {
+  /** Unique id of this event occurrence (also sent as X-Symbiosika-Delivery). */
+  id: string;
+  event: WebhookEvent;
+  source: WebhookEventSource;
+  tenantId: string;
+  occurredAt: string;
+  data: unknown;
+}
+
+/**
+ * Dispatch an event to all subscribed, enabled webhooks of a tenant.
+ * Returns the number of delivery jobs enqueued (0 if nothing subscribed).
+ */
+export const dispatchEvent = async (
+  tenantId: string,
+  event: WebhookEvent,
+  data: unknown,
+  options: DispatchEventOptions = {}
+): Promise<{ enqueued: number }> => {
+  try {
+    const rows = await getDb().query.webhooks.findMany({
+      where: and(eq(webhooks.tenantId, tenantId), eq(webhooks.enabled, true)),
+    });
+
+    // Match on the RESOLVED event so legacy ("chat-output") and canonical
+    // ("chat.output") stored values both subscribe to the same event.
+    const subscribed = rows.filter((w) => {
+      if (resolveWebhookEvent(w.event) !== event) return false;
+      if (w.tenantWide) return true;
+      return options.userId != null && w.userId === options.userId;
+    });
+
+    if (subscribed.length === 0) {
+      return { enqueued: 0 };
+    }
+
+    const envelope: WebhookEventEnvelope = {
+      id: randomUUID(),
+      event,
+      source: options.source ?? "user",
+      tenantId,
+      occurredAt: options.occurredAt ?? new Date().toISOString(),
+      data,
+    };
+
+    let enqueued = 0;
+    for (const webhook of subscribed) {
+      try {
+        const metadata: WebhookDeliveryJobMetadata = {
+          webhookId: webhook.id,
+          tenantId,
+          envelope,
+          attempt: 1,
+        };
+        await createJob(WEBHOOK_DELIVERY_JOB_TYPE, metadata, tenantId);
+        enqueued++;
+      } catch (e) {
+        log.error(
+          `Failed to enqueue webhook delivery for webhook ${webhook.id} (event ${event}): ${(e as Error).message}`
+        );
+      }
+    }
+
+    return { enqueued };
+  } catch (e) {
+    // Never let event dispatch break the caller's primary operation.
+    log.error(
+      `dispatchEvent failed for event ${event} / tenant ${tenantId}: ${(e as Error).message}`
+    );
+    return { enqueued: 0 };
+  }
+};

--- a/src/lib/webhooks/events.ts
+++ b/src/lib/webhooks/events.ts
@@ -1,0 +1,71 @@
+/**
+ * Central, code-side registry of the events an outgoing webhook can subscribe
+ * to. This is the single source of truth for "which events exist".
+ *
+ * Why a registry instead of a database enum: adding a new event is now a code
+ * change here (plus a `dispatchEvent(...)` call at the source of the event) and
+ * needs NO database migration. The `webhooks.event` column is plain text and is
+ * validated against this map on write.
+ *
+ * Event naming convention: `<domain>.<action>` (lower snake domain, dot,
+ * verb in past tense), e.g. `knowledge_text.created`.
+ */
+
+export const WEBHOOK_EVENTS = {
+  /** A chat/agent produced output (legacy; historically "chat-output"). */
+  "chat.output": {
+    description: "A chat or agent produced an output message.",
+  },
+  /** A wiki knowledge page (knowledge_text) was created. */
+  "knowledge_text.created": {
+    description: "A knowledge (wiki) page was created.",
+  },
+  /** A wiki knowledge page (knowledge_text) had its content/metadata changed. */
+  "knowledge_text.updated": {
+    description: "A knowledge (wiki) page was updated.",
+  },
+  /** A wiki knowledge page (knowledge_text) was deleted. */
+  "knowledge_text.deleted": {
+    description: "A knowledge (wiki) page was deleted.",
+  },
+} as const;
+
+export type WebhookEvent = keyof typeof WEBHOOK_EVENTS;
+
+/**
+ * Legacy/friendly event aliases → canonical event name.
+ *
+ * - `chat-output` is the value historically stored in the pgEnum column, kept
+ *   working so existing webhook rows and n8n registrations do not break.
+ * - the `...Created/Updated/Deleted` camelCase forms are what the n8n register
+ *   endpoint accepts as `event`, mirroring the existing `chatOutput`/`tool`
+ *   friendly names.
+ */
+const EVENT_ALIASES: Record<string, WebhookEvent> = {
+  "chat-output": "chat.output",
+  chatOutput: "chat.output",
+  knowledgeTextCreated: "knowledge_text.created",
+  knowledgeTextUpdated: "knowledge_text.updated",
+  knowledgeTextDeleted: "knowledge_text.deleted",
+};
+
+/**
+ * Resolve a stored/friendly event string to its canonical event name, or
+ * return null if it is not a known event. Accepts canonical names, the legacy
+ * `chat-output` value, and the camelCase register aliases.
+ */
+export const resolveWebhookEvent = (event: string): WebhookEvent | null => {
+  if (event in WEBHOOK_EVENTS) {
+    return event as WebhookEvent;
+  }
+  return EVENT_ALIASES[event] ?? null;
+};
+
+/** Type guard: is this string a canonical, known webhook event? */
+export const isKnownWebhookEvent = (event: string): event is WebhookEvent =>
+  event in WEBHOOK_EVENTS;
+
+/** All canonical event names, e.g. for validation error messages / docs. */
+export const ALL_WEBHOOK_EVENTS = Object.keys(
+  WEBHOOK_EVENTS
+) as WebhookEvent[];

--- a/src/lib/webhooks/signature.test.ts
+++ b/src/lib/webhooks/signature.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from "bun:test";
+import {
+  computeSignature,
+  buildSignatureHeaders,
+  verifySignature,
+  generateSigningSecret,
+  SIGNATURE_HEADER,
+  TIMESTAMP_HEADER,
+  SIGNING_SECRET_PREFIX,
+} from "./signature";
+
+describe("webhook signature", () => {
+  const secret = "whsec_testsecret";
+  const payload = JSON.stringify({ event: "knowledge_text.created", data: { id: "1" } });
+  const ts = 1_700_000_000;
+
+  test("sign → verify round-trip succeeds", () => {
+    const headers = buildSignatureHeaders(secret, payload, ts);
+    expect(headers[TIMESTAMP_HEADER]).toBe(String(ts));
+    expect(headers[SIGNATURE_HEADER]).toMatch(/^v1=[0-9a-f]{64}$/);
+
+    const ok = verifySignature({
+      secret,
+      payload,
+      signatureHeader: headers[SIGNATURE_HEADER],
+      timestampHeader: headers[TIMESTAMP_HEADER],
+      nowSeconds: ts,
+    });
+    expect(ok).toBe(true);
+  });
+
+  test("computeSignature is deterministic and binds the timestamp", () => {
+    expect(computeSignature(secret, payload, ts)).toBe(
+      computeSignature(secret, payload, ts)
+    );
+    // a different timestamp yields a different signature
+    expect(computeSignature(secret, payload, ts)).not.toBe(
+      computeSignature(secret, payload, ts + 1)
+    );
+  });
+
+  test("a tampered payload fails verification", () => {
+    const headers = buildSignatureHeaders(secret, payload, ts);
+    const ok = verifySignature({
+      secret,
+      payload: payload + "x", // body changed after signing
+      signatureHeader: headers[SIGNATURE_HEADER],
+      timestampHeader: headers[TIMESTAMP_HEADER],
+      nowSeconds: ts,
+    });
+    expect(ok).toBe(false);
+  });
+
+  test("a wrong secret fails verification", () => {
+    const headers = buildSignatureHeaders(secret, payload, ts);
+    const ok = verifySignature({
+      secret: "whsec_other",
+      payload,
+      signatureHeader: headers[SIGNATURE_HEADER],
+      timestampHeader: headers[TIMESTAMP_HEADER],
+      nowSeconds: ts,
+    });
+    expect(ok).toBe(false);
+  });
+
+  test("a stale timestamp (replay) is rejected", () => {
+    const headers = buildSignatureHeaders(secret, payload, ts);
+    const ok = verifySignature({
+      secret,
+      payload,
+      signatureHeader: headers[SIGNATURE_HEADER],
+      timestampHeader: headers[TIMESTAMP_HEADER],
+      toleranceSeconds: 300,
+      nowSeconds: ts + 301, // just outside the tolerance window
+    });
+    expect(ok).toBe(false);
+  });
+
+  test("missing headers fail closed", () => {
+    expect(
+      verifySignature({
+        secret,
+        payload,
+        signatureHeader: null,
+        timestampHeader: null,
+      })
+    ).toBe(false);
+  });
+
+  test("generateSigningSecret produces a prefixed, unique secret", () => {
+    const a = generateSigningSecret();
+    const b = generateSigningSecret();
+    expect(a.startsWith(SIGNING_SECRET_PREFIX)).toBe(true);
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThan(SIGNING_SECRET_PREFIX.length + 20);
+  });
+});

--- a/src/lib/webhooks/signature.ts
+++ b/src/lib/webhooks/signature.ts
@@ -1,0 +1,111 @@
+/**
+ * HMAC signing/verification for outgoing webhooks.
+ *
+ * Modelled on the Stripe/GitHub webhook signature scheme: the receiver stores a
+ * shared secret and can verify that a delivery genuinely originates from us and
+ * was not tampered with, WITHOUT the secret ever travelling on the wire.
+ *
+ * The signature is computed over `"<timestamp>.<rawBody>"` so that a captured
+ * request cannot be replayed later (the receiver rejects timestamps outside a
+ * tolerance window).
+ *
+ *   X-Symbiosika-Timestamp: <unix seconds>
+ *   X-Symbiosika-Signature: v1=<hex hmac-sha256>
+ *
+ * Verification uses a constant-time comparison to avoid timing side-channels.
+ */
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+export const SIGNATURE_HEADER = "X-Symbiosika-Signature";
+export const TIMESTAMP_HEADER = "X-Symbiosika-Timestamp";
+export const EVENT_HEADER = "X-Symbiosika-Event";
+export const DELIVERY_HEADER = "X-Symbiosika-Delivery";
+
+/** Prefix for generated signing secrets (Stripe-style, easy to recognise). */
+export const SIGNING_SECRET_PREFIX = "whsec_";
+
+/**
+ * Generate a new signing secret: the recognisable prefix + 32 random bytes as
+ * URL-safe base64 (~43 chars of entropy). Shown to the operator exactly once.
+ */
+export const generateSigningSecret = (): string =>
+  SIGNING_SECRET_PREFIX + randomBytes(32).toString("base64url");
+
+/**
+ * Compute the raw hex HMAC-SHA256 of `"<timestamp>.<payload>"` using `secret`.
+ */
+export const computeSignature = (
+  secret: string,
+  payload: string,
+  timestampSeconds: number
+): string =>
+  createHmac("sha256", secret)
+    .update(`${timestampSeconds}.${payload}`)
+    .digest("hex");
+
+/**
+ * Build the signature headers for a delivery. `timestampSeconds` defaults to
+ * "now"; pass it explicitly in tests for determinism.
+ */
+export const buildSignatureHeaders = (
+  secret: string,
+  payload: string,
+  timestampSeconds: number = Math.floor(Date.now() / 1000)
+): Record<string, string> => ({
+  [TIMESTAMP_HEADER]: String(timestampSeconds),
+  [SIGNATURE_HEADER]: `v1=${computeSignature(secret, payload, timestampSeconds)}`,
+});
+
+/** Constant-time comparison of two hex strings of equal expected length. */
+const safeHexEqual = (a: string, b: string): boolean => {
+  const bufA = Buffer.from(a, "hex");
+  const bufB = Buffer.from(b, "hex");
+  if (bufA.length !== bufB.length || bufA.length === 0) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+};
+
+/**
+ * Verify a signature header against the payload. Mirrors what a receiver should
+ * implement; also used by tests.
+ *
+ * @param toleranceSeconds max age (and future skew) of the timestamp; the
+ *        default 300s (5 min) is the common industry value and blocks replays.
+ */
+export const verifySignature = (opts: {
+  secret: string;
+  payload: string;
+  signatureHeader: string | null | undefined;
+  timestampHeader: string | null | undefined;
+  toleranceSeconds?: number;
+  nowSeconds?: number;
+}): boolean => {
+  const {
+    secret,
+    payload,
+    signatureHeader,
+    timestampHeader,
+    toleranceSeconds = 300,
+  } = opts;
+  if (!signatureHeader || !timestampHeader) {
+    return false;
+  }
+
+  const timestamp = Number(timestampHeader);
+  if (!Number.isFinite(timestamp)) {
+    return false;
+  }
+
+  const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000);
+  if (Math.abs(now - timestamp) > toleranceSeconds) {
+    return false; // outside the tolerance window → treat as replay/stale
+  }
+
+  // header form: "v1=<hex>"; be lenient about a missing scheme prefix.
+  const provided = signatureHeader.startsWith("v1=")
+    ? signatureHeader.slice(3)
+    : signatureHeader;
+  const expected = computeSignature(secret, payload, timestamp);
+  return safeHexEqual(provided, expected);
+};

--- a/src/lib/webhooks/trigger.ts
+++ b/src/lib/webhooks/trigger.ts
@@ -2,6 +2,13 @@ import { getDb } from "../db/db-connection";
 import { webhooks } from "../db/schema/webhooks";
 import { and, eq } from "drizzle-orm";
 import { fetchWithSsrfGuard, SsrfBlockedError } from "../utils/url-guard";
+import { decryptAes } from "../crypt/aes";
+import {
+  buildSignatureHeaders,
+  DELIVERY_HEADER,
+  EVENT_HEADER,
+} from "./signature";
+import { randomUUID } from "node:crypto";
 
 export interface WebhookTriggerOptions {
   payload?: any;
@@ -18,32 +25,51 @@ export class WebhookTriggerError extends Error {
 }
 
 /**
- * Trigger a webhook by its ID
+ * Trigger a webhook by its ID (manual / on-demand delivery).
+ *
+ * Unlike the event dispatcher this sends synchronously and returns the receiver
+ * response, but it uses the SAME authentication scheme: when the webhook is set
+ * to HMAC auth the body is signed so the receiver can verify the origin.
  */
 export const triggerWebhook = async (
   webhookId: string,
   tenantId: string,
   options: WebhookTriggerOptions = {}
 ) => {
-  // Get webhook details
+  // Get webhook details (scoped to the tenant; any event/type is triggerable)
   const webhook = await getDb().query.webhooks.findFirst({
-    where: and(
-      eq(webhooks.id, webhookId),
-      eq(webhooks.tenantId, tenantId),
-      eq(webhooks.event, "chat-output")
-    ),
+    where: and(eq(webhooks.id, webhookId), eq(webhooks.tenantId, tenantId)),
   });
 
   if (!webhook) {
     throw new WebhookTriggerError("Webhook not found", 404);
   }
 
+  const rawBody =
+    webhook.method !== "GET" ? JSON.stringify(options.payload ?? {}) : undefined;
+
   // Prepare headers
-  const headers = {
+  const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    ...(webhook.headers || {}),
+    [EVENT_HEADER]: webhook.event,
+    [DELIVERY_HEADER]: randomUUID(),
+    ...((webhook.headers as Record<string, string>) || {}),
     ...(options.headers || {}),
   };
+
+  // Sign the body when the webhook uses HMAC auth.
+  if (
+    webhook.authMode === "hmac" &&
+    webhook.signingSecret &&
+    rawBody !== undefined
+  ) {
+    const secret = decryptAes(
+      webhook.signingSecret,
+      "aes-256-cbc",
+      webhook.signingSecretKeyVersion ?? 1
+    ).value;
+    Object.assign(headers, buildSignatureHeaders(secret, rawBody));
+  }
 
   try {
     // SSRF guard: the webhook URL is operator/tenant supplied; ensure it cannot
@@ -51,10 +77,7 @@ export const triggerWebhook = async (
     const response = await fetchWithSsrfGuard(webhook.webhookUrl, {
       method: webhook.method,
       headers,
-      body:
-        webhook.method !== "GET"
-          ? JSON.stringify(options.payload || {})
-          : undefined,
+      body: rawBody,
     });
 
     if (!response.ok) {

--- a/src/routes/tenant/[tenantId]/webhooks/index.ts
+++ b/src/routes/tenant/[tenantId]/webhooks/index.ts
@@ -8,6 +8,7 @@ import {
   getAllUsersWebhooks,
   getWebhookById,
   updateWebhook,
+  toPublicWebhook,
 } from "../../../../lib/webhooks/crud";
 import {
   newWebhookSchema,
@@ -19,6 +20,12 @@ import {
   triggerWebhook,
   WebhookTriggerError,
 } from "../../../../lib/webhooks/trigger";
+import {
+  resolveWebhookEvent,
+  ALL_WEBHOOK_EVENTS,
+} from "../../../../lib/webhooks/events";
+import { generateSigningSecret } from "../../../../lib/webhooks/signature";
+import { encryptAes } from "../../../../lib/crypt/aes";
 import { describeRoute } from "hono-openapi";
 import { resolver, validator } from "hono-openapi";
 import { RESPONSES } from "../../../../lib/responses";
@@ -68,14 +75,46 @@ export default function defineWebhookRoutes(
         const parsed = c.req.valid("json");
         const { tenantId } = c.req.valid("param");
 
+        // Validate the event against the code-side registry and store its
+        // canonical name (accepts legacy/friendly aliases too).
+        const canonicalEvent = resolveWebhookEvent(parsed.event);
+        if (!canonicalEvent) {
+          throw new HTTPException(400, {
+            message: `Unknown webhook event "${parsed.event}". Known events: ${ALL_WEBHOOK_EVENTS.join(", ")}`,
+          });
+        }
+
+        // Auth: HMAC by default. When HMAC is used we generate a signing secret
+        // here, store it encrypted, and return it in CLEAR exactly once — it
+        // can never be read back later.
+        const authMode = parsed.authMode ?? "hmac";
+        let plaintextSecret: string | undefined;
+        let signingSecret: string | null = null;
+        let signingSecretKeyVersion: number | null = null;
+        if (authMode === "hmac") {
+          plaintextSecret = generateSigningSecret();
+          const enc = encryptAes(plaintextSecret);
+          signingSecret = enc.value;
+          signingSecretKeyVersion = enc.keyVersion;
+        }
+
         const webhook = await createWebhook(userId, {
           ...parsed,
+          event: canonicalEvent,
+          authMode,
+          signingSecret,
+          signingSecretKeyVersion,
           tenantId,
           userId,
         });
 
-        return c.json(webhook);
+        // Reveal the plaintext signing secret only on this create response.
+        return c.json({
+          ...toPublicWebhook(webhook),
+          ...(plaintextSecret ? { signingSecret: plaintextSecret } : {}),
+        });
       } catch (err) {
+        if (err instanceof HTTPException) throw err;
         throw new HTTPException(500, {
           message: "Error creating webhook: " + err,
         });
@@ -112,7 +151,7 @@ export default function defineWebhookRoutes(
         const userId = c.get("usersId");
         const { tenantId } = c.req.valid("param");
         const webhooks = await getAllUsersWebhooks(userId, tenantId);
-        return c.json(webhooks);
+        return c.json(webhooks.map(toPublicWebhook));
       } catch (err) {
         throw new HTTPException(500, {
           message: "Error getting webhooks: " + err,
@@ -150,7 +189,7 @@ export default function defineWebhookRoutes(
         const userId = c.get("usersId");
         const { tenantId } = c.req.valid("param");
         const webhooks = await getAllOrganisationWebhooks(tenantId);
-        return c.json(webhooks);
+        return c.json(webhooks.map(toPublicWebhook));
       } catch (err) {
         throw new HTTPException(500, {
           message: "Error getting webhooks: " + err,
@@ -194,7 +233,7 @@ export default function defineWebhookRoutes(
         if (!webhook) {
           throw new HTTPException(404, { message: "Webhook not found" });
         }
-        return c.json(webhook);
+        return c.json(toPublicWebhook(webhook));
       } catch (err) {
         if (err instanceof HTTPException) throw err;
         throw new HTTPException(500, {
@@ -237,11 +276,35 @@ export default function defineWebhookRoutes(
         const userId = c.get("usersId");
         const { id, tenantId } = c.req.valid("param");
         const parsed = c.req.valid("json");
-        const webhook = await updateWebhook(id, parsed, userId, tenantId);
+
+        // The signing secret is managed only via create / rotate-secret; never
+        // let an update overwrite it (that would corrupt the stored ciphertext).
+        const { signingSecret, signingSecretKeyVersion, ...updateInput } =
+          parsed as Record<string, unknown>;
+
+        // If the event is being changed, validate + canonicalize it.
+        if (updateInput.event !== undefined) {
+          const canonicalEvent = resolveWebhookEvent(
+            updateInput.event as string
+          );
+          if (!canonicalEvent) {
+            throw new HTTPException(400, {
+              message: `Unknown webhook event "${updateInput.event}". Known events: ${ALL_WEBHOOK_EVENTS.join(", ")}`,
+            });
+          }
+          updateInput.event = canonicalEvent;
+        }
+
+        const webhook = await updateWebhook(
+          id,
+          updateInput,
+          userId,
+          tenantId
+        );
         if (!webhook) {
           throw new HTTPException(404, { message: "Webhook not found" });
         }
-        return c.json(webhook);
+        return c.json(toPublicWebhook(webhook));
       } catch (err) {
         if (err instanceof HTTPException) throw err;
         throw new HTTPException(500, {
@@ -342,6 +405,26 @@ export default function defineWebhookRoutes(
             event: "chat-output" as const,
             webhookUrl: body.webhookUrl,
             tenantWide: body.tenantWide ?? false,
+            // n8n authenticates via its own webhook URL secret, not HMAC
+            authMode: "headers" as const,
+          };
+        } else if (
+          body.event === "knowledgeTextCreated" ||
+          body.event === "knowledgeTextUpdated" ||
+          body.event === "knowledgeTextDeleted"
+        ) {
+          // knowledge (wiki) page lifecycle events for n8n
+          const canonicalEvent = resolveWebhookEvent(body.event)!;
+          insertData = {
+            userId: userId,
+            tenantId,
+            name: body.name,
+            type: "n8n" as const,
+            event: canonicalEvent,
+            webhookUrl: body.webhookUrl,
+            tenantWide: body.tenantWide ?? false,
+            meta: body.meta ?? {},
+            authMode: "headers" as const,
           };
         } else if (body.event === "tool") {
           const data = {
@@ -465,6 +548,75 @@ export default function defineWebhookRoutes(
         }
         throw new HTTPException(500, {
           message: "Error triggering webhook: " + err,
+        });
+      }
+    }
+  );
+
+  /**
+   * Rotate the HMAC signing secret of a webhook.
+   *
+   * Generates a fresh secret, stores it encrypted, switches the webhook to
+   * HMAC auth, and returns the new secret in CLEAR exactly once. Any receiver
+   * verifying signatures must be updated with the returned value.
+   */
+  app.post(
+    API_BASE_PATH + "/tenant/:tenantId/webhooks/:id/rotate-secret",
+    authAndSetUsersInfo,
+    isTenantMember,
+    describeRoute({
+      tags: ["webhooks"],
+      summary: "Rotate a webhook's HMAC signing secret",
+      responses: {
+        200: {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: resolver(
+                v.object({ id: v.string(), signingSecret: v.string() })
+              ),
+            },
+          },
+        },
+      },
+    }),
+    validateScope("webhooks:write"),
+    validator(
+      "param",
+      v.object({ id: v.string(), tenantId: v.string() })
+    ),
+    async (c) => {
+      try {
+        const userId = c.get("usersId");
+        const { id, tenantId } = c.req.valid("param");
+
+        const existing = await getWebhookById(id, userId, tenantId);
+        if (!existing) {
+          throw new HTTPException(404, { message: "Webhook not found" });
+        }
+
+        const plaintextSecret = generateSigningSecret();
+        const enc = encryptAes(plaintextSecret);
+
+        const updated = await updateWebhook(
+          id,
+          {
+            authMode: "hmac",
+            signingSecret: enc.value,
+            signingSecretKeyVersion: enc.keyVersion,
+          },
+          userId,
+          tenantId
+        );
+        if (!updated) {
+          throw new HTTPException(404, { message: "Webhook not found" });
+        }
+
+        return c.json({ id, signingSecret: plaintextSecret });
+      } catch (err) {
+        if (err instanceof HTTPException) throw err;
+        throw new HTTPException(500, {
+          message: "Error rotating webhook secret: " + err,
         });
       }
     }


### PR DESCRIPTION
## Summary

Adds a generic, agnostic outgoing-webhook system on top of the existing `webhooks` table and wires the first producer: **`knowledge_text` (wiki page) lifecycle events**.

> Re-opened cleanly on top of the current `develop`. The previous PR (#74) was merged but its webhook files were subsequently overwritten by later merges to `develop`, so this branch re-applies the change on top of the latest `develop` (new migration renumbered to `0032`).

Design goals: optional (no subscription → nothing fires), one-or-many receiver URLs (one webhook row per URL), and a modern origin-authentication scheme — kept agnostic so more events can reuse it with a one-line `dispatchEvent(...)` call. n8n stays the primary consumer.

## Infrastructure (`src/lib/webhooks/`)

- **`events.ts`** — code-side event registry; the `event` column is widened from a pgEnum to `text`, so a new event is a registry entry, **not a migration**. Legacy `chat-output` and camelCase n8n aliases keep resolving.
- **`signature.ts`** — HMAC-SHA256 request signing (Stripe/GitHub scheme) over a timestamped payload (`X-Symbiosika-Signature: v1=…`, `X-Symbiosika-Timestamp`), constant-time verify, ±5 min replay window. The signing secret is generated once, returned in clear exactly once, and stored **AES-encrypted** — it never travels on read paths or the wire.
- **`dispatch.ts`** — `dispatchEvent(tenant, event, data)` enqueues one async delivery job per subscribed, enabled webhook (tenant-wide or acting-user). Never throws, so emitting an event can't break the primary operation.
- **`delivery-job.ts`** — background delivery via the job queue: SSRF guard, timeout, exponential-backoff retry on 5xx/network errors, no retry on 4xx.
- **schema** — new columns `enabled`, `auth_mode` (`hmac`|`headers`|`none`), `signing_secret` (+ key version). Read endpoints mask the secret; new `rotate-secret` route; events validated against the registry. Migration `0032` (enum → text, new columns, backfill existing rows to `headers`).

## knowledge_text integration (choke-point module)

- **`knowledge-text-events.ts`** centralises payload build + dispatch. The payload **never includes the page text** (only id + metadata) and carries a `source` discriminator (`user` | `sync`).
- Emits `created` / `updated` / `deleted` from `createKnowledgeText`, `updateKnowledgeText`, `deleteKnowledgeText` and the block-editor save — always **after** the existing chunk/embedding pipeline runs, so that pipeline is untouched. Pure derived-state writes (AI summary regeneration, embedding-link bookkeeping) do not emit.
- The source-sync path forwards `source: "sync"`.

## n8n compatibility

Register flow is unchanged and gains `knowledgeText{Created,Updated,Deleted}` friendly event names; register-created webhooks use `headers` auth (n8n authenticates via its own webhook URL).

## Usage (new producer = one line)

```ts
import { dispatchEvent } from "@framework/lib/webhooks/dispatch";
await dispatchEvent(tenantId, "knowledge_text.updated", { id }, { source: "user" });
```

## Tests

New: signature (unit), dispatch, delivery-job (retry / no-retry / signature verification), knowledge_text lifecycle integration. Existing webhook route and knowledge pipeline tests remain green (77 passing across the touched/added areas). Migration generated and applied against PGlite locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DmTH6She4r4uTd4m8TETU

---
_Generated by [Claude Code](https://claude.ai/code/session_015DmTH6She4r4uTd4m8TETU)_