### PR TITLE
fix(tests): pass framework test files under consumer-strict typecheck

### DIFF
--- a/src/lib/knowledge/attribute-extraction-mappers.test.ts
+++ b/src/lib/knowledge/attribute-extraction-mappers.test.ts
@@ -47,8 +47,8 @@ describe("attributeDefinitionsToExtractionTargets", () => {
     const [target] = attributeDefinitionsToExtractionTargets([
       { key: "count", type: "number", values: ["ignored"] },
     ]);
-    expect(target.type).toBe("number");
-    expect(target.options).toBeUndefined();
+    expect(target!.type).toBe("number");
+    expect(target!.options).toBeUndefined();
   });
 });
 

--- a/src/lib/knowledge/knowledge-text-chunks.test.ts
+++ b/src/lib/knowledge/knowledge-text-chunks.test.ts
@@ -32,7 +32,7 @@ describe("getPageChunkContext", () => {
       .insert(knowledgeChunks)
       .values(
         [0, 1, 2, 3, 4].map((order) => ({
-          knowledgeEntryId: entry.id,
+          knowledgeEntryId: entry!.id,
           text: `chunk-${order}`,
           order,
           embeddingModel: "test",
@@ -43,7 +43,7 @@ describe("getPageChunkContext", () => {
       );
 
     // link the page to the knowledge_entry
-    await updateKnowledgeText(pageId, { knowledgeEntryId: entry.id }, ctx);
+    await updateKnowledgeText(pageId, { knowledgeEntryId: entry!.id }, ctx);
   });
 
   test("returns the hit plus neighbours before/after in order", async () => {

--- a/src/lib/knowledge/knowledge-text-path.test.ts
+++ b/src/lib/knowledge/knowledge-text-path.test.ts
@@ -144,7 +144,7 @@ describe("getPageChunkContext surfaces the wiki path", () => {
       .insert(knowledgeChunks)
       .values(
         [0, 1].map((order) => ({
-          knowledgeEntryId: entry.id,
+          knowledgeEntryId: entry!.id,
           text: `chunk-${order}`,
           order,
           embeddingModel: "test",
@@ -154,7 +154,7 @@ describe("getPageChunkContext surfaces the wiki path", () => {
       );
 
     // link the page to the mirrored RAG entry
-    await updateKnowledgeText(childId, { knowledgeEntryId: entry.id }, ctx);
+    await updateKnowledgeText(childId, { knowledgeEntryId: entry!.id }, ctx);
   });
 
   test("returns the breadcrumb path of the page", async () => {

--- a/src/lib/knowledge/parsing/pdf/generic.test.ts
+++ b/src/lib/knowledge/parsing/pdf/generic.test.ts
@@ -7,7 +7,6 @@ import {
   afterEach,
   mock,
 } from "bun:test";
-import type { Server } from "bun";
 
 // Provide DB env defaults so importing the logger (which constructs a Postgres
 // client at module load) does not crash in an isolated run. postgres.js is
@@ -83,7 +82,7 @@ const RESULT_BODY = {
 const jobs = new Set<string>();
 let jobCounter = 0;
 
-let server: Server;
+let server: ReturnType<typeof Bun.serve>;
 
 beforeAll(() => {
   server = Bun.serve({
@@ -122,14 +121,14 @@ beforeAll(() => {
 
       const jobResultMatch = url.pathname.match(/^\/v1\/jobs\/([^/]+)\/result$/);
       if (jobResultMatch) {
-        return jobs.has(jobResultMatch[1])
+        return jobs.has(jobResultMatch[1]!)
           ? Response.json(RESULT_BODY)
           : Response.json({ error: "not_ready" }, { status: 409 });
       }
 
       const jobStatusMatch = url.pathname.match(/^\/v1\/jobs\/([^/]+)$/);
       if (jobStatusMatch) {
-        return jobs.has(jobStatusMatch[1])
+        return jobs.has(jobStatusMatch[1]!)
           ? Response.json({ job_id: jobStatusMatch[1], status: "completed" })
           : Response.json({ error: "unknown_job" }, { status: 404 });
       }
@@ -196,8 +195,8 @@ describe("Generic PDF Parser Service (against a fake service)", () => {
       { page: 1, text: "Hersteller ![img-1](/storage/img-1)" },
       { page: 2, text: "Seite zwei" },
     ]);
-    expect(result.metadata?.hersteller.value).toBe("Siemens");
-    expect(result.metadata?.typ.found).toBe(false);
+    expect(result.metadata?.hersteller?.value).toBe("Siemens");
+    expect(result.metadata?.typ?.found).toBe(false);
   });
 
   test("omits the extract field when no targets are given", async () => {
@@ -227,10 +226,10 @@ describe("Generic PDF Parser Service (against a fake service)", () => {
 
     const caps = await getGenericParserCapabilities();
     expect(caps.service).toBe("generic-v1");
-    expect(caps.modalities[0].mimeTypes).toEqual(["application/pdf"]);
-    expect(caps.modalities[0].features?.extractImages).toBe(true);
+    expect(caps.modalities[0]!.mimeTypes).toEqual(["application/pdf"]);
+    expect(caps.modalities[0]!.features?.extractImages).toBe(true);
     // Missing features default to false after normalization.
-    expect(caps.modalities[1].features?.async).toBe(false);
+    expect(caps.modalities[1]!.features?.async).toBe(false);
 
     // Second call is served from cache — service hit only once.
     await getGenericParserCapabilities();

--- a/src/lib/knowledge/source-hash.test.ts
+++ b/src/lib/knowledge/source-hash.test.ts
@@ -39,7 +39,7 @@ describe("computeSourceHash", () => {
     const buffer = view.buffer.slice(
       view.byteOffset,
       view.byteOffset + view.byteLength
-    );
+    ) as ArrayBuffer;
     expect(computeSourceHash(buffer)).toBe(computeSourceHash(view));
   });
 });

--- a/src/lib/usermanagement/invitations-accept-link.test.ts
+++ b/src/lib/usermanagement/invitations-accept-link.test.ts
@@ -76,14 +76,14 @@ describe("Accept invitation via emailed link", () => {
         )
       );
     expect(members.length).toBe(1);
-    expect(members[0].role).toBe("admin");
+    expect(members[0]!.role).toBe("admin");
 
     // Invitation must be marked accepted.
     const [inv] = await getDb()
       .select()
       .from(tenantInvitations)
       .where(eq(tenantInvitations.id, invitation.id));
-    expect(inv.status).toBe("accepted");
+    expect(inv!.status).toBe("accepted");
   });
 
   test("clicking the link twice is idempotent (no error)", async () => {
@@ -143,7 +143,7 @@ describe("Accept invitation via emailed link", () => {
       .select()
       .from(tenantInvitations)
       .where(eq(tenantInvitations.id, invitation.id));
-    expect(inv.status).toBe("pending");
+    expect(inv!.status).toBe("pending");
   });
 
   test("token for a deleted invitation throws", async () => {

--- a/tsconfig.strict-check.json
+++ b/tsconfig.strict-check.json
@@ -1,11 +1,14 @@
 {
   // Type-check-only config that mirrors the STRICTER settings a consuming
-  // backend applies to this framework's source (see quality pipeline):
+  // backend applies to this framework (see the consumer's quality pipeline):
   //   - noUncheckedIndexedAccess: on   (framework's own tsconfig leaves it off)
   //   - lib without "DOM"              (consumer runs on bun typings, no DOM)
-  // This surfaces null-safety and lib-portability issues in framework SOURCE
-  // before they break a downstream build. Test files are excluded (like the
-  // framework's own build and the consumer's typecheck).
+  //
+  // Test files are INCLUDED here on purpose: a consuming app that points its
+  // tsconfig "include" at framework/src type-checks the framework's *.test.ts
+  // too, so those files must also compile under these stricter settings. This
+  // catches the null-safety / lib-portability class of error that compiles
+  // fine under the framework's own tsconfig but breaks a downstream build.
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "lib": ["ESNext"],
@@ -14,5 +17,5 @@
     "declaration": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": []
 }


### PR DESCRIPTION
## Kontext

Eine konsumierende App, die ihr `tsconfig` `include` auf `framework/src` richtet, typecheckt auch die `*.test.ts` des Frameworks — und zwar unter strengeren Settings als der Framework-eigene Build (`noUncheckedIndexedAccess` an, `lib` ohne `DOM`). Das brachte **18 Fehler**, die der Framework-eigene Build nie sieht, weil er Testdateien ausschließt.

Folge-Arbeit zu PR #84 (dort wurden bereits die 8 Quell-Datei-Fehler + die Typecheck-Pipeline behoben). Da #84 gemergt ist, sitzt dieser Branch frisch auf `develop`.

## Änderungen

**Testdateien strict-clean gemacht** (rein typ-technisch, kein Laufzeitverhalten geändert):

- **Null-Safety (`noUncheckedIndexedAccess`):** Non-null-Assertions für destrukturierte / indexierte Ergebnisse, die die Tests ohnehin als vorhanden voraussetzen (`target!`, `entry!`, `inv!`, `members[0]!`, `caps.modalities[i]!`, Regex-Capture-Gruppen) — im bereits etablierten `entry!.id`-Idiom dieser Dateien; Optional-Chaining für echt optionale Metadaten-Felder.
- **Lib-Portabilität (ohne `DOM`):** Test-Server als `ReturnType<typeof Bun.serve>` statt des inzwischen generischen bun-`Server`-Typs typisiert und den dadurch ungenutzten `Server`-Import entfernt; in `source-hash.test` das geslicte Ergebnis auf `ArrayBuffer` gecastet (`ArrayBufferLike` schließt `SharedArrayBuffer` ein).

**CI-Lücke geschlossen:** `tsconfig.strict-check.json` schließt jetzt Testdateien **ein** (`exclude: []`). Vorher waren sie ausgenommen, weshalb die Framework-Pipeline grün war, während ein Consumer-Build rot wurde. Der `strict-consumer`-Job spiegelt nun exakt, was ein Consumer typecheckt, und fängt diese Fehlerklasse künftig direkt hier ab.

## Betroffene Dateien

| Datei | Fehler | Fix |
|---|---|---|
| `attribute-extraction-mappers.test.ts` | 2× `target` undefined | `target!` |
| `knowledge-text-chunks.test.ts` | 2× `entry` undefined | `entry!.id` |
| `knowledge-text-path.test.ts` | 2× `entry` undefined | `entry!.id` |
| `parsing/pdf/generic.test.ts` | 8× (Server-Generic, Regex-Gruppen, Metadaten, Array-Index) | `ReturnType<typeof Bun.serve>`, `[1]!`, `?.`, `modalities[i]!` |
| `source-hash.test.ts` | 1× `SharedArrayBuffer` | Cast auf `ArrayBuffer` |
| `invitations-accept-link.test.ts` | 3× `inv`/`members[0]` undefined | `!` |
| `tsconfig.strict-check.json` | — | Testdateien in Strict-Check aufgenommen |

## Verifikation

- `bun run typecheck` → Exit 0
- `bun run typecheck:strict` (jetzt inkl. Tests) → Exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtbmpQ1VPmVqvVttrMiBEF)_