### PR TITLE
Persist document-tag description in knowledge config PUT

### DIFF
--- a/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
+++ b/src/routes/tenant/[tenantId]/knowledge/texts/index.ts
@@ -883,6 +883,7 @@ export default function defineRoutesForKnowledgeTexts(
             v.object({
               key: v.pipe(v.string(), v.minLength(1)),
               label: v.optional(v.string()),
+              description: v.optional(v.string()),
               values: v.optional(v.array(v.string())),
             })
           )


### PR DESCRIPTION
## What

Accept `description` on each attribute definition in the knowledge-config `PUT /tenant/:tenantId/knowledge/texts/config` validator.

## Why

Document tags carry a `description` that is meant to be the instruction handed to the PDF parser's extractor. `attributeDefinitionsToExtractionTargets` already prefers `description ?? label ?? key`, but the config PUT validator only listed `key`, `label`, and `values`. Because valibot's `v.object` strips unknown keys, any `description` sent by the client was silently dropped before it reached `setKnowledgeTenantConfig` — so it was never persisted and the extractor always fell back to the display label.

## Change

Add `description: v.optional(v.string())` to the attribute schema so the field round-trips and reaches the parser.

This is the backend half of a two-part change; the companion frontend change (adding the "Beschreibung" field to the document-tags admin UI) lives in the `symbiosika/wiki` repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111U9Ec6yx5Gw67GGkJdnyj)_