### PR TITLE
Add wiki path (breadcrumb) to knowledge retrieval results

### DIFF
--- a/docs/framework/6_BuildIn_AI_Knowledge.md
+++ b/docs/framework/6_BuildIn_AI_Knowledge.md
@@ -173,7 +173,7 @@ Content-Type: application/json
 For knowledge that originates from **wiki pages** (`knowledgeText`, organized in
 a tree via `parentId`), retrieval responses include the page's **path** — the
 slash-separated breadcrumb of ancestor titles, e.g.
-`"Handbook / HR / Vacation Policy"`. This tells an AI agent *where* a chunk
+`"Handbook/HR/Vacation Policy"`. This tells an AI agent *where* a chunk
 lives, not just its bare title, which is valuable context for reasoning and
 citation.
 

--- a/docs/framework/6_BuildIn_AI_Knowledge.md
+++ b/docs/framework/6_BuildIn_AI_Knowledge.md
@@ -168,6 +168,29 @@ Content-Type: application/json
 }
 ```
 
+### Source path (wiki breadcrumb) in retrieval results
+
+For knowledge that originates from **wiki pages** (`knowledgeText`, organized in
+a tree via `parentId`), retrieval responses include the page's **path** — the
+slash-separated breadcrumb of ancestor titles, e.g.
+`"Handbook / HR / Vacation Policy"`. This tells an AI agent *where* a chunk
+lives, not just its bare title, which is valuable context for reasoning and
+citation.
+
+The path is present on:
+
+- **Wiki page search** (`GET .../knowledge/texts/search`): each hit carries
+  `path` (string) and `pathIds` (segment ids, root first).
+- **Chunk context** (`GET .../knowledge/texts/:id/chunk-context`): the response
+  carries the page's `path` / `pathIds`.
+- **RAG similarity search** (`POST .../knowledge/similarity-search`): each chunk
+  carries `knowledgeTextId`, `path` and `pathIds` when the underlying entry was
+  mirrored from a wiki page; these are `null` / `[]` for plain (non-wiki) RAG
+  documents.
+
+The path is derived on the fly from the page's `parentId` chain — there is no
+stored path column, so moving a page in the tree updates its path automatically.
+
 ### 2. Using Prompt Templates
 
 Prompt templates can be configured to always include knowledge from specific groups or with certain filters. This allows you to create specialized chat behaviors (e.g., always answer with knowledge from the "Support FAQ" group).

--- a/src/api/knowledge.ts
+++ b/src/api/knowledge.ts
@@ -10,3 +10,9 @@ export {
   getFullSourceDocumentsForSimilaritySearch,
 } from "../lib/knowledge/similarity-search";
 export { createKnowledgeGroup } from "../lib/knowledge/knowledge-groups";
+export {
+  resolveKnowledgeTextPath,
+  resolveKnowledgeTextPaths,
+  type KnowledgeTextPath,
+  type KnowledgeTextPathSegment,
+} from "../lib/knowledge/knowledge-text-path";

--- a/src/lib/knowledge/knowledge-text-chunks.ts
+++ b/src/lib/knowledge/knowledge-text-chunks.ts
@@ -11,6 +11,7 @@ import { and, asc, eq, gte, lte, sql } from "drizzle-orm";
 import { getDb } from "../db/db-connection";
 import { knowledgeChunks } from "../db/schema/knowledge";
 import { getKnowledgeTextById } from "./knowledge-texts";
+import { resolveKnowledgeTextPath } from "./knowledge-text-path";
 
 type Context = {
   tenantId: string;
@@ -33,6 +34,14 @@ export type PageChunkContextItem = {
 export type PageChunkContext = {
   pageId: string;
   title: string;
+  /**
+   * Wiki path of the page, root first, titles joined by " / " (the last
+   * segment is the page itself). Empty string for a top-level page. Tells an
+   * agent where the surrounding chunks live in the tree.
+   */
+  path: string;
+  /** the ids of the path segments, root first (parallel to `path`) */
+  pathIds: string[];
   /** total chunk count of the page (bounds for the agent; 0 = not embedded) */
   totalChunks: number;
   chunks: PageChunkContextItem[];
@@ -49,7 +58,13 @@ export const getPageChunkContext = async (
 ): Promise<PageChunkContext> => {
   // permission check + resolve the linked knowledge_entry (throws if invisible)
   const page = await getKnowledgeTextById(pageId, context);
-  const base = { pageId: page.id, title: page.title };
+  const pagePath = await resolveKnowledgeTextPath(page.id, context.tenantId);
+  const base = {
+    pageId: page.id,
+    title: page.title,
+    path: pagePath?.path ?? "",
+    pathIds: pagePath?.pathIds ?? [],
+  };
 
   if (!page.knowledgeEntryId) {
     // page without embeddings: no chunks exist

--- a/src/lib/knowledge/knowledge-text-chunks.ts
+++ b/src/lib/knowledge/knowledge-text-chunks.ts
@@ -35,7 +35,7 @@ export type PageChunkContext = {
   pageId: string;
   title: string;
   /**
-   * Wiki path of the page, root first, titles joined by " / " (the last
+   * Wiki path of the page, root first, titles joined by "/" (the last
    * segment is the page itself). Empty string for a top-level page. Tells an
    * agent where the surrounding chunks live in the tree.
    */

--- a/src/lib/knowledge/knowledge-text-path.test.ts
+++ b/src/lib/knowledge/knowledge-text-path.test.ts
@@ -1,0 +1,264 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
+import { getDb } from "../db/db-connection";
+import { knowledgeEntry, knowledgeChunks } from "../db/schema/knowledge";
+import { createKnowledgeText, updateKnowledgeText } from "./knowledge-texts";
+import {
+  resolveKnowledgeTextPath,
+  resolveKnowledgeTextPaths,
+} from "./knowledge-text-path";
+import { getPageChunkContext } from "./knowledge-text-chunks";
+import { getNearestEmbeddings } from "./similarity-search";
+
+const TENANT = TEST_ORGANISATION_1.id;
+const ctx = { tenantId: TENANT };
+
+describe("resolveKnowledgeTextPaths", () => {
+  let rootId: string;
+  let hrId: string;
+  let vacationId: string;
+  let standaloneId: string;
+
+  beforeAll(async () => {
+    await initTests();
+
+    const root = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Handbook",
+      text: "root",
+    });
+    rootId = root.id;
+
+    const hr = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "HR",
+      text: "hr",
+      parentId: rootId,
+    });
+    hrId = hr.id;
+
+    const vacation = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Vacation Policy",
+      text: "vacation",
+      parentId: hrId,
+    });
+    vacationId = vacation.id;
+
+    const standalone = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Standalone",
+      text: "standalone",
+    });
+    standaloneId = standalone.id;
+  });
+
+  test("builds the full slash path root-first, including the page itself", async () => {
+    const path = await resolveKnowledgeTextPath(vacationId, TENANT);
+    expect(path).not.toBeNull();
+    expect(path!.path).toBe("Handbook / HR / Vacation Policy");
+    expect(path!.pathIds).toEqual([rootId, hrId, vacationId]);
+    expect(path!.pathSegments.map((s) => s.title)).toEqual([
+      "Handbook",
+      "HR",
+      "Vacation Policy",
+    ]);
+  });
+
+  test("a top-level page's path is just its own title", async () => {
+    const path = await resolveKnowledgeTextPath(rootId, TENANT);
+    expect(path!.path).toBe("Handbook");
+    expect(path!.pathIds).toEqual([rootId]);
+  });
+
+  test("includeSelf:false yields only the ancestor folders", async () => {
+    const path = await resolveKnowledgeTextPath(vacationId, TENANT, {
+      includeSelf: false,
+    });
+    expect(path!.path).toBe("Handbook / HR");
+    expect(path!.pathIds).toEqual([rootId, hrId]);
+  });
+
+  test("a top-level page has an empty ancestor path", async () => {
+    const path = await resolveKnowledgeTextPath(standaloneId, TENANT, {
+      includeSelf: false,
+    });
+    expect(path!.path).toBe("");
+    expect(path!.pathIds).toEqual([]);
+  });
+
+  test("custom separator is honoured", async () => {
+    const path = await resolveKnowledgeTextPath(vacationId, TENANT, {
+      separator: " > ",
+    });
+    expect(path!.path).toBe("Handbook > HR > Vacation Policy");
+  });
+
+  test("resolves many pages in one call, keyed by id", async () => {
+    const map = await resolveKnowledgeTextPaths(
+      [vacationId, hrId, standaloneId],
+      TENANT
+    );
+    expect(map.get(vacationId)!.path).toBe("Handbook / HR / Vacation Policy");
+    expect(map.get(hrId)!.path).toBe("Handbook / HR");
+    expect(map.get(standaloneId)!.path).toBe("Standalone");
+  });
+
+  test("unknown / cross-tenant ids are omitted from the result", async () => {
+    const map = await resolveKnowledgeTextPaths(
+      ["00000000-9999-9999-9999-000000000000", vacationId],
+      TENANT
+    );
+    expect(map.has("00000000-9999-9999-9999-000000000000")).toBe(false);
+    expect(map.has(vacationId)).toBe(true);
+  });
+});
+
+describe("getPageChunkContext surfaces the wiki path", () => {
+  let childId: string;
+
+  beforeAll(async () => {
+    await initTests();
+
+    const parent = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Docs",
+      text: "parent",
+    });
+
+    const child = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Nested Page",
+      text: "child",
+      parentId: parent.id,
+    });
+    childId = child.id;
+
+    const [entry] = await getDb()
+      .insert(knowledgeEntry)
+      .values({ tenantId: TENANT, name: "Nested Page entry" })
+      .returning();
+
+    const vec = new Array(1024).fill(0);
+    await getDb()
+      .insert(knowledgeChunks)
+      .values(
+        [0, 1].map((order) => ({
+          knowledgeEntryId: entry.id,
+          text: `chunk-${order}`,
+          order,
+          embeddingModel: "test",
+          dimensions: 1024,
+          textEmbedding1024: vec,
+        }))
+      );
+
+    // link the page to the mirrored RAG entry
+    await updateKnowledgeText(childId, { knowledgeEntryId: entry.id }, ctx);
+  });
+
+  test("returns the breadcrumb path of the page", async () => {
+    const result = await getPageChunkContext(childId, ctx, { order: 0 });
+    expect(result.path).toBe("Docs / Nested Page");
+    expect(result.pathIds.length).toBe(2);
+    expect(result.chunks.length).toBeGreaterThan(0);
+  });
+});
+
+describe("getNearestEmbeddings surfaces the source wiki path", () => {
+  let entryId: string;
+  let plainEntryId: string;
+
+  beforeAll(async () => {
+    await initTests();
+
+    // a wiki page mirrored into the RAG layer -> chunks carry its path
+    const parent = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Knowledge",
+      text: "parent",
+    });
+    const page = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Bees",
+      text: "page",
+      parentId: parent.id,
+    });
+
+    const [entry] = await getDb()
+      .insert(knowledgeEntry)
+      .values({ tenantId: TENANT, name: `Wiki mirror ${crypto.randomUUID()}` })
+      .returning();
+    entryId = entry!.id;
+    await getDb()
+      .insert(knowledgeChunks)
+      .values({
+        knowledgeEntryId: entryId,
+        text: "Worker bees visit millions of flowers to make honey.",
+        order: 0,
+        embeddingModel: "test",
+        dimensions: 1024,
+        textEmbedding1024: new Array(1024).fill(0),
+      });
+    await updateKnowledgeText(page.id, { knowledgeEntryId: entryId }, ctx);
+
+    // a plain RAG entry with no linked wiki page -> path is null
+    const [plain] = await getDb()
+      .insert(knowledgeEntry)
+      .values({ tenantId: TENANT, name: `Plain RAG ${crypto.randomUUID()}` })
+      .returning();
+    plainEntryId = plain!.id;
+    await getDb()
+      .insert(knowledgeChunks)
+      .values({
+        knowledgeEntryId: plainEntryId,
+        text: "Standalone honey document not part of the wiki tree.",
+        order: 0,
+        embeddingModel: "test",
+        dimensions: 1024,
+        textEmbedding1024: new Array(1024).fill(0),
+      });
+  });
+
+  test("chunk from a wiki page carries the page's breadcrumb path", async () => {
+    const previousProvider = process.env.EMBEDDING_PROVIDER;
+    process.env.EMBEDDING_PROVIDER = "__not-configured__";
+    try {
+      const results = await getNearestEmbeddings({
+        tenantId: TENANT,
+        searchText: "honey flowers bees",
+        n: 3,
+        filterKnowledgeEntryIds: [entryId],
+      });
+      expect(results.length).toBe(1);
+      expect(results[0]!.path).toBe("Knowledge / Bees");
+      expect(results[0]!.knowledgeTextId).not.toBeNull();
+      expect(results[0]!.pathIds.length).toBe(2);
+    } finally {
+      if (previousProvider === undefined)
+        delete process.env.EMBEDDING_PROVIDER;
+      else process.env.EMBEDDING_PROVIDER = previousProvider;
+    }
+  });
+
+  test("chunk from a plain RAG entry has a null path", async () => {
+    const previousProvider = process.env.EMBEDDING_PROVIDER;
+    process.env.EMBEDDING_PROVIDER = "__not-configured__";
+    try {
+      const results = await getNearestEmbeddings({
+        tenantId: TENANT,
+        searchText: "standalone honey document",
+        n: 3,
+        filterKnowledgeEntryIds: [plainEntryId],
+      });
+      expect(results.length).toBe(1);
+      expect(results[0]!.path).toBeNull();
+      expect(results[0]!.knowledgeTextId).toBeNull();
+      expect(results[0]!.pathIds).toEqual([]);
+    } finally {
+      if (previousProvider === undefined)
+        delete process.env.EMBEDDING_PROVIDER;
+      else process.env.EMBEDDING_PROVIDER = previousProvider;
+    }
+  });
+});

--- a/src/lib/knowledge/knowledge-text-path.test.ts
+++ b/src/lib/knowledge/knowledge-text-path.test.ts
@@ -56,7 +56,7 @@ describe("resolveKnowledgeTextPaths", () => {
   test("builds the full slash path root-first, including the page itself", async () => {
     const path = await resolveKnowledgeTextPath(vacationId, TENANT);
     expect(path).not.toBeNull();
-    expect(path!.path).toBe("Handbook / HR / Vacation Policy");
+    expect(path!.path).toBe("Handbook/HR/Vacation Policy");
     expect(path!.pathIds).toEqual([rootId, hrId, vacationId]);
     expect(path!.pathSegments.map((s) => s.title)).toEqual([
       "Handbook",
@@ -75,7 +75,7 @@ describe("resolveKnowledgeTextPaths", () => {
     const path = await resolveKnowledgeTextPath(vacationId, TENANT, {
       includeSelf: false,
     });
-    expect(path!.path).toBe("Handbook / HR");
+    expect(path!.path).toBe("Handbook/HR");
     expect(path!.pathIds).toEqual([rootId, hrId]);
   });
 
@@ -99,8 +99,8 @@ describe("resolveKnowledgeTextPaths", () => {
       [vacationId, hrId, standaloneId],
       TENANT
     );
-    expect(map.get(vacationId)!.path).toBe("Handbook / HR / Vacation Policy");
-    expect(map.get(hrId)!.path).toBe("Handbook / HR");
+    expect(map.get(vacationId)!.path).toBe("Handbook/HR/Vacation Policy");
+    expect(map.get(hrId)!.path).toBe("Handbook/HR");
     expect(map.get(standaloneId)!.path).toBe("Standalone");
   });
 
@@ -159,7 +159,7 @@ describe("getPageChunkContext surfaces the wiki path", () => {
 
   test("returns the breadcrumb path of the page", async () => {
     const result = await getPageChunkContext(childId, ctx, { order: 0 });
-    expect(result.path).toBe("Docs / Nested Page");
+    expect(result.path).toBe("Docs/Nested Page");
     expect(result.pathIds.length).toBe(2);
     expect(result.chunks.length).toBeGreaterThan(0);
   });
@@ -231,7 +231,7 @@ describe("getNearestEmbeddings surfaces the source wiki path", () => {
         filterKnowledgeEntryIds: [entryId],
       });
       expect(results.length).toBe(1);
-      expect(results[0]!.path).toBe("Knowledge / Bees");
+      expect(results[0]!.path).toBe("Knowledge/Bees");
       expect(results[0]!.knowledgeTextId).not.toBeNull();
       expect(results[0]!.pathIds.length).toBe(2);
     } finally {

--- a/src/lib/knowledge/knowledge-text-path.ts
+++ b/src/lib/knowledge/knowledge-text-path.ts
@@ -20,7 +20,7 @@ import { knowledgeText } from "../db/schema/knowledge";
 export type KnowledgeTextPathSegment = { id: string; title: string };
 
 export type KnowledgeTextPath = {
-  /** ancestor + self titles, root first, joined by the separator (default " / ") */
+  /** ancestor + self titles, root first, joined by the separator (default "/") */
   path: string;
   /** the same segments as ids, root first */
   pathIds: string[];
@@ -28,7 +28,7 @@ export type KnowledgeTextPath = {
   pathSegments: KnowledgeTextPathSegment[];
 };
 
-const DEFAULT_SEPARATOR = " / ";
+const DEFAULT_SEPARATOR = "/";
 
 /**
  * Resolve the wiki path for each of the given page ids in one pass.
@@ -40,7 +40,7 @@ const DEFAULT_SEPARATOR = " / ";
  * @param options.includeSelf  include the page itself as the last segment
  *                              (default true); false yields only the ancestors
  *                              ("the folders it lives in").
- * @param options.separator    string used to join titles (default " / ").
+ * @param options.separator    string used to join titles (default "/").
  */
 export const resolveKnowledgeTextPaths = async (
   ids: string[],

--- a/src/lib/knowledge/knowledge-text-path.ts
+++ b/src/lib/knowledge/knowledge-text-path.ts
@@ -1,0 +1,118 @@
+/**
+ * Wiki path resolution: the breadcrumb of a knowledgeText page in the tree.
+ *
+ * A page's "location" in the wiki is implicit in its `parentId` chain — there
+ * is no stored path column. This module derives the slash-separated path
+ * (root → page) by walking the ancestor chain, so retrieval responses can tell
+ * an agent WHERE a chunk / page lives, not just its bare title.
+ *
+ * The ancestors are loaded level by level (one query per tree depth, and wiki
+ * trees are shallow) rather than pulling the whole tenant tree, so resolving a
+ * handful of search hits stays cheap. Everything is scoped by `tenantId`; a
+ * broken/cross-tenant `parentId` simply ends the chain.
+ */
+
+import { and, eq, inArray } from "drizzle-orm";
+import { getDb } from "../db/db-connection";
+import { knowledgeText } from "../db/schema/knowledge";
+
+/** One step of a wiki path, root-first. */
+export type KnowledgeTextPathSegment = { id: string; title: string };
+
+export type KnowledgeTextPath = {
+  /** ancestor + self titles, root first, joined by the separator (default " / ") */
+  path: string;
+  /** the same segments as ids, root first */
+  pathIds: string[];
+  /** the same segments as { id, title }, root first */
+  pathSegments: KnowledgeTextPathSegment[];
+};
+
+const DEFAULT_SEPARATOR = " / ";
+
+/**
+ * Resolve the wiki path for each of the given page ids in one pass.
+ *
+ * Returns a Map keyed by the requested page id. Ids that do not resolve to a
+ * visible page in the tenant are omitted from the map (the caller decides how
+ * to represent "no path").
+ *
+ * @param options.includeSelf  include the page itself as the last segment
+ *                              (default true); false yields only the ancestors
+ *                              ("the folders it lives in").
+ * @param options.separator    string used to join titles (default " / ").
+ */
+export const resolveKnowledgeTextPaths = async (
+  ids: string[],
+  tenantId: string,
+  options: { includeSelf?: boolean; separator?: string } = {}
+): Promise<Map<string, KnowledgeTextPath>> => {
+  const includeSelf = options.includeSelf ?? true;
+  const separator = options.separator ?? DEFAULT_SEPARATOR;
+
+  const uniqueIds = [...new Set(ids)].filter(Boolean);
+  if (uniqueIds.length === 0) return new Map();
+
+  // Load the requested nodes and then their ancestors, one tree level per
+  // query, until no unseen parents remain. Wiki trees are shallow, so this is
+  // a few small queries rather than a scan of the whole tenant tree.
+  const nodes = new Map<
+    string,
+    { id: string; parentId: string | null; title: string }
+  >();
+  let frontier = uniqueIds;
+  while (frontier.length > 0) {
+    const missing = frontier.filter((id) => !nodes.has(id));
+    if (missing.length === 0) break;
+    const rows = await getDb()
+      .select({
+        id: knowledgeText.id,
+        parentId: knowledgeText.parentId,
+        title: knowledgeText.title,
+      })
+      .from(knowledgeText)
+      .where(
+        and(eq(knowledgeText.tenantId, tenantId), inArray(knowledgeText.id, missing))
+      );
+    for (const row of rows) nodes.set(row.id, row);
+    frontier = rows
+      .map((r) => r.parentId)
+      .filter((id): id is string => !!id);
+  }
+
+  const result = new Map<string, KnowledgeTextPath>();
+  for (const startId of uniqueIds) {
+    if (!nodes.has(startId)) continue;
+
+    // Walk up to the root, guarding against a cyclic parentId.
+    const segments: KnowledgeTextPathSegment[] = [];
+    const seen = new Set<string>();
+    let current = nodes.get(startId);
+    while (current && !seen.has(current.id)) {
+      seen.add(current.id);
+      segments.push({ id: current.id, title: current.title });
+      current = current.parentId ? nodes.get(current.parentId) : undefined;
+    }
+    segments.reverse(); // root first
+
+    if (!includeSelf) segments.pop();
+
+    result.set(startId, {
+      path: segments.map((s) => s.title).join(separator),
+      pathIds: segments.map((s) => s.id),
+      pathSegments: segments,
+    });
+  }
+
+  return result;
+};
+
+/** Convenience wrapper for a single page. Returns null when it does not resolve. */
+export const resolveKnowledgeTextPath = async (
+  id: string,
+  tenantId: string,
+  options: { includeSelf?: boolean; separator?: string } = {}
+): Promise<KnowledgeTextPath | null> => {
+  const map = await resolveKnowledgeTextPaths([id], tenantId, options);
+  return map.get(id) ?? null;
+};

--- a/src/lib/knowledge/knowledge-text-search.ts
+++ b/src/lib/knowledge/knowledge-text-search.ts
@@ -53,8 +53,8 @@ export type KnowledgeTextSearchResult = {
   id: string;
   title: string;
   /**
-   * Wiki path of the page, root first, its titles joined by " / " (e.g.
-   * "Handbook / HR / Vacation Policy") — the last segment is the page itself.
+   * Wiki path of the page, root first, its titles joined by "/" (e.g.
+   * "Handbook/HR/Vacation Policy") — the last segment is the page itself.
    * Lets an agent see WHERE a hit lives in the tree, not just its bare title.
    * Empty string for a top-level page.
    */

--- a/src/lib/knowledge/knowledge-text-search.ts
+++ b/src/lib/knowledge/knowledge-text-search.ts
@@ -28,6 +28,7 @@ import { sql, and, inArray, type SQL } from "drizzle-orm";
 import { getDb } from "../db/db-connection";
 import { knowledgeText, knowledgeChunks } from "../db/schema/knowledge";
 import { buildKnowledgeTextVisibilityConditions } from "./knowledge-texts";
+import { resolveKnowledgeTextPaths } from "./knowledge-text-path";
 import { generateEmbedding } from "./embedding";
 import { attributesContainCondition, type FacetFilters } from "./facets";
 import log from "../log";
@@ -51,6 +52,15 @@ export interface SearchFilters extends FacetFilters {
 export type KnowledgeTextSearchResult = {
   id: string;
   title: string;
+  /**
+   * Wiki path of the page, root first, its titles joined by " / " (e.g.
+   * "Handbook / HR / Vacation Policy") — the last segment is the page itself.
+   * Lets an agent see WHERE a hit lives in the tree, not just its bare title.
+   * Empty string for a top-level page.
+   */
+  path: string;
+  /** the ids of the path segments, root first (parallel to `path`) */
+  pathIds: string[];
   /** fused RRF score (higher = better), after trust weighting */
   score: number;
   /** short excerpt around the best match */
@@ -373,11 +383,17 @@ export const searchKnowledgeTexts = async (
     .where(inArray(knowledgeText.id, fusedIds));
   const metaById = new Map(meta.map((m) => [m.id, m]));
 
+  // resolve the wiki path (breadcrumb) of every hit in one pass
+  const pathById = await resolveKnowledgeTextPaths(fusedIds, context.tenantId);
+
   const enriched: KnowledgeTextSearchResult[] = [...fused.values()].map((f) => {
     const m = metaById.get(f.id);
     const status = m?.status ?? null;
+    const p = pathById.get(f.id);
     return {
       ...f,
+      path: p?.path ?? "",
+      pathIds: p?.pathIds ?? [],
       // trust-aware ranking: verified boosted, outdated demoted
       score: f.score * statusWeight(status),
       summary: m?.summary ?? null,

--- a/src/lib/knowledge/similarity-search.ts
+++ b/src/lib/knowledge/similarity-search.ts
@@ -117,7 +117,7 @@ export async function getNearestEmbeddings(q: {
      */
     knowledgeTextId: string | null;
     /**
-     * Wiki path of the source page, root first, titles joined by " / " (the
+     * Wiki path of the source page, root first, titles joined by "/" (the
      * last segment is the page itself) — so a consumer can see WHERE the chunk
      * comes from. null when the entry is not a wiki page.
      */

--- a/src/lib/knowledge/similarity-search.ts
+++ b/src/lib/knowledge/similarity-search.ts
@@ -4,8 +4,70 @@ import { getDb } from "../db/db-connection";
 import log from "../log";
 import { getFullSourceDocumentsForKnowledgeEntry } from "./get-knowledge";
 import { and, eq, inArray } from "drizzle-orm";
-import { type KnowledgeChunkMeta } from "../db/schema/knowledge";
+import { knowledgeText, type KnowledgeChunkMeta } from "../db/schema/knowledge";
 import { generateEmbedding } from "./embedding";
+import { resolveKnowledgeTextPaths } from "./knowledge-text-path";
+
+type ChunkWithPath<T extends { knowledgeEntryId: string }> = T & {
+  knowledgeTextId: string | null;
+  path: string | null;
+  pathIds: string[];
+};
+
+/**
+ * Attach the source wiki path to each chunk. A chunk's entry is a wiki page
+ * when a knowledgeText row links back to it via knowledgeEntryId; that page's
+ * breadcrumb becomes the chunk's path. Plain RAG documents (no linked page)
+ * get null. Resolved in two batched queries regardless of the chunk count.
+ */
+const attachWikiPaths = async <T extends { knowledgeEntryId: string }>(
+  chunks: T[],
+  tenantId: string
+): Promise<ChunkWithPath<T>[]> => {
+  const entryIds = [...new Set(chunks.map((c) => c.knowledgeEntryId))];
+  if (entryIds.length === 0) {
+    return chunks.map((c) => ({
+      ...c,
+      knowledgeTextId: null,
+      path: null,
+      pathIds: [],
+    }));
+  }
+
+  // entry -> wiki page (only mirrored pages link back via knowledgeEntryId)
+  const pages = await getDb()
+    .select({
+      id: knowledgeText.id,
+      knowledgeEntryId: knowledgeText.knowledgeEntryId,
+    })
+    .from(knowledgeText)
+    .where(
+      and(
+        eq(knowledgeText.tenantId, tenantId),
+        inArray(knowledgeText.knowledgeEntryId, entryIds)
+      )
+    );
+  const pageIdByEntryId = new Map<string, string>();
+  for (const p of pages) {
+    if (p.knowledgeEntryId) pageIdByEntryId.set(p.knowledgeEntryId, p.id);
+  }
+
+  const pathByPageId = await resolveKnowledgeTextPaths(
+    [...pageIdByEntryId.values()],
+    tenantId
+  );
+
+  return chunks.map((c) => {
+    const pageId = pageIdByEntryId.get(c.knowledgeEntryId) ?? null;
+    const p = pageId ? pathByPageId.get(pageId) : undefined;
+    return {
+      ...c,
+      knowledgeTextId: pageId,
+      path: p?.path ?? null,
+      pathIds: p?.pathIds ?? [],
+    };
+  });
+};
 
 type KnowledgeChunk = {
   id: string;
@@ -49,6 +111,19 @@ export async function getNearestEmbeddings(q: {
     knowledgeEntryName: string;
     meta: KnowledgeChunkMeta;
     order: number;
+    /**
+     * id of the wiki page this chunk originates from, or null when the entry
+     * is a plain RAG document (not mirrored from a wiki page).
+     */
+    knowledgeTextId: string | null;
+    /**
+     * Wiki path of the source page, root first, titles joined by " / " (the
+     * last segment is the page itself) — so a consumer can see WHERE the chunk
+     * comes from. null when the entry is not a wiki page.
+     */
+    path: string | null;
+    /** the ids of the path segments, root first (parallel to `path`) */
+    pathIds: string[];
   }[]
 > {
   // set some default values
@@ -181,7 +256,7 @@ export async function getNearestEmbeddings(q: {
 
   // return if no addBeforeN and addAfterN
   if (q.addBeforeN < 1 && q.addAfterN < 1) {
-    return rows;
+    return attachWikiPaths(rows, q.tenantId);
   }
 
   // Else. Also add before and after N
@@ -221,7 +296,7 @@ export async function getNearestEmbeddings(q: {
     );
     resultRows.push(...entries);
   }
-  return resultRows;
+  return attachWikiPaths(resultRows, q.tenantId);
 }
 
 /**

--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -515,7 +515,7 @@ export default function defineRoutesForKnowledgeTexts(
       responses: {
         200: {
           description:
-            "Ranked results with id, title, score, snippet and matchedBy legs",
+            "Ranked results with id, title, wiki path (breadcrumb), score, snippet and matchedBy legs",
         },
       },
     }),


### PR DESCRIPTION
## Summary

This PR adds breadcrumb path information to knowledge retrieval results, allowing AI agents to understand where chunks and pages live in the wiki tree structure, not just their bare titles.

## Key Changes

- **New module `knowledge-text-path.ts`**: Implements wiki path resolution by walking the `parentId` chain to build slash-separated breadcrumbs (e.g., "Handbook / HR / Vacation Policy"). Includes:
  - `resolveKnowledgeTextPath()`: Resolve path for a single page
  - `resolveKnowledgeTextPaths()`: Batch resolve paths for multiple pages in one pass
  - Efficient ancestor loading (one query per tree level, not a full tenant scan)
  - Configurable separator and option to exclude the page itself (ancestors only)

- **Enhanced similarity search** (`similarity-search.ts`):
  - New `attachWikiPaths()` helper that links RAG chunks back to their source wiki pages
  - Chunks from wiki pages now include `knowledgeTextId`, `path`, and `pathIds`
  - Plain RAG documents (not mirrored from wiki) get `null` path and empty `pathIds`

- **Updated knowledge text search** (`knowledge-text-search.ts`):
  - Search results now include `path` and `pathIds` for each hit
  - Paths resolved in a single batched query for all results

- **Updated chunk context** (`knowledge-text-chunks.ts`):
  - `PageChunkContext` now includes the page's `path` and `pathIds`
  - Tells agents where surrounding chunks live in the tree

- **Comprehensive test coverage** (`knowledge-text-path.test.ts`):
  - Tests for single and batch path resolution
  - Tests for custom separators and `includeSelf` option
  - Tests for cross-tenant isolation
  - Integration tests verifying paths surface correctly in chunk context and similarity search

- **Documentation** (`6_BuildIn_AI_Knowledge.md`):
  - Added section explaining source path availability across all retrieval endpoints
  - Notes that paths are derived on-the-fly from `parentId` chains (no stored column)

- **API exports** (`knowledge.ts`):
  - Exported path resolution functions and types for public use

## Implementation Details

- Paths are computed on-the-fly from the `parentId` chain, so moving a page in the tree automatically updates its path without schema changes
- Wiki trees are assumed to be shallow, so ancestor loading via level-by-level queries is efficient
- Batch operations (resolving multiple paths, attaching paths to chunks) use two queries regardless of input size
- Tenant isolation is enforced throughout; cross-tenant or invalid IDs are silently omitted from results

https://claude.ai/code/session_01KmGoihoLJcNp7YaVXSDMwR