### PR TITLE
Improve AI structured output reliability with fallback salvaging

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -68,6 +68,10 @@ POSTGRES_DB=dev
 # OPENROUTER_MODEL=mistralai/mistral-large
 # OPENROUTER_REFERER=            # optional attribution header
 # OPENROUTER_TITLE=              # optional attribution header
+#    Structured outputs (response_format: json_schema) are requested by default
+#    so schema-bound generation (generateObject) transmits its schema. Set to
+#    "false" only if the chosen model rejects json_schema requests.
+# OPENROUTER_STRUCTURED_OUTPUTS=true
 # -- Optional cheaper model for knowledge page summaries. When unset, the
 #    provider's default model is used. The summary task is trivial, so a small
 #    model is recommended.

--- a/src/lib/ai/ai.test.ts
+++ b/src/lib/ai/ai.test.ts
@@ -6,6 +6,7 @@ import {
   getModel,
   generateText,
   generateStructured,
+  salvageStructuredText,
   AiNotConfiguredError,
 } from "./index";
 import { AI_PROVIDER } from "./types";
@@ -21,12 +22,15 @@ const ORIGINAL_ENV = {
   AI_PROVIDER: process.env.AI_PROVIDER,
   MISTRAL_API_KEY: process.env.MISTRAL_API_KEY,
   OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+  OPENROUTER_STRUCTURED_OUTPUTS: process.env.OPENROUTER_STRUCTURED_OUTPUTS,
 };
 
 afterEach(() => {
   process.env.AI_PROVIDER = ORIGINAL_ENV.AI_PROVIDER;
   process.env.MISTRAL_API_KEY = ORIGINAL_ENV.MISTRAL_API_KEY;
   process.env.OPENROUTER_API_KEY = ORIGINAL_ENV.OPENROUTER_API_KEY;
+  process.env.OPENROUTER_STRUCTURED_OUTPUTS =
+    ORIGINAL_ENV.OPENROUTER_STRUCTURED_OUTPUTS;
 });
 
 describe("AI provider layer", () => {
@@ -82,5 +86,56 @@ describe("AI provider layer", () => {
         prompt: "p",
       })
     ).rejects.toBeInstanceOf(AiNotConfiguredError);
+  });
+
+  test("openrouter models request structured outputs by default", () => {
+    process.env.AI_PROVIDER = AI_PROVIDER.OPENROUTER;
+    process.env.OPENROUTER_API_KEY = "sk-or-test";
+    delete process.env.OPENROUTER_STRUCTURED_OUTPUTS;
+
+    const model = getStandardModel() as { supportsStructuredOutputs?: boolean };
+    expect(model?.supportsStructuredOutputs).toBe(true);
+  });
+
+  test("OPENROUTER_STRUCTURED_OUTPUTS=false disables structured outputs", () => {
+    process.env.AI_PROVIDER = AI_PROVIDER.OPENROUTER;
+    process.env.OPENROUTER_API_KEY = "sk-or-test";
+    process.env.OPENROUTER_STRUCTURED_OUTPUTS = "false";
+
+    const model = getStandardModel() as { supportsStructuredOutputs?: boolean };
+    expect(model?.supportsStructuredOutputs).toBe(false);
+  });
+});
+
+describe("salvageStructuredText", () => {
+  const schema = v.object({ summary: v.string() });
+
+  test("parses plain JSON", () => {
+    expect(
+      salvageStructuredText(schema, '{"summary": "A page about X."}')
+    ).toEqual({ summary: "A page about X." });
+  });
+
+  test("parses JSON inside a fenced code block", () => {
+    const text = 'Here you go:\n```json\n{"summary": "Fenced."}\n```\nDone.';
+    expect(salvageStructuredText(schema, text)).toEqual({
+      summary: "Fenced.",
+    });
+  });
+
+  test("parses JSON surrounded by prose", () => {
+    const text = 'Sure! {"summary": "Embedded."} Hope that helps.';
+    expect(salvageStructuredText(schema, text)).toEqual({
+      summary: "Embedded.",
+    });
+  });
+
+  test("rejects JSON that does not match the schema", () => {
+    expect(salvageStructuredText(schema, '{"other": 1}')).toBeNull();
+  });
+
+  test("returns null for non-JSON text or missing text", () => {
+    expect(salvageStructuredText(schema, "no json here")).toBeNull();
+    expect(salvageStructuredText(schema, undefined)).toBeNull();
   });
 });

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -23,9 +23,11 @@
 import {
   generateText as aiGenerateText,
   generateObject,
+  NoObjectGeneratedError,
   type LanguageModel,
 } from "ai";
 import { valibotSchema } from "@ai-sdk/valibot";
+import * as v from "valibot";
 import type { GenericSchema } from "valibot";
 import log from "../log";
 import {
@@ -116,8 +118,41 @@ export const generateText = async (params: {
 };
 
 /**
+ * Last-resort recovery when `generateObject` rejects a response: models that
+ * lack schema-enforced outputs often return the right JSON wrapped in a code
+ * fence or with stray text around it. Extract the JSON and validate it against
+ * the same schema — never returns anything the schema did not accept.
+ */
+export const salvageStructuredText = <T>(
+  schema: GenericSchema<T>,
+  text: string | undefined
+): T | null => {
+  if (!text) return null;
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1];
+  const candidates = [text, fenced].filter(
+    (c): c is string => typeof c === "string"
+  );
+  // Also try the outermost {...} span for output with surrounding prose.
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start !== -1 && end > start) candidates.push(text.slice(start, end + 1));
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = v.parse(schema, JSON.parse(candidate.trim()));
+      return parsed;
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+};
+
+/**
  * Generate a structured object from the model using a valibot schema. The AI
  * SDK forces the model to produce output matching the schema and validates it.
+ * If the model's response is rejected but contains recognizable JSON (e.g. a
+ * fenced code block), it is salvaged and re-validated before giving up.
  */
 export const generateStructured = async <T>(params: {
   schema: GenericSchema<T>;
@@ -127,13 +162,26 @@ export const generateStructured = async <T>(params: {
   model?: string;
 }): Promise<T> => {
   const model = requireModel(params.model);
-  const { object } = await generateObject({
-    model,
-    schema: valibotSchema(params.schema),
-    system: params.system,
-    prompt: params.prompt,
-  });
-  return object as T;
+  try {
+    const { object } = await generateObject({
+      model,
+      schema: valibotSchema(params.schema),
+      system: params.system,
+      prompt: params.prompt,
+    });
+    return object as T;
+  } catch (error) {
+    if (NoObjectGeneratedError.isInstance(error)) {
+      const salvaged = salvageStructuredText(params.schema, error.text);
+      if (salvaged !== null) {
+        log.debug(
+          "generateStructured: salvaged schema-valid JSON from a rejected model response"
+        );
+        return salvaged;
+      }
+    }
+    throw error;
+  }
 };
 
 /** Log the resolved AI configuration once at startup (no secrets). */

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -38,6 +38,18 @@ const openRouterHeaders = (): Record<string, string> => {
   return headers;
 };
 
+/**
+ * Whether OpenRouter chat models are asked for schema-enforced structured
+ * outputs (`response_format: json_schema`). Without this the AI SDK cannot
+ * transmit the schema of a `generateObject` call at all (the request is
+ * downgraded to plain JSON mode and the model never sees the expected shape,
+ * which then fails validation with `AI_NoObjectGeneratedError`). OpenRouter
+ * routes such requests only to backends that support structured outputs.
+ * Set OPENROUTER_STRUCTURED_OUTPUTS=false for models that reject json_schema.
+ */
+const openRouterStructuredOutputs = (): boolean =>
+  process.env.OPENROUTER_STRUCTURED_OUTPUTS !== "false";
+
 /** Build a fresh OpenRouter provider from the current environment. */
 const openRouterProvider = () =>
   createOpenAICompatible({
@@ -45,6 +57,7 @@ const openRouterProvider = () =>
     baseURL: OPENROUTER_BASE_URL,
     apiKey: process.env.OPENROUTER_API_KEY ?? "",
     headers: openRouterHeaders(),
+    supportsStructuredOutputs: openRouterStructuredOutputs(),
   });
 
 // --- Configuration checks ---------------------------------------------------

--- a/src/lib/knowledge/entry-summaries.ts
+++ b/src/lib/knowledge/entry-summaries.ts
@@ -2,8 +2,10 @@
  * AI description for RAG knowledge entries (`knowledge_entry.description`).
  *
  * Replaces the long-disabled summary code in add-knowledge.ts. Generation goes
- * through the central AI layer (`generateStructured`), so it uses the globally
- * configured text provider — no separate provider wiring.
+ * through the central AI layer (`generateText`), so it uses the globally
+ * configured text provider — no separate provider wiring. The result is a
+ * single free-text paragraph, so plain text generation is used instead of
+ * structured output (which not every model supports reliably).
  *
  * Behaviour:
  *   - gated on `isAiEnabled()`: without a configured global LLM the ingestion
@@ -14,8 +16,7 @@
  *     call, so the cost per document is bounded regardless of its length.
  */
 
-import * as v from "valibot";
-import { generateStructured, isAiEnabled } from "../ai";
+import { generateText, isAiEnabled } from "../ai";
 import log from "../log";
 
 /** Above this full-text length the LLM gets a chunk excerpt, not full text. */
@@ -27,22 +28,16 @@ const CHUNK_LEAD_LENGTH = 300;
 /** DB check constraint: length(description) <= 10000. */
 const MAX_DESCRIPTION_LENGTH = 10_000;
 
-const DESCRIPTION_SCHEMA = v.object({
-  description: v.pipe(
-    v.string(),
-    v.description(
-      "A short, factual description (3-5 sentences) of what this document " +
-        "contains and what questions it can answer. No preamble."
-    )
-  ),
-});
-
 const DESCRIPTION_SYSTEM_PROMPT =
   "You write terse catalog descriptions for documents in a knowledge base. " +
   "Given a document (or an excerpt of a long one), respond with a 3-5 " +
   "sentence description of what the document contains and what questions it " +
   "can answer. Be concrete and specific; name the topic. Do not start with " +
-  "'This document'. Write in the document's language.";
+  "'This document'. Write in the document's language. Respond with the " +
+  "description text only — no preamble, no quotes, no markdown.";
+
+/** Token cap for the generated description (3-5 sentences, bounds cost). */
+const DESCRIPTION_MAX_OUTPUT_TOKENS = 500;
 
 type SummaryChunk = { text: string; header?: string | null };
 
@@ -92,8 +87,7 @@ export const generateEntryDescription = async (params: {
   if (params.fullText.trim().length === 0) return undefined;
 
   try {
-    const { description } = await generateStructured({
-      schema: DESCRIPTION_SCHEMA,
+    const description = await generateText({
       system: params.customPrompt ?? DESCRIPTION_SYSTEM_PROMPT,
       prompt: buildEntryDescriptionInput(
         params.title,
@@ -101,6 +95,8 @@ export const generateEntryDescription = async (params: {
         params.chunks
       ),
       model: params.model || undefined,
+      maxOutputTokens: DESCRIPTION_MAX_OUTPUT_TOKENS,
+      temperature: 0.2,
     });
     return description.trim().slice(0, MAX_DESCRIPTION_LENGTH);
   } catch (error) {

--- a/src/lib/knowledge/summaries.ts
+++ b/src/lib/knowledge/summaries.ts
@@ -25,7 +25,6 @@
  */
 
 import { and, eq, isNull, lte, sql, inArray } from "drizzle-orm";
-import * as v from "valibot";
 import { getDb } from "../db/db-connection";
 import { knowledgeText } from "../db/schema/knowledge";
 import type { KnowledgeTextSelect } from "../db/schema/knowledge";
@@ -33,7 +32,7 @@ import { jobs } from "../db/schema/jobs";
 import { createJob } from "../jobs";
 import type { JobHandlerRegister } from "../jobs";
 import { computeSourceHash } from "./source-hash";
-import { generateStructured, isAiEnabled } from "../ai";
+import { generateText, isAiEnabled } from "../ai";
 import { getAppSpecificData } from "../specific-data";
 import { getKnowledgeTenantConfig } from "./knowledge-config";
 import log from "../log";
@@ -127,24 +126,20 @@ export const buildSummaryInput = (title: string, text: string): string => {
   return parts.join("\n").slice(0, INPUT_BUDGET);
 };
 
-const SUMMARY_SCHEMA = v.object({
-  summary: v.pipe(
-    v.string(),
-    v.description(
-      "A 1-2 sentence, factual description of what this knowledge page is about, " +
-        "so a reader can tell it apart from similar pages. No preamble."
-    )
-  ),
-});
-
 const SUMMARY_SYSTEM_PROMPT =
   "You write terse catalog descriptions for knowledge base pages. Given a page, respond " +
   "with a single 1-2 sentence summary of what the page is about and what a " +
   "reader would find on it. Be concrete and specific; name the topic. Do not " +
-  "start with 'This page' or 'This document'. Write in the page's language.";
+  "start with 'This page' or 'This document'. Write in the page's language. " +
+  "Respond with the summary text only — no preamble, no quotes, no markdown.";
+
+/** Token cap for the generated summary (1-2 sentences, keeps cost bounded). */
+const SUMMARY_MAX_OUTPUT_TOKENS = 200;
 
 /**
- * Generate a fresh summary string for a page via the configured LLM.
+ * Generate a fresh summary string for a page via the configured LLM. Plain
+ * text generation — the result is a single free-text sentence, so no JSON /
+ * structured output is needed (which not every model supports reliably).
  * Assumes `isAiEnabled()` was already checked by the caller.
  */
 export const generatePageSummary = async (page: {
@@ -152,11 +147,12 @@ export const generatePageSummary = async (page: {
   text: string;
 }): Promise<string> => {
   const input = buildSummaryInput(page.title, page.text);
-  const { summary } = await generateStructured({
-    schema: SUMMARY_SCHEMA,
+  const summary = await generateText({
     system: SUMMARY_SYSTEM_PROMPT,
     prompt: input,
     model: summaryModelId(),
+    maxOutputTokens: SUMMARY_MAX_OUTPUT_TOKENS,
+    temperature: 0.2,
   });
   return summary.trim();
 };


### PR DESCRIPTION
## Summary
This PR improves the reliability of structured output generation by adding a fallback mechanism to salvage valid JSON from rejected model responses, and switches knowledge entry summaries from structured to plain text generation for better compatibility.

## Key Changes

- **Added `salvageStructuredText()` function**: A recovery mechanism that extracts JSON from model responses that fail schema validation. It attempts to parse JSON from multiple sources (plain text, fenced code blocks, and outermost `{...}` spans) and validates against the provided schema before returning.

- **Enhanced `generateStructured()` error handling**: Now catches `NoObjectGeneratedError` and attempts to salvage valid JSON from the error's text content before re-throwing, with debug logging when successful.

- **Switched knowledge summaries to plain text generation**: 
  - `generateEntryDescription()` now uses `generateText()` instead of `generateStructured()`
  - `generatePageSummary()` now uses `generateText()` instead of `generateStructured()`
  - Updated system prompts to explicitly request text-only output (no preamble, quotes, or markdown)
  - Added `maxOutputTokens` and `temperature` parameters for better cost control and consistency

- **OpenRouter structured outputs configuration**:
  - Added `OPENROUTER_STRUCTURED_OUTPUTS` environment variable (defaults to `true`)
  - Implemented `openRouterStructuredOutputs()` to control whether the OpenRouter provider requests schema-enforced outputs
  - Updated provider initialization to pass `supportsStructuredOutputs` flag
  - Added documentation explaining why this is needed for `generateObject` to transmit schemas

- **Comprehensive test coverage**: Added tests for `salvageStructuredText()` covering plain JSON, fenced code blocks, embedded JSON, schema validation, and edge cases. Also added tests for OpenRouter structured outputs configuration.

## Implementation Details

The salvage mechanism prioritizes candidates in order: original text, fenced code block content, and outermost JSON object span. This handles common patterns where models wrap JSON in markdown or include surrounding prose.

The switch to plain text generation for summaries is motivated by improved model compatibility—not all models reliably support structured outputs, while plain text generation is universally supported. The salvage mechanism provides a safety net for cases where structured output is still needed.

https://claude.ai/code/session_01YWfD3s7gifjBRK6e9Y2cEs