### PR TITLE
Add zero-setup PGlite test runner (test:local) and rework testing skills

### DIFF
--- a/.scripts/test-local.ts
+++ b/.scripts/test-local.ts
@@ -1,0 +1,183 @@
+/**
+ * Zero-setup local test runner (PGlite).
+ *
+ * Runs the backend test suite against an embedded PGlite database — no Docker,
+ * no external Postgres, no .env required. Designed so a coding agent (or a
+ * developer) can verify work with a single command:
+ *
+ *   bun run test:local                                  # all tests
+ *   bun run test:local src/lib/wiki/tree.test.ts        # one file
+ *   bun run test:local --fresh                          # wipe the test DB first
+ *   bun run test:local --serve                          # no tests: just start the
+ *                                                       #   test DB + migrations and
+ *                                                       #   keep serving (for db:query,
+ *                                                       #   manual `bun test`, dev server)
+ *   bun run test:local --keep <files>                   # run tests, then keep the DB
+ *                                                       #   serving for inspection
+ *
+ * What it does:
+ *   1. Starts PGlite (with pgvector) on its own port (default 5499) via the
+ *      Postgres wire protocol — separate from a dev DB on 5432.
+ *   2. Applies framework + app migrations (idempotent, fast on re-runs).
+ *   3. Runs `bun test <args>` with the right environment and exits with the
+ *      test run's exit code.
+ *
+ * Environment defaults it provides (existing env vars win, except POSTGRES_*
+ * which are always pointed at the test DB so tests can never hit a real one):
+ *   POSTGRES_* ..................... the embedded test database
+ *   JWT_PRIVATE_KEY / PUBLIC_KEY ... a shared local HS256 secret (the framework
+ *                                    signs and verifies session JWTs symmetrically,
+ *                                    so both MUST hold the same value)
+ *   SMTP_HOST=console.localhost .... emails go to logs/email/ instead of the network
+ *
+ * The DB persists in ./dev-db/pglite-test-<port> between runs (gitignored) so
+ * repeat runs skip migration work. Use --fresh for a clean slate.
+ *
+ * This script only depends on the framework layout (framework/ + drizzle
+ * configs) — it is app-agnostic and can be shared across apps built on the
+ * symbiosika-framework.
+ */
+import { PGlite } from "@electric-sql/pglite";
+import { vector } from "@electric-sql/pglite-pgvector";
+import { PGLiteSocketServer } from "@electric-sql/pglite-socket";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+
+// Run from the app's backend root (the directory containing framework/ and
+// package.json) — `bun run test:local` does this automatically. Location-
+// independent so the same file works from <app>/.scripts/ or framework/.scripts/.
+// Layout detection: in an app, the framework lives in framework/ and the app's
+// own drizzle.config.ts sits in the root; in the framework repo itself, the
+// framework config IS ./drizzle.config.ts and there is no app config.
+const BACKEND_DIR = process.cwd();
+const isAppLayout = existsSync(
+  path.join(BACKEND_DIR, "framework", "drizzle.config.ts")
+);
+if (!isAppLayout && !existsSync(path.join(BACKEND_DIR, "drizzle.config.ts"))) {
+  console.error(
+    `[test-local] run this from the backend root (no framework/drizzle.config.ts or drizzle.config.ts found in ${BACKEND_DIR})`
+  );
+  process.exit(1);
+}
+
+// ---- CLI args ---------------------------------------------------------------
+const rawArgs = process.argv.slice(2);
+const fresh = rawArgs.includes("--fresh");
+const serveOnly = rawArgs.includes("--serve");
+const keepOpen = rawArgs.includes("--keep");
+const testArgs = rawArgs.filter(
+  (a) => !["--fresh", "--serve", "--keep"].includes(a)
+);
+
+// ---- Test database ------------------------------------------------------------
+const PORT = parseInt(process.env.TEST_DB_PORT ?? "5499");
+const HOST = "127.0.0.1";
+// Port is part of the default dir name so two concurrent instances (on
+// different ports) never open the same data directory.
+const DIR =
+  process.env.TEST_DB_DIR ??
+  path.join(BACKEND_DIR, "dev-db", `pglite-test-${PORT}`);
+
+if (fresh && existsSync(DIR)) {
+  console.log(`[test-local] --fresh: removing ${DIR}`);
+  rmSync(DIR, { recursive: true, force: true });
+}
+mkdirSync(DIR, { recursive: true });
+
+console.log(`[test-local] starting PGlite on ${HOST}:${PORT} (dir: ${DIR})`);
+const db = await PGlite.create(DIR, { extensions: { vector } });
+await db.exec("CREATE EXTENSION IF NOT EXISTS vector;");
+
+let server: PGLiteSocketServer;
+try {
+  server = new PGLiteSocketServer({ db, port: PORT, host: HOST, maxConnections: 20 });
+  await server.start();
+} catch (error) {
+  console.error(
+    `[test-local] could not listen on port ${PORT} — is another test-local or ` +
+      `db server still running? (override with TEST_DB_PORT=<port>)`
+  );
+  console.error(error);
+  process.exit(1);
+}
+
+// ---- Environment for all child processes ------------------------------------
+// POSTGRES_* is force-pointed at the embedded DB (never a real database).
+// Everything else only fills in gaps so an existing .env still wins.
+const jwtSecret =
+  process.env.JWT_PRIVATE_KEY && process.env.JWT_PUBLIC_KEY
+    ? undefined // both present → keep them
+    : "local-test-secret";
+const env: Record<string, string | undefined> = {
+  ...process.env,
+  POSTGRES_HOST: HOST,
+  POSTGRES_PORT: String(PORT),
+  POSTGRES_DB: "postgres",
+  POSTGRES_USER: "postgres",
+  POSTGRES_PASSWORD: "postgres",
+  POSTGRES_CA: "",
+  POSTGRES_CONNECTION_POOL_SIZE: process.env.POSTGRES_CONNECTION_POOL_SIZE ?? "5",
+  ...(jwtSecret && { JWT_PRIVATE_KEY: jwtSecret, JWT_PUBLIC_KEY: jwtSecret }),
+  // AES master key for tenant secrets. Without it the framework generates one
+  // and calls process.exit() mid-test-run. Deterministic so data encrypted in
+  // the persistent test DB stays decryptable across runs. Local tests only.
+  SECRETS_AES_KEY: process.env.SECRETS_AES_KEY ?? "10".repeat(32),
+  SECRETS_AES_IV: process.env.SECRETS_AES_IV ?? "10".repeat(16),
+  SMTP_HOST: process.env.SMTP_HOST ?? "console.localhost",
+};
+
+const run = async (cmd: string[], label: string): Promise<number> => {
+  console.log(`[test-local] ${label}: ${cmd.join(" ")}`);
+  const proc = Bun.spawn(cmd, {
+    cwd: BACKEND_DIR,
+    env,
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+  return await proc.exited;
+};
+
+const shutdown = async (code: number): Promise<never> => {
+  await server.stop().catch(() => {});
+  await db.close().catch(() => {});
+  process.exit(code);
+};
+process.on("SIGINT", () => void shutdown(130));
+process.on("SIGTERM", () => void shutdown(143));
+
+// ---- Migrations ---------------------------------------------------------------
+const frameworkConfig = isAppLayout
+  ? "framework/drizzle.config.ts"
+  : "drizzle.config.ts";
+const frameworkMigrate = await run(
+  ["bunx", "drizzle-kit", "migrate", "--config", frameworkConfig],
+  "framework migrations"
+);
+if (frameworkMigrate !== 0) await shutdown(frameworkMigrate);
+
+if (isAppLayout && existsSync(path.join(BACKEND_DIR, "drizzle.config.ts"))) {
+  const appMigrate = await run(["bunx", "drizzle-kit", "migrate"], "app migrations");
+  if (appMigrate !== 0) await shutdown(appMigrate);
+}
+
+// ---- Tests / serve mode ---------------------------------------------------------
+const printEnvHint = () => {
+  console.log(
+    `\n[test-local] test DB is serving on ${HOST}:${PORT}. Use it with e.g.:\n` +
+      `  POSTGRES_HOST=${HOST} POSTGRES_PORT=${PORT} POSTGRES_DB=postgres ` +
+      `POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres \\\n` +
+      `    bun run db:query "SELECT count(*) FROM base_users"\n` +
+      `Press Ctrl+C to stop.`
+  );
+};
+
+if (serveOnly) {
+  printEnvHint();
+  // keep process alive until Ctrl+C
+} else {
+  const exitCode = await run(["bun", "test", ...testArgs], "tests");
+  if (keepOpen) {
+    printEnvHint();
+  } else {
+    await shutdown(exitCode);
+  }
+}

--- a/docs/skills/backend-app/SKILL.md
+++ b/docs/skills/backend-app/SKILL.md
@@ -13,7 +13,10 @@ The app uses the symbiosika-framework (`backend/framework/`). Path alias: `@fram
 
 ## Commands
 
-- `bun run docker:up` / `docker:down` - Start/stop development database
+- `bun run docker:up` / `docker:down` - Start/stop development database (Docker)
+- `bun run db:local` - Start an embedded PGlite dev database on port 5432 (no Docker needed)
+- `bun run test:local` - Run tests against an embedded PGlite DB, zero setup (see backend-testing skill)
+- `bun run db:query "<SQL>"` - Inspect the dev database (see db-query skill)
 - `bun run dev` - Start dev server with hot reload
 - `bun run init` - Generate secrets (AES keys, JWT keys) into .env
 - `bun run app:generate` - Generate app-specific migrations

--- a/docs/skills/backend-testing/SKILL.md
+++ b/docs/skills/backend-testing/SKILL.md
@@ -10,13 +10,37 @@ description: >
 
 Uses Bun's built-in test framework (`bun:test`).
 
-## Running Tests
+## Running Tests (zero setup — use this)
+
+`bun run test:local` runs tests against an **embedded PGlite database** — no
+Docker, no external Postgres, no `.env` needed. It starts PGlite (with
+pgvector) on port 5499, applies framework + app migrations, sets all required
+env defaults (DB, JWT secret, `SMTP_HOST=console.localhost`), runs the tests,
+and shuts down. Always run it from the `backend/` directory. Never use `cd`.
 
 ```bash
-bun test src/routes/tenant/[tenantId]/example.test.ts
+bun run test:local                                    # all tests
+bun run test:local ./src/lib/example.test.ts          # one file
+bun run test:local --fresh                            # wipe the test DB first
+bun run test:local --keep ./src/lib/example.test.ts   # keep DB serving after tests
+bun run test:local --serve                            # only start test DB + migrations
 ```
 
-Always run from root `/backend` directory. Never use `cd`.
+Notes:
+- The test DB persists in `dev-db/pglite-test-<port>/` (gitignored); repeat runs are fast.
+  Use `--fresh` after schema experiments or when state looks corrupted.
+- With `--keep`/`--serve` you can inspect data afterwards:
+  `POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5499 POSTGRES_DB=postgres POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres bun run db:query "SELECT ..."`
+- App-specific test env (e.g. feature stubs) belongs in the app's `test:local`
+  script line in `package.json`, not in the runner.
+- Bare `bun test <file>` also works, but only if a database is already running
+  and `POSTGRES_*`/JWT env is set — prefer `test:local`.
+- Suites whose describe-name says `needs MISTRAL_API_KEY` (or similar) call real
+  AI APIs; without those keys they fail slowly with retries/timeouts. That is
+  expected — skip them when running offline instead of chasing the failures.
+- JWT gotcha: session tokens are **HS256** — `JWT_PRIVATE_KEY` and
+  `JWT_PUBLIC_KEY` must contain the **same** secret, otherwise every
+  authenticated request returns 401. `test:local` handles this for you.
 
 ## Test File Structure
 
@@ -163,32 +187,17 @@ import {
 - **Clean up test data** in `beforeAll` AND `afterAll`
 - **Path alias**: `@framework/*` → `./framework/src/*`
 
-## Common Assertions
+## Response Conventions
+
+API responses follow `{ success: boolean, data: ... }`:
 
 ```typescript
-// Status codes
-expect(response.status).toBe(200);   // Success
-expect(response.status).toBe(400);   // Validation error
-expect(response.status).toBe(401);   // Unauthorized
-expect(response.status).toBe(403);   // Forbidden
-expect(response.status).toBe(404);   // Not found
-
-// Response structure
 expect(response.jsonResponse?.success).toBe(true);
-expect(response.jsonResponse?.data).toBeDefined();
-expect(Array.isArray(response.jsonResponse?.data)).toBe(true);
-expect(response.jsonResponse?.data.length).toBeGreaterThan(0);
-
-// Data validation
 expect(response.jsonResponse?.data.id).toBe(entryId);
-expect(response.jsonResponse?.data.name).toBe("Expected Name");
-
-// Error testing
-expect(async () => await fn()).toThrow();
-
-// Flexible (edge cases)
-expect([200, 400]).toContain(response.status);
 ```
+
+Status codes follow the usual semantics (200 / 400 validation / 401 no token /
+403 wrong tenant or missing permission / 404).
 
 ## Security Test Pattern
 

--- a/docs/skills/db-query/SKILL.md
+++ b/docs/skills/db-query/SKILL.md
@@ -27,11 +27,22 @@ about the values.
 
 ## Usage
 
+Run from the `backend/` directory:
+
 ```bash
 bun run db:query "<SQL>"
 ```
 
 Always wrap the query in quotes so the shell passes it as a single argument.
+
+To query the **local PGlite test database** (started via `bun run test:local
+--serve` or `--keep`, see the backend-testing skill), point the env at it:
+
+```bash
+POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5499 POSTGRES_DB=postgres \
+POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres \
+bun run db:query "SELECT count(*) FROM base_users"
+```
 
 ## Examples
 

--- a/docs/skills/testuser/SKILL.md
+++ b/docs/skills/testuser/SKILL.md
@@ -14,11 +14,15 @@ Uses the debug email flow: the magic-link token is read directly from `logs/emai
 
 ## Steps
 
-Run the script and show the full output:
+Run the script **from the `backend/` directory** and show the full output:
 
 ```bash
 bash ./.scripts/testuser.sh
 ```
+
+(The script expects to live in `<app-root>/.scripts/` — it reads the magic-link
+email from `<app-root>/logs/email/`, which the server writes relative to its
+working directory.)
 
 ## What the script does
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "dev": "bun --hot run demo.ts",
     "dev:inspect": "bun --inspect --hot run demo.ts",
     "db:local": "bun run ./.scripts/local-db-server.ts",
+    "test:local": "bun run ./.scripts/test-local.ts",
     "db:query": "bun run ./.scripts/db-query.ts",
     "dev:local": "pglite-server --db=./dev-db/pglite --extensions=vector -m 20 -p 5432 --run 'bun run framework:migrate && bun run dev'",
     "framework:migrate": "drizzle-kit migrate",


### PR DESCRIPTION
## What

One-command backend testing against an embedded PGlite database — no Docker, no external Postgres, no `.env`:

```bash
bun run test:local [files...]   # boot PGlite (pgvector) → migrate → bun test
bun run test:local --fresh      # wipe the test DB first
bun run test:local --keep       # keep the DB serving after tests (for db:query)
bun run test:local --serve      # only start test DB + migrations
```

`.scripts/test-local.ts` starts PGlite on its own port (default 5499, so it never clashes with a dev DB on 5432), applies migrations, sets all required env defaults and runs `bun test`, propagating the exit code.

## Why

Coding agents (and fresh dev environments) previously needed: a running DB, a `.env`, JWT keys, AES secrets, and knowledge of several non-obvious pitfalls before a single test could run. Now it is one command.

Non-obvious env the runner handles automatically:
- **HS256 JWT**: `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` must hold the **same** secret (the middleware verifies symmetrically) — otherwise every authenticated request is 401.
- **AES secrets**: without `SECRETS_AES_KEY`/`SECRETS_AES_IV` the framework generates keys and calls `process.exit()` mid-test-run.
- `SMTP_HOST=console.localhost` so tests never touch the network for mail.
- `POSTGRES_*` is always forced to the embedded DB so tests can never hit a real database; all other defaults only fill gaps (existing env wins).

## Design

- **Layout-agnostic**: works inside an app (`<app>/.scripts/`, migrates framework + app drizzle configs) and standalone in this repo (migrates `./drizzle.config.ts` only).
- **App-agnostic**: app-specific test env (e.g. feature stubs) belongs in the app's own `test:local` script line in its `package.json`, not in the runner.
- Test DB persists per port in `dev-db/pglite-test-<port>/` (gitignored) so repeat runs skip migration work; two concurrent instances never share a data dir.

## Skills

- `backend-testing` now leads with the zero-setup flow, documents the HS256 gotcha and that `needs MISTRAL_API_KEY` suites fail slowly offline (expected); generic assertion examples trimmed (commodity knowledge).
- `db-query` documents querying the test DB via env override.
- `backend-app` lists the local DB commands (`db:local`, `test:local`, `db:query`).
- `testuser` documents that the script must live in `<app-root>/.scripts/` so it finds `<app-root>/logs/email/` (in apps where it lives only in `framework/.scripts/` it looks in the wrong folder).

## Verification

- symbiosika/wiki, full suite via `bun run test:local`: **890/906 pass** across 137 files (~4.5 min); the 16 failures are suites requiring external AI keys or internet (Mistral embeddings, ping, URL import).
- Standalone in this repo: DB-backed suites (`src/test/uuid.test.ts`, `src/lib/knowledge/knowledge-texts.test.ts`) green.
- `--serve` + `db:query` against the test DB verified end-to-end.

Companion PR in the app repo (adds the script + `test:local`/`db:query` package.json entries there until this lands and `sync-skills` distributes it): symbiosika/wiki#101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPA4YLezKv98mWk251VQ7

---
_Generated by [Claude Code](https://claude.ai/code/session_014oPA4YLezKv98mWk251VQ7)_