### PR TITLE
fix(knowledge): clean removal of blocks via content edit

### DIFF
--- a/src/lib/knowledge/knowledge-text-edit.test.ts
+++ b/src/lib/knowledge/knowledge-text-edit.test.ts
@@ -136,7 +136,7 @@ describe("Knowledge Text Edit (string replacement)", () => {
     expect(blocks[1]?.content).toBe("Body with a correction inside.");
   });
 
-  it("rejects an oldString that spans block boundaries", async () => {
+  it("rejects a non-empty replacement that spans block boundaries", async () => {
     const page = await createPage("");
     await syncKnowledgeTextBlocks(
       page.id,
@@ -155,6 +155,128 @@ describe("Knowledge Text Edit (string replacement)", () => {
         ctx
       )
     ).rejects.toThrow("spans multiple blocks");
+  });
+
+  it("drops a block that an edit empties instead of leaving a placeholder", async () => {
+    const page = await createPage("");
+    const saved = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "Keep me" },
+        { type: "markdown", content: "Remove me entirely" },
+        { type: "markdown", content: "Keep me too" },
+      ],
+      ctx
+    );
+
+    const result = await editKnowledgeTextContent(
+      page.id,
+      { oldString: "Remove me entirely", newString: "" },
+      ctx
+    );
+    expect(result.replacements).toBe(1);
+
+    const blocks = await getKnowledgeTextBlocks(page.id, ctx);
+    expect(blocks.map((b) => b.content)).toEqual(["Keep me", "Keep me too"]);
+    // surviving blocks kept their ids
+    expect(blocks[0]?.id).toBe(saved.blocks[0]!.id);
+    expect(blocks[1]?.id).toBe(saved.blocks[2]!.id);
+    // no empty placeholder left behind in the materialized text
+    expect(result.content).toBe("Keep me\n\nKeep me too");
+  });
+
+  it("removes multiple whole blocks at once when the deletion spans them", async () => {
+    const page = await createPage("");
+    const saved = await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "Intro paragraph" },
+        { type: "markdown", content: "Section to drop A" },
+        { type: "markdown", content: "Section to drop B" },
+        { type: "markdown", content: "Closing paragraph" },
+      ],
+      ctx
+    );
+
+    // oldString is copied verbatim from read_page_content: the two middle
+    // blocks joined by the block separator, plus the leading separator.
+    const result = await editKnowledgeTextContent(
+      page.id,
+      {
+        oldString: "\n\nSection to drop A\n\nSection to drop B",
+        newString: "",
+      },
+      ctx
+    );
+    expect(result.replacements).toBe(1);
+
+    const blocks = await getKnowledgeTextBlocks(page.id, ctx);
+    expect(blocks.map((b) => b.content)).toEqual([
+      "Intro paragraph",
+      "Closing paragraph",
+    ]);
+    expect(blocks[0]?.id).toBe(saved.blocks[0]!.id);
+    expect(blocks[1]?.id).toBe(saved.blocks[3]!.id);
+    expect(result.content).toBe("Intro paragraph\n\nClosing paragraph");
+  });
+
+  it("trims boundary blocks partially covered by a spanning deletion", async () => {
+    const page = await createPage("");
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "keep start remove tail" },
+        { type: "markdown", content: "remove head keep end" },
+      ],
+      ctx
+    );
+
+    const result = await editKnowledgeTextContent(
+      page.id,
+      { oldString: "remove tail\n\nremove head", newString: "" },
+      ctx
+    );
+    expect(result.replacements).toBe(1);
+
+    // both boundary blocks survive (they still have content) and the
+    // materialized text is clean — the removed middle is gone
+    const blocks = await getKnowledgeTextBlocks(page.id, ctx);
+    expect(blocks.length).toBe(2);
+    expect(result.content).toBe("keep start\n\nkeep end");
+  });
+
+  it("rejects a spanning deletion that is not unique without replaceAll", async () => {
+    const page = await createPage("");
+    await syncKnowledgeTextBlocks(
+      page.id,
+      [
+        { type: "markdown", content: "alpha" },
+        { type: "markdown", content: "beta" },
+        { type: "markdown", content: "alpha" },
+        { type: "markdown", content: "beta" },
+      ],
+      ctx
+    );
+
+    // "alpha\n\nbeta" spans the 1↔2 and 3↔4 gaps: two occurrences
+    await expect(
+      editKnowledgeTextContent(
+        page.id,
+        { oldString: "alpha\n\nbeta", newString: "" },
+        ctx
+      )
+    ).rejects.toThrow("not unique");
+
+    // replaceAll removes every spanning occurrence, leaving no blocks
+    const result = await editKnowledgeTextContent(
+      page.id,
+      { oldString: "alpha\n\nbeta", newString: "", replaceAll: true },
+      ctx
+    );
+    expect(result.replacements).toBe(2);
+    const blocks = await getKnowledgeTextBlocks(page.id, ctx);
+    expect(blocks.length).toBe(0);
+    expect(result.content).toBe("");
   });
 
   it("counts occurrences across blocks for uniqueness", async () => {

--- a/src/lib/knowledge/knowledge-text-edit.ts
+++ b/src/lib/knowledge/knowledge-text-edit.ts
@@ -11,7 +11,10 @@
  *
  * Edits on block pages are applied inside the affected block(s), then run
  * through the normal block sync, so text cache, history, page links and the
- * embedding mirror all stay consistent.
+ * embedding mirror all stay consistent. A replacement that empties a block
+ * drops it instead of leaving an empty placeholder block behind, and a
+ * deletion (empty `newString`) whose `oldString` spans several blocks removes
+ * the covered blocks in one go — the clean "remove multiple blocks at once".
  */
 
 import {
@@ -21,7 +24,10 @@ import {
 import {
   getKnowledgeTextBlocks,
   syncKnowledgeTextBlocks,
+  type KnowledgeTextBlockInput,
 } from "./knowledge-text-blocks";
+import { materializeBlocksTextWithSpans } from "./materialize-blocks";
+import type { KnowledgeTextBlockSelect } from "../db/schema/knowledge";
 
 type Context = {
   tenantId: string;
@@ -94,6 +100,91 @@ const replaceAllOccurrences = (
   replacement: string
 ): string => haystack.split(needle).join(replacement);
 
+/** Message used when a cross-block match can't be resolved to a clean edit. */
+const SPANS_BLOCKS_MESSAGE =
+  "oldString spans multiple blocks. Edit the blocks individually " +
+  "(PUT .../blocks) or use a shorter string within one block";
+
+type WorkingBlock = {
+  id: string;
+  type: "markdown" | "html";
+  content: string;
+  meta: Record<string, unknown>;
+};
+
+const toWorkingBlock = (block: KnowledgeTextBlockSelect): WorkingBlock => ({
+  id: block.id,
+  type: block.type,
+  content: block.content,
+  meta: (block.meta ?? {}) as Record<string, unknown>,
+});
+
+/**
+ * Delete every (or the first) occurrence of `oldString` from the materialized
+ * text of a block page, mapping the removal back onto the underlying blocks:
+ * blocks the match fully covers are emptied (and later dropped), boundary
+ * blocks keep the part outside the match. Only markdown blocks can be edited
+ * this way — an html block's stored content differs from its materialized
+ * markdown, so offsets can't be mapped back; touching one throws
+ * `SPANS_BLOCKS_MESSAGE`.
+ *
+ * Returns the surviving block inputs (emptied blocks removed) and the number
+ * of matches deleted.
+ */
+const deleteSpanningText = (
+  blocks: KnowledgeTextBlockSelect[],
+  oldString: string,
+  replaceAll: boolean
+): { inputs: KnowledgeTextBlockInput[]; replacements: number } => {
+  // Progressively edit a mutable copy so replaceAll can remove several matches,
+  // re-materializing between each removal. Nothing is persisted until the
+  // caller runs the returned inputs through syncKnowledgeTextBlocks, so a throw
+  // mid-way leaves the stored page untouched.
+  const working = blocks.map(toWorkingBlock);
+  const touched = new Set<string>();
+
+  let replacements = 0;
+  while (true) {
+    const { text, spans } = materializeBlocksTextWithSpans(working);
+    const matchStart = text.indexOf(oldString);
+    if (matchStart === -1) break;
+    const matchEnd = matchStart + oldString.length;
+
+    const byId = new Map(working.map((b) => [b.id, b]));
+    let mutated = false;
+    for (const span of spans) {
+      const overlapStart = Math.max(matchStart, span.start);
+      const overlapEnd = Math.min(matchEnd, span.end);
+      if (overlapStart >= overlapEnd) continue; // this block isn't covered
+
+      const block = byId.get(span.blockId)!;
+      if (block.type !== "markdown") throw new Error(SPANS_BLOCKS_MESSAGE);
+
+      const rendered = text.slice(span.start, span.end);
+      block.content =
+        rendered.slice(0, overlapStart - span.start) +
+        rendered.slice(overlapEnd - span.start);
+      touched.add(block.id);
+      mutated = true;
+    }
+
+    // The match sat entirely in the separators between blocks (e.g. oldString
+    // is only blank lines): nothing to remove and looping would never end.
+    if (!mutated) break;
+
+    replacements++;
+    if (!replaceAll) break;
+  }
+
+  if (replacements === 0) throw new Error(SPANS_BLOCKS_MESSAGE);
+
+  const inputs: KnowledgeTextBlockInput[] = working
+    .filter((b) => b.content.trim().length > 0 || !touched.has(b.id))
+    .map((b) => ({ id: b.id, type: b.type, content: b.content, meta: b.meta }));
+
+  return { inputs, replacements };
+};
+
 export type EditKnowledgeTextResult = {
   id: string;
   replacements: number;
@@ -107,8 +198,11 @@ export type EditKnowledgeTextResult = {
  * - `oldString` must occur in the page; with `replaceAll: false` (default)
  *   it must occur exactly once, otherwise the edit is rejected with a
  *   descriptive error (agents then send a longer, unique string)
- * - on block pages the replacement happens inside the affected blocks; an
- *   `oldString` spanning two blocks is rejected with a clear error
+ * - on block pages the replacement happens inside the affected blocks; a block
+ *   left empty by the edit is dropped rather than kept as an empty placeholder
+ * - a deletion (`newString: ""`) whose `oldString` spans several blocks removes
+ *   the fully covered blocks at once; a non-empty replacement across a block
+ *   boundary is still rejected, as there's no unambiguous block for the result
  */
 export const editKnowledgeTextContent = async (
   id: string,
@@ -150,14 +244,34 @@ export const editKnowledgeTextContent = async (
   const totalOccurrences = occurrencesPerBlock.reduce((a, b) => a + b, 0);
 
   if (totalOccurrences === 0) {
-    // distinguish "not present at all" from "spans block boundaries"
-    if (countOccurrences(page.text, oldString) > 0) {
+    // Not found inside any single block. It may still exist in the materialized
+    // text, straddling the gap between adjacent blocks. Deleting such a span is
+    // supported — it's the clean way to remove one or more whole blocks at once
+    // — but replacing it is not, because there's no unambiguous block to put
+    // the replacement text into.
+    const spanning = countOccurrences(
+      materializeBlocksTextWithSpans(blocks.map(toWorkingBlock)).text,
+      oldString
+    );
+    if (spanning === 0) {
+      throw new Error("oldString not found in the document");
+    }
+    if (newString.length > 0) {
+      throw new Error(SPANS_BLOCKS_MESSAGE);
+    }
+    if (spanning > 1 && !replaceAll) {
       throw new Error(
-        "oldString spans multiple blocks. Edit the blocks individually " +
-          "(PUT .../blocks) or use a shorter string within one block"
+        `oldString is not unique (${spanning} occurrences). ` +
+          "Provide more surrounding context or set replaceAll: true"
       );
     }
-    throw new Error("oldString not found in the document");
+    const { inputs, replacements } = deleteSpanningText(
+      blocks,
+      oldString,
+      replaceAll
+    );
+    const result = await syncKnowledgeTextBlocks(id, inputs, context);
+    return { id, replacements, content: result.knowledgeText.text };
   }
   if (totalOccurrences > 1 && !replaceAll) {
     throw new Error(
@@ -166,19 +280,25 @@ export const editKnowledgeTextContent = async (
     );
   }
 
-  const result = await syncKnowledgeTextBlocks(
-    id,
-    blocks.map((block, i) => ({
-      id: block.id,
-      type: block.type,
-      content:
-        occurrencesPerBlock[i]! > 0
-          ? replaceAllOccurrences(block.content, oldString, newString)
-          : block.content,
-      meta: (block.meta ?? {}) as Record<string, unknown>,
-    })),
-    context
+  // Apply the replacement inside each affected block. When a replacement leaves
+  // a block empty (e.g. deleting its whole content), drop the block rather than
+  // keep it as an empty placeholder — otherwise the editor renders a stray
+  // blank block. Blocks the edit didn't touch are passed through untouched,
+  // including any that were already empty.
+  const nextBlocks = blocks.map((block, i) => ({
+    id: block.id,
+    type: block.type,
+    content:
+      occurrencesPerBlock[i]! > 0
+        ? replaceAllOccurrences(block.content, oldString, newString)
+        : block.content,
+    meta: (block.meta ?? {}) as Record<string, unknown>,
+  }));
+  const keptBlocks = nextBlocks.filter(
+    (block, i) => occurrencesPerBlock[i] === 0 || block.content.trim().length > 0
   );
+
+  const result = await syncKnowledgeTextBlocks(id, keptBlocks, context);
 
   return {
     id,


### PR DESCRIPTION
## Problem

Editing a block page with `edit_page_content` (the shared `editKnowledgeTextContent` used by the MCP server, the in-app AI tool, and the document agent) could only *replace* content inside individual blocks. That left two gaps reported by an MCP-using agent:

- Emptying a block (replacing its whole content with `""`) kept the now-empty block row, which the editor renders as a **stray blank placeholder block**.
- Any `oldString` that spanned more than one block was **rejected outright**, so there was no clean way to remove several blocks at once — the natural thing to do when an agent copies a contiguous region straight out of `read_page_content`.

## Change

`editKnowledgeTextContent` on block pages now:

- **Drops blocks the edit empties** instead of keeping an empty placeholder row. Blocks the edit didn't touch (including any that were already empty) are passed through unchanged.
- **Supports cross-block deletion**: a deletion (`newString: ""`) whose `oldString` spans several blocks — copied verbatim from `read_page_content`, blank-line separators included — removes the fully covered blocks in one go and trims the partially covered boundary blocks. `replaceAll` and uniqueness semantics carry over.

Guardrails kept:

- A **non-empty** replacement across a block boundary is still rejected (`spans multiple blocks`), since there's no unambiguous block to hold the result.
- Cross-block deletion only maps back onto **markdown** blocks; touching an `html` block (whose stored content differs from its materialized markdown, so offsets can't be mapped back) throws the same `spans multiple blocks` error.

The removal is applied to a mutable copy and only persisted through the normal `syncKnowledgeTextBlocks` path, so a mid-operation throw leaves the stored page untouched, and text cache / history / links / embedding mirror all stay consistent.

## Tests

Added to `knowledge-text-edit.test.ts`:

- drops a block that an edit empties (no placeholder, surviving ids stable)
- removes multiple whole blocks at once via a spanning deletion
- trims boundary blocks partially covered by a spanning deletion
- rejects a non-unique spanning deletion without `replaceAll`, and removes all with `replaceAll`
- the existing "spans block boundaries" case is kept as the non-empty-replacement rejection

15/15 edit tests pass and the surrounding block / agent-api suites stay green (the full-suite failures in this sandbox are all embedding/search tests that need `MISTRAL_API_KEY`, unrelated to this change).

## Note for integrators

The consuming app (`symbiosika/wiki`) bumps its `backend/framework` submodule to this branch in [wiki#114](https://github.com/symbiosika/wiki/pull/114). Once this merges into `develop`, the wiki submodule pointer should be re-pointed to the merged commit before that PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuU4VsxNxPKVXL8RJufG1h)_