### PR TITLE
fix(oauth2): never issue a tenant-less token on the consent path

### DIFF
--- a/src/lib/oauth2/index.ts
+++ b/src/lib/oauth2/index.ts
@@ -324,12 +324,33 @@ export function defineOAuth2Routes(app: App, API_BASE_PATH: string) {
     if (requested.some((s) => !isScopeAllowed(s, client)))
       return c.json({ error: "invalid_scope" }, 400);
 
-    // Tenant.
+    // Tenant. Resolve the same way the authorize step does. A token MUST carry
+    // a tenant binding: never mint a tenant-less token for a user who has
+    // memberships, otherwise the resource server cannot map the token to an
+    // organisation (it then fails with "User is not a member of this tenant"
+    // or silently falls back to a configured default). If the organisation is
+    // still ambiguous here, send the user back through /oauth/authorize, which
+    // presents the organisation picker.
     const memberships = await tenantMembershipsOf(userId);
     const wanted = params.get("tenant_id");
     let tenantId: string | null = null;
     if (wanted && memberships.some((m) => m.id === wanted)) tenantId = wanted;
     else if (memberships.length === 1) tenantId = memberships[0]!.id;
+
+    if (!tenantId) {
+      if (memberships.length === 0) {
+        const redirect = appendParams(redirectUri, {
+          error: "access_denied",
+          state,
+        });
+        return wantsJson(c) ? c.json({ redirect }, 400) : c.redirect(redirect);
+      }
+      // Ambiguous organisation (multiple memberships, none selected): restart
+      // authorize so the tenant picker resolves it before a token is issued.
+      if (wantsJson(c))
+        return c.json({ step: "tenant", tenants: memberships });
+      return c.redirect(`/oauth/authorize?${authorizeQuery}`);
+    }
 
     await saveConsent(userId, client.clientId, requested);
 


### PR DESCRIPTION
## Problem

When a user authorizes an OAuth2 client (e.g. the claude.ai wiki connector), the issued access token must carry a `tenant` binding — the resource server uses it to scope every API call to one organisation. The **consent decision handler** (`POST /oauth/consent`) resolved the tenant only when:

- a valid `tenant_id` was passed, or
- the user had exactly **one** membership.

A user with **multiple** memberships and no selection fell through with `tenantId = null`, minting a token with no `tenant` binding. Downstream that surfaces as **`User is not a member of this tenant`** (or a silent fallback to a configured default organisation in the resource server).

This was asymmetric with `GET /oauth/authorize`, which already handles the multi-membership case by showing the organisation picker.

## Fix

Mirror the authorize-time resolution in the consent handler. When the organisation is still ambiguous after resolution:

- **multiple memberships, none selected** → restart `/oauth/authorize` so the tenant picker resolves it before a token is issued (JSON clients get `{ step: "tenant", tenants }`);
- **no membership** → deny cleanly (`access_denied`).

A tenant-less token is never issued for a user who has memberships.

## Scope

- `src/lib/oauth2/index.ts` — consent handler tenant resolution only.
- No API/response shape changes for the existing single-membership and explicit-`tenant_id` paths.

## Testing

- `bunx tsc --noEmit` clean for the changed file.

> Companion change in the wiki repo (`symbiosika/wiki`) hardens the MCP resource server so an OAuth token without a tenant binding fails loud instead of silently falling back, and advertises the `user:read` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A69WwyFohsgkB85gH83ZkX)_