### PR TITLE
fix(settings.test): make settings-list json cast strict-safe

### DIFF
--- a/src/routes/tenant/[tenantId]/settings/index.test.ts
+++ b/src/routes/tenant/[tenantId]/settings/index.test.ts
@@ -123,7 +123,7 @@ describe("Tenant Settings Routes", () => {
       headers: { Cookie: `jwt=${memberJwt}` },
     });
     expect(res.status).toBe(200);
-    const rows: any[] = await res.json();
+    const rows = (await res.json()) as any[];
     const keys = rows.map((r) => r.key);
     expect(keys).toContain(TEST_KEY);
     expect(keys).toContain(OTHER_KEY);


### PR DESCRIPTION
The strict consumer-mirroring typecheck (tsconfig.strict-check.json) failed on `const rows: any[] = await res.json()`: res.json() returns `unknown`, which is not assignable to `any[]`, so tsc errored with TS2322.

Cast the parsed body instead — `(await res.json()) as any[]` — matching the pattern already used elsewhere in this file (lines 107/117/144). Verified: typecheck:strict and typecheck both pass under TS 5.9 and 7.


Claude-Session: https://claude.ai/code/session_01VevTGGXLDjK7MV6JVcQCjE