### PR TITLE
Fix append_to_page silently dropping content on block-mode pages

### DIFF
--- a/src/lib/knowledge/knowledge-text-agent.test.ts
+++ b/src/lib/knowledge/knowledge-text-agent.test.ts
@@ -8,6 +8,10 @@ import {
   getPagesBatch,
   appendToKnowledgeText,
 } from "./knowledge-text-agent";
+import {
+  syncKnowledgeTextBlocks,
+  getKnowledgeTextBlocks,
+} from "./knowledge-text-blocks";
 
 const TENANT = TEST_ORGANISATION_1.id;
 const ctx = { tenantId: TENANT };
@@ -96,6 +100,37 @@ describe("context-economy endpoints", () => {
     expect(fetched.text).toBe("first\n\nsecond");
     // append marks the summary stale (normal edit path)
     expect(fetched.summaryStale).toBe(true);
+  });
+
+  test("appendToKnowledgeText writes through blocks on a block page", async () => {
+    // a block page keeps its real content in blocks; the `text` column is only
+    // a cache re-materialized from the blocks. Appending must add a block, not
+    // just poke the cache (which is silently discarded on the next render).
+    const page = await createKnowledgeText({
+      tenantId: TENANT,
+      title: "Block append target",
+      text: "",
+    });
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [{ type: "html", content: "<p>Existing intro.</p>" }],
+      ctx
+    );
+
+    const res = await appendToKnowledgeText(page.id, "## Appended section", ctx);
+    expect(res.appendedChars).toBe("## Appended section".length);
+
+    // the appended content landed in a real, new markdown block
+    const blocks = await getKnowledgeTextBlocks(page.id, ctx);
+    expect(blocks.length).toBe(2);
+    expect(blocks[1]?.type).toBe("markdown");
+    expect(blocks[1]?.content).toBe("## Appended section");
+
+    // and the materialized cache reflects it (blocks joined by a blank line)
+    const fetched = await getKnowledgeTextById(page.id, ctx);
+    expect(fetched.contentMode).toBe("blocks");
+    expect(fetched.text).toBe("Existing intro.\n\n## Appended section");
+    expect(res.totalChars).toBe(fetched.text.length);
   });
 
   test("subtree respects maxDepth and flags omitted children", async () => {

--- a/src/lib/knowledge/knowledge-text-agent.ts
+++ b/src/lib/knowledge/knowledge-text-agent.ts
@@ -20,6 +20,10 @@ import {
   getKnowledgeTextById,
   updateKnowledgeText,
 } from "./knowledge-texts";
+import {
+  getKnowledgeTextBlocks,
+  syncKnowledgeTextBlocks,
+} from "./knowledge-text-blocks";
 import { attributesContainCondition, type FacetFilters } from "./facets";
 
 type Context = {
@@ -188,9 +192,20 @@ export interface AppendResult {
 
 /**
  * append text to a page without the caller doing a read-modify-write and
- * without returning the (potentially large) full content. Goes through
- * updateKnowledgeText so history, permissions, page link/file bookkeeping and
- * summary-stale marking all behave exactly like a normal edit.
+ * without returning the (potentially large) full content.
+ *
+ * The write path depends on the page's content mode, because the two modes
+ * store their content differently:
+ *
+ *   - text pages keep the content in the `text` column, so we read-modify-write
+ *     it through updateKnowledgeText (history, links/files, summary-stale).
+ *   - block pages store the content as ordered blocks; the `text` column is
+ *     only a cache re-materialized from the blocks on every save. Writing that
+ *     cache directly is silently discarded on the next block render, so for a
+ *     block page we append a new markdown block through syncKnowledgeTextBlocks
+ *     (which re-materializes the cache and runs the same bookkeeping). The
+ *     blocks are joined by a blank line, so the default "\n\n" separator is
+ *     honoured naturally; a custom `separator` only applies to text pages.
  */
 export const appendToKnowledgeText = async (
   id: string,
@@ -199,6 +214,29 @@ export const appendToKnowledgeText = async (
   options: { separator?: string } = {}
 ): Promise<AppendResult> => {
   const current = await getKnowledgeTextById(id, context);
+
+  if (current.contentMode === "blocks") {
+    const existing = await getKnowledgeTextBlocks(id, context);
+    const result = await syncKnowledgeTextBlocks(
+      id,
+      [
+        ...existing.map((block) => ({
+          id: block.id,
+          type: block.type,
+          content: block.content,
+          meta: (block.meta ?? {}) as Record<string, unknown>,
+        })),
+        { type: "markdown" as const, content: appendText },
+      ],
+      context
+    );
+    return {
+      id,
+      appendedChars: appendText.length,
+      totalChars: result.knowledgeText.text.length,
+    };
+  }
+
   const separator = options.separator ?? "\n\n";
   const base = current.text ?? "";
   const newText = base.length > 0 ? `${base}${separator}${appendText}` : appendText;


### PR DESCRIPTION
## Problem

`append_to_page` (MCP) → `POST /knowledge/texts/:id/append` → `appendToKnowledgeText()` reported success (`appendedChars` / `totalChars`) but left the page's actual content unchanged on **block-mode pages**.

Root cause: `appendToKnowledgeText()` always wrote the new content via `updateKnowledgeText({ text })`. For a block-mode page the `text` column is only a **materialized cache** re-assembled from the page's blocks on every save, so that write was silently discarded on the next block render. The counters in the response were computed from the (temporarily updated) cache, which is why the API looked like it succeeded while the blocks — the real content — never changed.

## Fix

Branch on `contentMode`, mirroring what `editKnowledgeTextContent()` already does:

- **Block pages** — append the content as a new markdown block via `syncKnowledgeTextBlocks`, which re-materializes the `text` cache and runs the same links / files / embedding / history bookkeeping.
- **Text pages** — keep the existing read-modify-write path.

Blocks are joined by a blank line, so the default `"\n\n"` separator is honoured naturally; a custom `separator` only applies to text pages.

## Tests

Added a block-page regression test in `knowledge-text-agent.test.ts` asserting a real new markdown block is created and the materialized text becomes `"Existing intro.\n\n## Appended section"`. The existing text-page append test is unchanged. Ran the agent / edit / blocks knowledge suites locally (pglite) — all green.

## Files

- `src/lib/knowledge/knowledge-text-agent.ts` — the fix
- `src/lib/knowledge/knowledge-text-agent.test.ts` — regression test

## Related

Consumed by `symbiosika/wiki` via the `backend/framework` submodule — see symbiosika/wiki#105, which bumps the submodule pointer to this branch. Land this PR (or its commit into #105's base) before merging #105 so the submodule reference resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVBPo537eNB6MjQqCHWcea)_