### PR TITLE
feat(ssrf): targeted SSRF_ALLOWED_HOSTS allowlist for internal webhook targets

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -116,3 +116,16 @@ SMTP_PASS=
 # TLS
 # TLS_CERT_PATH=/usr/src/app/certs/server.crt
 # TLS_KEY_PATH=/usr/src/app/certs/server.key
+# SSRF guard for server-side fetches (outgoing webhooks, URL knowledge import).
+# By default the guard blocks targets that resolve to private/internal
+# addresses (loopback, RFC1918, link-local incl. cloud metadata).
+#
+# SSRF_ALLOW_PRIVATE_TARGETS=true disables the internal-address check for ALL
+# outgoing requests — only for fully trusted, single-tenant deployments.
+# SSRF_ALLOW_PRIVATE_TARGETS=false
+#
+# SSRF_ALLOWED_HOSTS is the targeted alternative: a comma-separated allowlist of
+# specific internal targets to permit while everything else stays protected.
+# Entries may be a hostname, an IP literal, or an IPv4 CIDR, e.g.:
+#   SSRF_ALLOWED_HOSTS=n8n.internal.example.com,192.168.0.79,10.0.0.0/24
+# SSRF_ALLOWED_HOSTS=

--- a/src/lib/utils/url-guard.test.ts
+++ b/src/lib/utils/url-guard.test.ts
@@ -104,3 +104,59 @@ describe("assertPublicHttpUrl", () => {
     }
   });
 });
+
+describe("assertPublicHttpUrl with SSRF_ALLOWED_HOSTS", () => {
+  let saved: string | undefined;
+  beforeAll(() => {
+    saved = process.env.SSRF_ALLOWED_HOSTS;
+  });
+  afterAll(() => {
+    if (saved !== undefined) process.env.SSRF_ALLOWED_HOSTS = saved;
+    else delete process.env.SSRF_ALLOWED_HOSTS;
+  });
+
+  it("allows an explicitly allowlisted literal private IP", async () => {
+    process.env.SSRF_ALLOWED_HOSTS = "192.168.0.79";
+    try {
+      const url = await assertPublicHttpUrl("http://192.168.0.79/webhook");
+      expect(url.hostname).toBe("192.168.0.79");
+    } finally {
+      delete process.env.SSRF_ALLOWED_HOSTS;
+    }
+  });
+
+  it("allows a private IP inside an allowlisted CIDR but blocks outside it", async () => {
+    process.env.SSRF_ALLOWED_HOSTS = "192.168.0.0/24";
+    try {
+      const url = await assertPublicHttpUrl("http://192.168.0.79/hook");
+      expect(url.hostname).toBe("192.168.0.79");
+      // outside the /24 → still blocked
+      await expect(
+        assertPublicHttpUrl("http://192.168.1.5/hook")
+      ).rejects.toThrow(SsrfBlockedError);
+    } finally {
+      delete process.env.SSRF_ALLOWED_HOSTS;
+    }
+  });
+
+  it("allows an allowlisted hostname (bypassing the localhost block)", async () => {
+    process.env.SSRF_ALLOWED_HOSTS = "localhost";
+    try {
+      const url = await assertPublicHttpUrl("http://localhost:3000/hook");
+      expect(url.hostname).toBe("localhost");
+    } finally {
+      delete process.env.SSRF_ALLOWED_HOSTS;
+    }
+  });
+
+  it("does not allow private IPs that are not in the allowlist", async () => {
+    process.env.SSRF_ALLOWED_HOSTS = "192.168.0.79";
+    try {
+      await expect(
+        assertPublicHttpUrl("http://10.0.0.5/hook")
+      ).rejects.toThrow(SsrfBlockedError);
+    } finally {
+      delete process.env.SSRF_ALLOWED_HOSTS;
+    }
+  });
+});

--- a/src/lib/utils/url-guard.ts
+++ b/src/lib/utils/url-guard.ts
@@ -31,6 +31,63 @@ export class SsrfBlockedError extends Error {
 const allowPrivateTargets = () =>
   process.env.SSRF_ALLOW_PRIVATE_TARGETS === "true";
 
+/**
+ * Targeted allowlist for otherwise-blocked (private/internal) targets.
+ *
+ * Unlike the blunt SSRF_ALLOW_PRIVATE_TARGETS switch (which disables ALL
+ * internal-address protection for every server-side fetch), this lets an
+ * operator permit specific known-good internal targets — e.g. a self-hosted
+ * n8n on the private network — while every other host stays protected.
+ *
+ * SSRF_ALLOWED_HOSTS is a comma-separated list of entries, each one of:
+ *   - a hostname, e.g. `n8n.cereda-systems.de` (exact, case-insensitive) —
+ *     the operator explicitly trusts this host, so it is allowed regardless of
+ *     the (possibly private) address it resolves to,
+ *   - an IP literal, e.g. `192.168.0.79`,
+ *   - an IPv4 CIDR, e.g. `192.168.0.0/24`.
+ */
+interface SsrfAllowlist {
+  hostnames: Set<string>;
+  ips: Set<string>;
+  cidrs: { base: number; bits: number }[];
+}
+
+const parseAllowlist = (): SsrfAllowlist => {
+  const raw = process.env.SSRF_ALLOWED_HOSTS;
+  const allow: SsrfAllowlist = { hostnames: new Set(), ips: new Set(), cidrs: [] };
+  if (!raw) return allow;
+  for (const rawEntry of raw.split(",")) {
+    const entry = rawEntry.trim().toLowerCase();
+    if (!entry) continue;
+    if (entry.includes("/")) {
+      // IPv4 CIDR (e.g. 192.168.0.0/24)
+      const [base, bitsStr] = entry.split("/");
+      const baseInt = ipv4ToInt(base ?? "");
+      const bits = Number(bitsStr);
+      if (baseInt !== null && Number.isInteger(bits) && bits >= 0 && bits <= 32) {
+        allow.cidrs.push({ base: baseInt, bits });
+      }
+    } else if (/^[0-9.]+$/.test(entry) || entry.includes(":")) {
+      allow.ips.add(entry);
+    } else {
+      allow.hostnames.add(entry);
+    }
+  }
+  return allow;
+};
+
+/** True when a literal IP is explicitly allowlisted (exact IP or IPv4 CIDR). */
+const isAllowlistedAddress = (ip: string, allow: SsrfAllowlist): boolean => {
+  const addr = ip.toLowerCase();
+  if (allow.ips.has(addr)) return true;
+  const v = ipv4ToInt(addr);
+  if (v === null) return false; // CIDR allowlist is IPv4-only
+  return allow.cidrs.some(({ base, bits }) => {
+    const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+    return (v & mask) === (base & mask);
+  });
+};
+
 const ipv4ToInt = (ip: string): number | null => {
   const parts = ip.split(".");
   if (parts.length !== 4) return null;
@@ -108,6 +165,14 @@ export const assertPublicHttpUrl = async (rawUrl: string): Promise<URL> => {
   }
 
   const host = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+
+  // Targeted allowlist: an explicitly trusted hostname is allowed regardless
+  // of the (possibly private) address it resolves to.
+  const allow = parseAllowlist();
+  if (allow.hostnames.has(host)) {
+    return url;
+  }
+
   if (host === "localhost" || host.endsWith(".localhost")) {
     throw new SsrfBlockedError("Blocked host: localhost");
   }
@@ -116,7 +181,7 @@ export const assertPublicHttpUrl = async (rawUrl: string): Promise<URL> => {
   // all addresses and ensure none are internal.
   const looksLikeIp = /^[0-9.]+$/.test(host) || host.includes(":");
   if (looksLikeIp) {
-    if (isBlockedAddress(host)) {
+    if (isBlockedAddress(host) && !isAllowlistedAddress(host, allow)) {
       throw new SsrfBlockedError(`Blocked address: ${host}`);
     }
     return url;
@@ -132,7 +197,7 @@ export const assertPublicHttpUrl = async (rawUrl: string): Promise<URL> => {
     throw new SsrfBlockedError(`Host did not resolve: ${host}`);
   }
   for (const { address } of resolved) {
-    if (isBlockedAddress(address)) {
+    if (isBlockedAddress(address) && !isAllowlistedAddress(address, allow)) {
       throw new SsrfBlockedError(
         `Host ${host} resolves to a blocked address (${address})`
       );


### PR DESCRIPTION
## Problem (production)

Outgoing webhook delivery to a self-hosted n8n on the private network fails permanently:

```
Webhook URL not allowed: Host n8n.cereda-systems.de resolves to a blocked address (192.168.0.79)
```

The SSRF guard blocks private/internal addresses by design. The only existing escape hatch, `SSRF_ALLOW_PRIVATE_TARGETS=true`, disables the internal-address check for **all** server-side fetches (webhooks **and** URL knowledge import) — too broad when webhook/import URLs are user-supplied.

## Change

Add **`SSRF_ALLOWED_HOSTS`** — a comma-separated allowlist of specific trusted internal targets that are permitted even when they resolve to a private address, while every other host stays protected. Entries may be:

- a **hostname** (exact, case-insensitive) — trusted regardless of the address it resolves to, e.g. `n8n.cereda-systems.de`
- an **IP literal**, e.g. `192.168.0.79`
- an **IPv4 CIDR**, e.g. `192.168.0.0/24`

The blunt `SSRF_ALLOW_PRIVATE_TARGETS` switch is unchanged. Documented in `.env.default`.

## Fix for the reported case

Set on the prod environment:

```
SSRF_ALLOWED_HOSTS=n8n.cereda-systems.de
```

(or the IP/CIDR `192.168.0.79` / `192.168.0.0/24`). New deliveries then succeed; the SSRF guard keeps protecting every other target.

## Tests

`url-guard.test.ts` extended: allowlisted literal IP, CIDR in-range allowed / out-of-range blocked, hostname bypass of the localhost block, and a non-allowlisted private IP still blocked.

## Note

A blocked delivery is treated as permanent (no retry), so the already-failed jobs won't re-run — but future events deliver once the env var is set. Existing failed pages can be re-saved/re-triggered if immediate redelivery is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DmTH6She4r4uTd4m8TETU

---
_Generated by [Claude Code](https://claude.ai/code/session_015DmTH6She4r4uTd4m8TETU)_