### PR TITLE
fix(auth): accept pending tenant invitations on magic-link sign-up

### DIFF
--- a/src/lib/auth/magic-link.ts
+++ b/src/lib/auth/magic-link.ts
@@ -10,7 +10,11 @@ import { smtpService } from "../email";
 import { generateUserSessionJwt } from ".";
 import { _GLOBAL_SERVER_CONFIG } from "../../store";
 import { postRegisterActions } from "./actions";
-import { checkIfInvitationCodeIsNeededToRegister, getPendingInvitationsForEmail } from "../usermanagement/invitations";
+import {
+  checkIfInvitationCodeIsNeededToRegister,
+  getPendingInvitationsForEmail,
+  acceptAllPendingInvitationsForTenantMember,
+} from "../usermanagement/invitations";
 import { checkGeneralInvitationCode } from "./index";
 
 const EXPIRE_TIME = 15 * 60 * 1000; // 15 minutes
@@ -55,25 +59,27 @@ export const createMagicLinkToken = async (
 
   // If creating a new user, check invitation code requirements
   if (isNewUser && createUserIfMissing) {
+    // A pending tenant invitation for this email is, on its own, sufficient
+    // authorisation to register – it stands in for a general invitation code.
+    // The list is needed both for the code-requirement bypass below and to
+    // auto-accept the memberships once the account exists.
+    const { invitedInTenantIds } = await getPendingInvitationsForEmail(email);
+
     // Check if invitation codes are required
     const invitationCodeNeeded = await checkIfInvitationCodeIsNeededToRegister();
-    
-    if (invitationCodeNeeded) {
-      // Check if user has pending invitations
-      const { invitedInTenantIds } = await getPendingInvitationsForEmail(email);
-      
-      // If no pending invitations, require invitation code
-      if (invitedInTenantIds.length < 1) {
-        if (!invitationCode) {
-          throw new Error("Invitation code needed");
-        }
-        
-        // Validate the invitation code
-        try {
-          await checkGeneralInvitationCode(invitationCode);
-        } catch (error) {
-          throw new Error("Invitation code not found");
-        }
+
+    // Only demand a general invitation code when one is required AND the user
+    // has no pending invitation to fall back on.
+    if (invitationCodeNeeded && invitedInTenantIds.length < 1) {
+      if (!invitationCode) {
+        throw new Error("Invitation code needed");
+      }
+
+      // Validate the invitation code
+      try {
+        await checkGeneralInvitationCode(invitationCode);
+      } catch (error) {
+        throw new Error("Invitation code not found");
       }
     }
 
@@ -107,6 +113,20 @@ export const createMagicLinkToken = async (
       throw new Error("Failed to create user");
     }
     userResult = newUser;
+
+    // Auto-accept every pending tenant invitation for this email. This mirrors
+    // `LocalAuth.register` and is what makes the passwordless (magic-link)
+    // sign-up land an invitee straight in the organisation they were invited
+    // to. Without it the invitation stays "pending" and the freshly created
+    // user has no tenant membership (they'd end up in an empty default tenant).
+    if (invitedInTenantIds.length > 0) {
+      for (const tenantId of invitedInTenantIds) {
+        await acceptAllPendingInvitationsForTenantMember(
+          newUser[0].id,
+          tenantId
+        );
+      }
+    }
 
     // Execute post-register actions for newly created user. The register meta
     // (invitation code + custom data) is forwarded so custom hooks can react

--- a/src/lib/usermanagement/invitations-accept-link.test.ts
+++ b/src/lib/usermanagement/invitations-accept-link.test.ts
@@ -6,13 +6,14 @@ import {
   TEST_ORG3_USER_1,
 } from "../../test/init.test";
 import { getDb } from "../db/db-connection";
-import { tenantInvitations, tenantMembers } from "../db/schema/users";
+import { tenantInvitations, tenantMembers, users } from "../db/schema/users";
 import {
   createInvitationToken,
   verifyInvitationToken,
   createTenantInvitation,
   acceptInvitationByToken,
 } from "./invitations";
+import { createMagicLinkToken } from "../auth/magic-link";
 
 /**
  * Tests for the "one click = accepted" invitation link flow
@@ -151,5 +152,70 @@ describe("Accept invitation via emailed link", () => {
       "00000000-0000-0000-0000-000000000999"
     );
     await expect(acceptInvitationByToken(token)).rejects.toThrow();
+  });
+
+  // Regression: an invited but not-yet-registered user who signs in through the
+  // passwordless magic-link flow (createUserIfMissing=true) must end up as a
+  // confirmed member of the tenant they were invited to. Previously the
+  // magic-link path created the account but left the invitation "pending", so
+  // the invitee landed in the app without the invited membership.
+  test("magic-link sign-up of an invited new user accepts the pending invitation", async () => {
+    const email = "magic-invitee@symbiosika.com";
+
+    // Clean any leftovers from earlier runs.
+    await getDb().delete(users).where(eq(users.email, email));
+    await getDb()
+      .delete(tenantInvitations)
+      .where(eq(tenantInvitations.email, email));
+
+    const invitation = await createTenantInvitation(
+      {
+        tenantId: TEST_ORGANISATION_1.id,
+        email,
+        role: "admin",
+        status: "pending",
+      },
+      false
+    );
+
+    // No general invitation code is passed – the pending tenant invitation must
+    // be enough to both authorise the sign-up and grant the membership.
+    await createMagicLinkToken(email, "login", /* createUserIfMissing */ true);
+
+    // The account now exists …
+    const [user] = await getDb()
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, email));
+    expect(user).toBeDefined();
+
+    // … the invitation is marked accepted …
+    const [inv] = await getDb()
+      .select()
+      .from(tenantInvitations)
+      .where(eq(tenantInvitations.id, invitation.id));
+    expect(inv!.status).toBe("accepted");
+
+    // … and the membership exists with the invited role.
+    const members = await getDb()
+      .select()
+      .from(tenantMembers)
+      .where(
+        and(
+          eq(tenantMembers.tenantId, TEST_ORGANISATION_1.id),
+          eq(tenantMembers.userId, user!.id)
+        )
+      );
+    expect(members.length).toBe(1);
+    expect(members[0]!.role).toBe("admin");
+
+    // Cleanup so the suite stays isolated.
+    await getDb()
+      .delete(tenantMembers)
+      .where(eq(tenantMembers.userId, user!.id));
+    await getDb().delete(users).where(eq(users.email, email));
+    await getDb()
+      .delete(tenantInvitations)
+      .where(eq(tenantInvitations.email, email));
   });
 });


### PR DESCRIPTION
## Problem

When an admin invites a **new** user (one without an account yet), the invitation email links to `/api/v1/user/accept-invitation?token=…`. For a not-yet-registered email that endpoint returns `needs_registration` and forwards the invitee to the login page with their email pre-filled.

From there the invitee signs in through the **passwordless magic-link flow** (`send-magic-link?...&createUserIfMissing=true`). `createMagicLinkToken` created the account but **never accepted the pending tenant invitation** — unlike the password-based `LocalAuth.register`, which does (`acceptAllPendingInvitationsForTenantMember`).

Consequences:
- The invitation stayed `pending` forever.
- The freshly created user had **no tenant membership**, so on app init they were dropped into a brand-new empty "Default" tenant instead of the organisation they were invited to.

In short: the invitation link was "not enough" to actually get the invitee into the org.

## Fix

`createMagicLinkToken` now mirrors `LocalAuth.register`:

- The list of pending invitations for the email is fetched up front and used both for the invitation-code bypass and for acceptance.
- After the account is created, **every pending tenant invitation for that email is auto-accepted**, granting the invited membership and role.
- The "a pending invitation stands in for a general invitation code" bypass is hoisted so it is evaluated regardless of whether a general code is configured (behaviour unchanged when a code is required and no invitation exists).

## Tests

- Added a regression test in `invitations-accept-link.test.ts`: an invited new user signing up via `createMagicLinkToken(createUserIfMissing=true)` with **no** invitation code ends up with the invitation marked `accepted` and a tenant membership carrying the invited role.
- Verified locally against a PGlite Postgres: the new test plus the existing auth, invitation-route and user-route suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013v1MpZQSdXiDXQ7M4NNH6P)_