### PR TITLE
fix(jobs): prevent duplicate processing of queued jobs

### DIFF
--- a/src/lib/jobs/index.test.ts
+++ b/src/lib/jobs/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { defineJob, createJob, getJob, startJobQueue, stopJobQueue } from ".";
+import {
+  defineJob,
+  createJob,
+  getJob,
+  startJobQueue,
+  stopJobQueue,
+  processJob,
+} from ".";
 import { initTests, TEST_ORGANISATION_1 } from "../../test/init.test";
 
 describe("Job Queue System", () => {
@@ -84,5 +91,46 @@ describe("Job Queue System", () => {
 
     // The future job must not have been picked up yet
     expect(future.status).toBe("pending");
+  }, 10000);
+
+  it("runs a job at most once when two cycles pick up the same job", async () => {
+    // Reproduces the mass-import race: overlapping worker cycles (setInterval
+    // does not wait for its async callback) — or two server instances — both
+    // SELECT the same pending job and then both try to process it. The atomic
+    // pending -> running claim in processJob must let only one of them actually
+    // execute the handler, so a slow ingest job can't have its temporary upload
+    // file deleted out from under a concurrent duplicate run ("File not found").
+    //
+    // The two cycles are simulated by handing the *same* pending job row to two
+    // concurrent processJob() calls: that is exactly the post-SELECT state both
+    // cycles are in. (Two concurrent processDueJobsOnce() drains would NOT
+    // reproduce it here — PGlite serialises connections, so the second drain's
+    // SELECT already sees the job as running and never reaches the claim.)
+    let runs = 0;
+    defineJob("claim-race-job", {
+      async execute() {
+        runs++;
+        // Stay "running" a moment so both claim attempts overlap in JS land.
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        return { runs };
+      },
+    });
+
+    // Stop the background interval so only our explicit calls process the job.
+    stopJobQueue();
+
+    const job = await createJob(
+      "claim-race-job",
+      { test: true },
+      TEST_ORGANISATION_1.id
+    );
+
+    // Both "cycles" hold the same pending job row and race to process it.
+    await Promise.all([processJob(job), processJob(job)]);
+
+    const completed = await getJob(job.id);
+    expect(completed.status).toBe("completed");
+    // Exactly one claim wins — the handler must have executed exactly once.
+    expect(runs).toBe(1);
   }, 10000);
 });

--- a/src/lib/jobs/index.ts
+++ b/src/lib/jobs/index.ts
@@ -23,6 +23,11 @@ const jobHandlers: Record<string, JobHandler> = {};
 let jobQueueRunning = false;
 // Handle of the background polling interval, so it can be stopped again.
 let jobQueueInterval: ReturnType<typeof setInterval> | null = null;
+// Whether a poll cycle is currently draining the queue. `setInterval` does not
+// wait for its async callback to resolve, so without this guard a cycle that
+// runs longer than CHECK_CYCLE_MS (e.g. a mass import with PDF parsing +
+// embeddings) would overlap with the next tick and process jobs concurrently.
+let cycleInFlight = false;
 
 /**
  * Returns true once startJobQueue() has been called.
@@ -80,8 +85,38 @@ async function notifyUserOnJobFinish(
   }
 }
 
-async function processJob(job: Job) {
+/**
+ * Execute a single job. Atomically claims it first (pending -> running) so that
+ * two callers holding the same job row — e.g. two overlapping worker cycles, or
+ * two server instances — never both run the handler. Exported so tests can
+ * drive the claim deterministically (PGlite serialises connections, so the
+ * race has to be reproduced by calling this directly rather than via two
+ * concurrent {@link processDueJobsOnce} drains).
+ */
+export async function processJob(job: Job) {
   await log.debug(`Executing job: ${job.id} from type ${job.type}`);
+
+  // Atomically claim the job before doing any work: flip pending -> running
+  // only while it is *still* pending. Postgres serialises the concurrent
+  // UPDATEs, so exactly one caller gets a row back here; every other caller
+  // matches zero rows and bails out below. Without this claim, two overlapping
+  // worker cycles (or two server instances) both SELECT the same pending job
+  // and run it twice — which e.g. deletes a temporary upload file out from
+  // under the first run, so the losing run fails with "File not found" (see the
+  // knowledge-ingest jobs' `deleteAfter`). The plain `select` in
+  // processDueJobsOnce is intentionally left unlocked; this UPDATE is the
+  // single point that guarantees at-most-once execution.
+  const claimed = await getDb()
+    .update(jobs)
+    .set({ status: "running" })
+    .where(and(eq(jobs.id, job.id), eq(jobs.status, "pending")))
+    .returning();
+  if (claimed.length === 0) {
+    await log.debug(
+      `Job ${job.id} was already claimed by another worker cycle; skipping`
+    );
+    return;
+  }
 
   const executor = jobHandlers[job.type];
   if (!executor) {
@@ -101,12 +136,6 @@ async function processJob(job: Job) {
     }
     throw new Error(`No executor found for job type: ${job.type}`);
   }
-
-  // update the job status to running
-  await getDb()
-    .update(jobs)
-    .set({ status: "running" })
-    .where(eq(jobs.id, job.id));
 
   try {
     const result = await executor.execute(job.metadata, job);
@@ -173,6 +202,15 @@ export async function startJobQueue() {
   jobQueueRunning = true;
   jobQueueInterval = setInterval(async () => {
     // log.debug("Checking for pending jobs");
+    // Skip this tick while the previous cycle is still draining the queue, so
+    // two cycles never run concurrently within one process (see cycleInFlight).
+    // Per-job at-most-once execution is still guaranteed by the atomic claim in
+    // processJob; this guard just avoids pointless overlapping work and keeps a
+    // single instance's ordering intact.
+    if (cycleInFlight) {
+      return;
+    }
+    cycleInFlight = true;
     // A single failing job (e.g. one with no registered handler) must never
     // reject the interval callback: an unhandled rejection from this
     // background timer would otherwise surface as a failure in whatever
@@ -181,6 +219,8 @@ export async function startJobQueue() {
       await processDueJobsOnce();
     } catch (error) {
       log.error(`Job queue cycle failed: ${(error as Error).message}`);
+    } finally {
+      cycleInFlight = false;
     }
   }, CHECK_CYCLE_MS);
 }
@@ -197,6 +237,7 @@ export function stopJobQueue() {
     jobQueueInterval = null;
   }
   jobQueueRunning = false;
+  cycleInFlight = false;
 }
 
 export async function getJob(id: string) {


### PR DESCRIPTION
## Problem

During wiki **mass-imports** (importing a whole folder), users saw spurious
`Import fehlgeschlagen — Failed to get file from database. Error: File not found`
notifications, and occasionally duplicate pages, even though every upload
succeeded in the browser (no failed fetch). The uploads were fine; the failure
was in the background job queue executing the same job more than once.

## Root cause

Two independent issues in `src/lib/jobs/index.ts`:

1. **No atomic claim.** `processDueJobsOnce()` SELECTs all pending jobs, then
   `processJob()` set `status='running'` *unconditionally* — no guard that the
   row was still `pending`. Two workers holding the same job row both ran the
   handler. For `knowledge:ingest` jobs the first run deletes the temporary
   upload file (`deleteAfter`), so the losing duplicate run fails its
   `getFileFromDb()` with "File not found".

2. **Overlapping poll cycles.** `setInterval()` does not wait for its async
   callback, so a cycle that runs longer than `CHECK_CYCLE_MS` (a mass import
   with PDF parsing + embeddings easily does) overlaps the next tick and
   processes jobs concurrently within a single instance.

## Changes

1. **Atomic claim** — flip `pending → running` only while still pending:
   `UPDATE jobs SET status='running' WHERE id = ? AND status = 'pending' RETURNING`.
   Only the caller that gets a row back proceeds; everyone else skips. This
   guarantees at-most-once execution across overlapping cycles **and multiple
   server instances**.

2. **Overlap guard** — a `cycleInFlight` flag skips a tick while the previous
   cycle is still draining the queue (reset in `stopJobQueue()`).

`processJob` is now exported so the race can be tested deterministically
(PGlite serialises connections, so two concurrent `processDueJobsOnce()` drains
can't reproduce it).

## Testing

- Added a regression test that hands the **same** pending job to two concurrent
  `processJob()` calls and asserts the handler runs **exactly once**.
- Verified it catches the bug: removing the `status='pending'` guard makes the
  handler run twice and the test fails (`Expected: 1, Received: 2`).
- `bun run typecheck` clean; existing job / notify-on-completion / ingestion-job
  tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHWrJffzHuAfsUDrmVEULJ)_